### PR TITLE
Improve app-wide scroll performance

### DIFF
--- a/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke.xcscheme
+++ b/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/TwinskaraokeWatchApp.xcscheme
+++ b/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/TwinskaraokeWatchApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -1,21 +1,85 @@
 import LNPopupUI
+import Combine
 import SwiftUI
 
 #if canImport(UIKit)
   import UIKit
 #endif
 
-struct ContentView: View {
-  @StateObject var audioManager = AudioPlayerManager.shared
+@MainActor
+private final class PopupPlaybackState: ObservableObject {
+  static let shared = PopupPlaybackState()
 
+  @Published private(set) var hasCurrentSong = false
+  @Published private(set) var title = ""
+  @Published private(set) var subtitle = ""
+  @Published private(set) var artwork: UIImage?
+  @Published private(set) var progress: Float = 0
+  @Published private(set) var isPlaying = false
+  @Published private(set) var isRadioMode = false
+
+  private var cancellables = Set<AnyCancellable>()
+
+  private init(manager: AudioPlayerManager = .shared) {
+    manager.$currentSong
+      .map { song in
+        PopupSongSnapshot(
+          id: song?.id,
+          title: song?.title ?? "",
+          subtitle: song?.displayArtist ?? ""
+        )
+      }
+      .removeDuplicates()
+      .sink { [weak self] snapshot in
+        self?.hasCurrentSong = snapshot.id != nil
+        self?.title = snapshot.title
+        self?.subtitle = snapshot.subtitle
+      }
+      .store(in: &cancellables)
+
+    manager.$nowPlayingArtwork
+      .removeDuplicates(by: { $0 === $1 })
+      .sink { [weak self] in self?.artwork = $0 }
+      .store(in: &cancellables)
+
+    manager.$progress
+      .throttle(for: .milliseconds(350), scheduler: RunLoop.main, latest: true)
+      .map { Float(min(max($0, 0), 1)) }
+      .removeDuplicates()
+      .sink { [weak self] in self?.progress = $0 }
+      .store(in: &cancellables)
+
+    manager.$isPlaying
+      .removeDuplicates()
+      .sink { [weak self] in self?.isPlaying = $0 }
+      .store(in: &cancellables)
+
+    manager.$isRadioMode
+      .removeDuplicates()
+      .sink { [weak self] isRadioMode in
+        self?.isRadioMode = isRadioMode
+        if isRadioMode {
+          self?.progress = 0
+        }
+      }
+      .store(in: &cancellables)
+  }
+}
+
+private struct PopupSongSnapshot: Equatable {
+  let id: String?
+  let title: String
+  let subtitle: String
+}
+
+struct ContentView: View {
   var body: some View {
     PopupHostView()
-      .environmentObject(audioManager)
+      .environmentObject(AudioPlayerManager.shared)
   }
 }
 
 private struct PopupHostView: View {
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
@@ -24,7 +88,6 @@ private struct PopupHostView: View {
   var body: some View {
     rootShell
       .modifier(PopupModifier())
-      .environmentObject(audioManager)
       .onAppear {
         configureTabBarAppearance()
         applyUITestInitialSectionIfNeeded()
@@ -293,18 +356,21 @@ private extension RootSection {
 }
 
 private struct PopupModifier: ViewModifier {
-  @EnvironmentObject var audioManager: AudioPlayerManager
+  @ObservedObject private var popupState = PopupPlaybackState.shared
+
   func body(content: Content) -> some View {
     content
       .popup(
-        isBarPresented: .constant(audioManager.currentSong != nil),
-        isPopupOpen: $audioManager.showFullScreen
+        isBarPresented: .constant(popupState.hasCurrentSong),
+        isPopupOpen: Binding(
+          get: { AudioPlayerManager.shared.showFullScreen },
+          set: { AudioPlayerManager.shared.showFullScreen = $0 }
+        )
       ) {
-        PopupContent()
-          .environmentObject(audioManager)
+        PopupContent(popupState: popupState)
       }
       .popupBarStyle(.floating)
-      .popupBarProgressViewStyle(audioManager.isRadioMode ? .none : .bottom)
+      .popupBarProgressViewStyle(popupState.isRadioMode ? .none : .bottom)
       .popupCloseButtonStyle(.none)
       .popupInteractionStyle(.drag)
       .popupBarMarqueeScrollEnabled(false)
@@ -317,27 +383,32 @@ private struct PopupModifier: ViewModifier {
 }
 
 private struct PopupContent: View {
-  @EnvironmentObject var audioManager: AudioPlayerManager
+  @ObservedObject private var popupState: PopupPlaybackState
+
+  init(popupState: PopupPlaybackState) {
+    self.popupState = popupState
+  }
+
   var body: some View {
     FullScreenPlayerView()
-      .environmentObject(audioManager)
+      .environmentObject(AudioPlayerManager.shared)
       .modifier(
         PopupTitleModifier(
-          title: audioManager.currentSong?.title ?? "",
-          subtitle: audioManager.currentSong?.displayArtist ?? "")
+          title: popupState.title,
+          subtitle: popupState.subtitle)
       )
-      .modifier(PopupImageModifier(artwork: audioManager.nowPlayingArtwork))
+      .modifier(PopupImageModifier(artwork: popupState.artwork))
       .modifier(
         PopupProgressModifier(
-          progress: audioManager.isRadioMode ? 0 : Float(min(max(audioManager.progress, 0), 1))
+          progress: popupState.isRadioMode ? 0 : popupState.progress
         )
       )
       .popupBarButtons({
         PopupBarTrailingItems(
-          isPlaying: audioManager.isPlaying,
-          isRadioMode: audioManager.isRadioMode,
-          onTogglePlayPause: { [weak audioManager] in audioManager?.togglePlayPause() },
-          onNext: { [weak audioManager] in audioManager?.playNextOrRandom() })
+          isPlaying: popupState.isPlaying,
+          isRadioMode: popupState.isRadioMode,
+          onTogglePlayPause: { AudioPlayerManager.shared.togglePlayPause() },
+          onNext: { AudioPlayerManager.shared.playNextOrRandom() })
       })
   }
 }

--- a/Twinskaraoke/Components/LoadingImage.swift
+++ b/Twinskaraoke/Components/LoadingImage.swift
@@ -32,11 +32,11 @@ enum ImageCacheConfig {
     #endif
   }
   static let thumbnailPixelSize = CGSize(width: 480, height: 480)
+  /// Keep list artwork on normal priority so image fetch/decode work does not
+  /// compete with touch tracking during scroll. Callers can opt into full size separately.
   static let defaultOptions: SDWebImageOptions = [
     .retryFailed,
-    .scaleDownLargeImages,
-    .continueInBackground,
-    .highPriority
+    .scaleDownLargeImages
   ]
 }
 
@@ -48,76 +48,91 @@ struct LoadingImage: View {
   var lowResURL: URL? = nil
   var transparentBackground: Bool = false
   var fullResolution: Bool = false
+  /// Use this for fixed-size thumbnails to avoid a GeometryReader per cell and
+  /// to downsample the source image to the actual display size.
+  var fixedDisplaySize: CGSize? = nil
   @State private var fullLoaded: Bool = false
   @State private var loadFailed: Bool = false
   @State private var renderedFullURL: URL?
   var body: some View {
-    GeometryReader { geo in
-      let pixelSize = NSValue(cgSize: thumbnailPixelSize(for: geo.size))
-      let context: [SDWebImageContextOption: Any] =
-        fullResolution
-        ? [:] : [
-          .imageThumbnailPixelSize: pixelSize,
-          .imageDecodeOptions: [SDImageCoderOption.decodeScaleFactor: 1.0]
-        ]
-      ZStack {
-        if !transparentBackground {
-          MusicArtworkPlaceholder()
-        }
-        if let lowResURL, !fullLoaded {
-          WebImage(
-            url: lowResURL,
-            options: [.retryFailed, .scaleDownLargeImages, .fromCacheOnly],
-            context: [.imageThumbnailPixelSize: NSValue(cgSize: CGSize(width: 120, height: 120))]
-          ) { image in
-            image
-              .resizable()
-              .aspectRatio(contentMode: contentMode)
-              .frame(width: geo.size.width, height: geo.size.height)
-              .clipped()
-              .blur(radius: 2)
-          } placeholder: {
-            Color.clear
-          }
-        }
-        if let url, !loadFailed {
-          WebImage(
-            url: url,
-            options: ImageCacheConfig.defaultOptions,
-            context: context
-          ) { image in
-            image
-              .resizable()
-              .aspectRatio(contentMode: contentMode)
-              .frame(width: geo.size.width, height: geo.size.height)
-              .clipped()
-              .onAppear {
-                markRendered(url)
-              }
-          } placeholder: {
-            Color.clear
-          }
-          .onFailure { _ in
-            markFinishedAfterFailure()
-          }
-          .onSuccess { _, _, _ in
-            markRendered(url)
-          }
-          .transition(.opacity.animation(.easeOut(duration: 0.15)))
-        }
-
-        if shouldShowLoading {
-          LoadingIndicator(size: min(geo.size.width, geo.size.height) * 0.5)
-            .transition(.opacity.animation(.easeOut(duration: 0.12)))
+    Group {
+      if let fixedDisplaySize {
+        imageContent(size: fixedDisplaySize)
+          .frame(width: fixedDisplaySize.width, height: fixedDisplaySize.height)
+      } else {
+        GeometryReader { geo in
+          imageContent(size: geo.size)
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .center)
         }
       }
-      .frame(width: geo.size.width, height: geo.size.height, alignment: .center)
     }
     .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     .onChange(of: url) {
       fullLoaded = false
       loadFailed = false
       renderedFullURL = nil
+    }
+  }
+
+  @ViewBuilder
+  private func imageContent(size: CGSize) -> some View {
+    let pixelSize = NSValue(cgSize: thumbnailPixelSize(for: size))
+    let context: [SDWebImageContextOption: Any] =
+      fullResolution
+      ? [:] : [
+        .imageThumbnailPixelSize: pixelSize,
+        .imageDecodeOptions: [SDImageCoderOption.decodeScaleFactor: 1.0]
+      ]
+    ZStack {
+      if !transparentBackground {
+        MusicArtworkPlaceholder()
+      }
+      if let lowResURL, !fullLoaded {
+        WebImage(
+          url: lowResURL,
+          options: [.retryFailed, .scaleDownLargeImages, .fromCacheOnly],
+          context: [.imageThumbnailPixelSize: NSValue(cgSize: CGSize(width: 120, height: 120))]
+        ) { image in
+          image
+            .resizable()
+            .aspectRatio(contentMode: contentMode)
+            .frame(width: size.width, height: size.height)
+            .clipped()
+            .blur(radius: 2)
+        } placeholder: {
+          Color.clear
+        }
+      }
+      if let url, !loadFailed {
+        WebImage(
+          url: url,
+          options: ImageCacheConfig.defaultOptions,
+          context: context
+        ) { image in
+          image
+            .resizable()
+            .aspectRatio(contentMode: contentMode)
+            .frame(width: size.width, height: size.height)
+            .clipped()
+            .onAppear {
+              markRendered(url)
+            }
+        } placeholder: {
+          Color.clear
+        }
+        .onFailure { _ in
+          markFinishedAfterFailure()
+        }
+        .onSuccess { _, _, _ in
+          markRendered(url)
+        }
+        .transition(.opacity.animation(.easeOut(duration: 0.15)))
+      }
+
+      if shouldShowLoading {
+        LoadingIndicator(size: min(size.width, size.height) * 0.5)
+          .transition(.opacity.animation(.easeOut(duration: 0.12)))
+      }
     }
   }
 

--- a/Twinskaraoke/Components/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/ScrollOptimization.swift
@@ -9,22 +9,22 @@ extension View {
       .scrollDismissesKeyboard(.interactively)
   }
 
-  /// Optimize LazyVStack for smooth scrolling with content buffering
-  func optimizedLazyStack() -> some View {
-    self
-  }
 }
 
-/// Optimized scroll position tracking that doesn't impact scroll performance
+/// Preference-based scroll tracking should publish coarse changes only; sub-point
+/// jitter creates unnecessary SwiftUI invalidations while the finger is moving.
 struct SmoothScrollOffsetPreferenceKey: PreferenceKey {
   static var defaultValue: CGFloat = 0
   static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-    value = nextValue()
+    let next = nextValue()
+    if abs(next - value) >= 1 {
+      value = next
+    }
   }
 }
 
 extension ScrollView {
-  /// Track scroll offset without impacting performance
+  /// Track scroll offset for coarse UI chrome changes.
   func trackScrollOffset(_ offset: Binding<CGFloat>, coordinateSpace: String = "scroll") -> some View {
     self
       .coordinateSpace(name: coordinateSpace)

--- a/Twinskaraoke/Components/SongRow.swift
+++ b/Twinskaraoke/Components/SongRow.swift
@@ -1,4 +1,49 @@
+import Combine
 import SwiftUI
+
+/// Song rows only need a tiny playback snapshot. Observing the full audio manager here
+/// would make every visible row redraw on high-frequency progress updates while scrolling.
+@MainActor
+final class PlaybackRowState: ObservableObject {
+  static let shared = PlaybackRowState()
+
+  @Published private(set) var currentSongID: String?
+  @Published private(set) var isPlaying = false
+  @Published private(set) var isRadioMode = false
+  @Published private(set) var radioArtworkURL: URL?
+
+  private var cancellables = Set<AnyCancellable>()
+
+  private init(manager: AudioPlayerManager = .shared) {
+    manager.$currentSong
+      .map(\.?.id)
+      .removeDuplicates()
+      .sink { [weak self] in self?.currentSongID = $0 }
+      .store(in: &cancellables)
+
+    manager.$isPlaying
+      .removeDuplicates()
+      .sink { [weak self] in self?.isPlaying = $0 }
+      .store(in: &cancellables)
+
+    manager.$isRadioMode
+      .removeDuplicates()
+      .sink { [weak self] in self?.isRadioMode = $0 }
+      .store(in: &cancellables)
+
+    manager.$radioArtworkURL
+      .removeDuplicates()
+      .sink { [weak self] in self?.radioArtworkURL = $0 }
+      .store(in: &cancellables)
+  }
+
+  func displayImageURL(for song: Song) -> URL? {
+    if isRadioMode, currentSongID == song.id, let radioArtworkURL {
+      return radioArtworkURL
+    }
+    return song.imageURL
+  }
+}
 
 enum SongRowSize {
   case compact, regular
@@ -32,18 +77,21 @@ enum SongRowSize {
 struct SongRow: View {
   let song: Song
   let size: SongRowSize
+  /// Large collection screens can hide thumbnails so rows stay cheap during fast flings.
   var showsArtwork: Bool = true
   var trailing: AnyView? = nil
-  @EnvironmentObject var audioManager: AudioPlayerManager
+  @ObservedObject private var playback = PlaybackRowState.shared
   @StateObject private var downloads = DownloadManager.shared
   @State private var showAddToPlaylist = false
-  private var isCurrentSong: Bool { audioManager.currentSong?.id == song.id }
+  private var isCurrentSong: Bool { playback.currentSongID == song.id }
   var body: some View {
     HStack(spacing: 12) {
       ZStack {
         if showsArtwork {
           LoadingImage(
-            url: audioManager.displayImageURL(for: song), cornerRadius: size.cornerRadius
+            url: playback.displayImageURL(for: song),
+            cornerRadius: size.cornerRadius,
+            fixedDisplaySize: CGSize(width: size.artSize, height: size.artSize)
           )
           .frame(width: size.artSize, height: size.artSize)
           .clipShape(RoundedRectangle(cornerRadius: size.cornerRadius, style: .continuous))
@@ -61,7 +109,7 @@ struct SongRow: View {
           RoundedRectangle(cornerRadius: size.cornerRadius, style: .continuous)
             .fill(Color.appArtworkOverlay)
             .frame(width: size.artSize, height: size.artSize)
-          EqualizerBars(isAnimating: audioManager.isPlaying)
+          EqualizerBars(isAnimating: playback.isPlaying)
             .frame(width: size.indicatorSize, height: size.indicatorSize)
             .foregroundColor(.primary)
         }
@@ -112,7 +160,6 @@ struct SongRow: View {
       songActions
     } preview: {
       SongContextPreview(song: song)
-        .environmentObject(audioManager)
     }
     .sheet(isPresented: $showAddToPlaylist) {
       AddToPlaylistSheet(song: song)
@@ -236,7 +283,7 @@ struct MusicGridCard: View {
   var size: MusicGridCardSize = .regular
   var width: CGFloat?
   var accessibilityIdentifier: String?
-  @EnvironmentObject private var audioManager: AudioPlayerManager
+  @ObservedObject private var playback = PlaybackRowState.shared
   @State private var showAddToPlaylist = false
 
   init(
@@ -261,7 +308,7 @@ struct MusicGridCard: View {
   var body: some View {
     Button {
       AppHaptic.selection.play()
-      audioManager.play(song: song, context: context)
+      AudioPlayerManager.shared.play(song: song, context: context)
     } label: {
       VStack(alignment: .leading, spacing: size.textSpacing) {
         artwork
@@ -284,7 +331,6 @@ struct MusicGridCard: View {
       }
     } preview: {
       SongContextPreview(song: song)
-        .environmentObject(audioManager)
     }
     .sheet(isPresented: $showAddToPlaylist) {
       AddToPlaylistSheet(song: song)
@@ -313,8 +359,14 @@ struct MusicGridCard: View {
 
   @ViewBuilder
   private var artworkContent: some View {
-    if let imageURL = audioManager.displayImageURL(for: song) {
-      LoadingImage(url: imageURL, cornerRadius: AM.Radius.card)
+    if let imageURL = playback.displayImageURL(for: song) {
+      // Fixed card dimensions let LoadingImage request a deterministic thumbnail size
+      // without measuring every card through GeometryReader.
+      LoadingImage(
+        url: imageURL,
+        cornerRadius: AM.Radius.card,
+        fixedDisplaySize: width.map { CGSize(width: $0, height: $0) }
+      )
     } else {
       RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous)
         .fill(Color.appPlaceholderPrimary)
@@ -345,14 +397,13 @@ private struct MusicGridCardShadow: ViewModifier {
 struct SongActionsMenuItems: View {
   let song: Song
   let onAddToPlaylist: () -> Void
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @StateObject private var downloads = DownloadManager.shared
   @ObservedObject private var favorites = FavoritesManager.shared
 
   var body: some View {
     Button {
       AppHaptic.selection.play()
-      audioManager.playNext(song: song)
+      AudioPlayerManager.shared.playNext(song: song)
     } label: {
       Label("Play Next", systemImage: "text.insert")
     }
@@ -409,11 +460,15 @@ struct SongActionsMenuItems: View {
 
 struct SongContextPreview: View {
   let song: Song
-  @EnvironmentObject private var audioManager: AudioPlayerManager
+  @ObservedObject private var playback = PlaybackRowState.shared
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      LoadingImage(url: audioManager.displayImageURL(for: song), cornerRadius: 10)
+      LoadingImage(
+        url: playback.displayImageURL(for: song),
+        cornerRadius: 10,
+        fixedDisplaySize: CGSize(width: 220, height: 220)
+      )
         .aspectRatio(1, contentMode: .fill)
         .frame(width: 220, height: 220)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -438,7 +493,7 @@ private struct SongRowAccessibilityModifier: ViewModifier {
   let song: Song
   var isPending = false
   let onPlay: () -> Void
-  @EnvironmentObject private var audioManager: AudioPlayerManager
+  @ObservedObject private var playback = PlaybackRowState.shared
   @ObservedObject private var downloads = DownloadManager.shared
   @ObservedObject private var favorites = FavoritesManager.shared
 
@@ -453,7 +508,7 @@ private struct SongRowAccessibilityModifier: ViewModifier {
       }
       .accessibilityAction(named: "Play Next") {
         AppHaptic.selection.play()
-        audioManager.playNext(song: song)
+        AudioPlayerManager.shared.playNext(song: song)
       }
       .accessibilityAction(named: favoriteActionTitle) {
         toggleFavorite()
@@ -468,8 +523,8 @@ private struct SongRowAccessibilityModifier: ViewModifier {
     if !song.durationText.isEmpty {
       values.append(song.durationText)
     }
-    if audioManager.currentSong?.id == song.id {
-      values.append(audioManager.isPlaying ? "Now playing" : "Current song")
+    if playback.currentSongID == song.id {
+      values.append(playback.isPlaying ? "Now playing" : "Current song")
     }
     if isPending {
       values.append("Loading")

--- a/Twinskaraoke/Features/Account/AccountView.swift
+++ b/Twinskaraoke/Features/Account/AccountView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct AccountView: View {
   @StateObject private var auth = AuthManager()
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @State private var showLoginSheet = false
   @State private var showQRApprove = false

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct HomeView: View {
   @StateObject var viewModel = HomeViewModel()
   @StateObject private var recentlyPlayed = RecentlyPlayedStore.shared
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
@@ -516,12 +515,11 @@ private struct NewFeatureCard: View {
   let context: [Song]
   let width: CGFloat
   let artworkSize: CGFloat
-  @EnvironmentObject private var audioManager: AudioPlayerManager
 
   var body: some View {
     Button {
       AppHaptic.selection.play()
-      audioManager.play(song: song, context: context)
+      AudioPlayerManager.shared.play(song: song, context: context)
     } label: {
       VStack(alignment: .leading, spacing: 8) {
         VStack(alignment: .leading, spacing: 2) {
@@ -596,7 +594,6 @@ private struct NewSongListPreview: View {
   let title: String
   let songs: [Song]
   var horizontalPadding: CGFloat = AM.Spacing.screenMargin
-  @EnvironmentObject private var audioManager: AudioPlayerManager
 
   var body: some View {
     VStack(alignment: .leading, spacing: AM.Spacing.s) {
@@ -605,7 +602,7 @@ private struct NewSongListPreview: View {
         ForEach(songs) { song in
           Button {
             AppHaptic.selection.play()
-            audioManager.play(song: song, context: songs)
+            AudioPlayerManager.shared.play(song: song, context: songs)
           } label: {
             SongRow(song: song, size: .compact)
               .padding(.horizontal, horizontalPadding)
@@ -696,7 +693,6 @@ private struct LatestSingleSection: View {
   let song: Song
   let context: [Song]
   var horizontalPadding: CGFloat = AM.Spacing.screenMargin
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @State private var showAddToPlaylist = false
 
   var body: some View {
@@ -739,7 +735,6 @@ private struct LatestSingleSection: View {
         }
       } preview: {
         SongContextPreview(song: song)
-          .environmentObject(audioManager)
       }
       .sheet(isPresented: $showAddToPlaylist) {
         AddToPlaylistSheet(song: song)
@@ -750,7 +745,7 @@ private struct LatestSingleSection: View {
 
   private func play() {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: context)
+    AudioPlayerManager.shared.play(song: song, context: context)
   }
 }
 
@@ -1021,11 +1016,12 @@ struct HomeSkeletonView: View {
 struct BrowseSongCollectionView: View {
   let title: String
   let songs: [Song]
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
   @State private var scrollOffset: CGFloat = 0
+  // Very large result sets skip per-row artwork to keep cell creation and image
+  // decoding from dominating a fast collection scroll.
   private var showsArtwork: Bool { songs.count <= 200 }
   private var usesWideOverview: Bool {
     horizontalSizeClass == .regular
@@ -1057,7 +1053,7 @@ struct BrowseSongCollectionView: View {
       }
       .scrollDismissesKeyboard(.interactively)
       .coordinateSpace(name: "browseScroll")
-      .onPreferenceChange(BrowseScrollOffsetKey.self) { scrollOffset = $0 }
+      .onPreferenceChange(BrowseScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }
     }
     .navigationTitle(scrollOffset < -180 ? title : "")
     .navigationBarTitleDisplayMode(.inline)
@@ -1109,7 +1105,7 @@ struct BrowseSongCollectionView: View {
 
   private func play(_ song: Song) {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: songs)
+    AudioPlayerManager.shared.play(song: song, context: songs)
   }
 
   @ViewBuilder
@@ -1192,7 +1188,7 @@ struct BrowseSongCollectionView: View {
       Button {
         if let first = songs.first {
           AppHaptic.medium.play()
-          audioManager.playInOrder(song: first, context: songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: songs)
         }
       } label: {
         Label("Play", systemImage: "play.fill")
@@ -1208,7 +1204,7 @@ struct BrowseSongCollectionView: View {
       .accessibilityValue("\(songs.count) songs")
       Button {
         AppHaptic.selection.play()
-        audioManager.playShuffled(from: songs)
+        AudioPlayerManager.shared.playShuffled(from: songs)
       } label: {
         Label("Shuffle", systemImage: "shuffle")
           .font(.system(size: 17, weight: .semibold))
@@ -1231,6 +1227,12 @@ private struct BrowseScrollOffsetKey: PreferenceKey {
   static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
     value = nextValue()
   }
+}
+
+private func quantizedScrollOffset(_ offset: CGFloat) -> CGFloat {
+  // Parallax and nav chrome do not need pixel-accurate offsets; bucketing the value
+  // cuts down SwiftUI invalidations while preserving the visible effect.
+  (offset / 8).rounded() * 8
 }
 
 final class PlaylistListLoader: ObservableObject {

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -313,7 +313,6 @@ private struct ArtistAvatar: View {
 struct ArtistDetailView: View {
   let artist: Artist
   @StateObject private var loader = ArtistDetailViewModel()
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
   @State private var scrollOffset: CGFloat = 0
@@ -346,10 +345,13 @@ struct ArtistDetailView: View {
           }
           .padding(.horizontal)
           if !songs.isEmpty {
+            // Artist pages can return hundreds of tracks; skip artwork past this
+            // point so a fling does not queue hundreds of image loads.
+            let showsRowArtwork = songs.count <= 200
             actionButtons
             LazyVStack(spacing: 0) {
               ForEach(songs) { song in
-                ArtistSongRow(song: song) {
+                ArtistSongRow(song: song, showsArtwork: showsRowArtwork) {
                   play(song)
                 }
                   .padding(.horizontal)
@@ -392,7 +394,7 @@ struct ArtistDetailView: View {
       }
       .scrollIndicators(.hidden)
       .coordinateSpace(name: "artistScroll")
-      .onPreferenceChange(ArtistScrollOffsetKey.self) { scrollOffset = $0 }
+      .onPreferenceChange(ArtistScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }
     }
     .musicScreenBackground()
     .navigationTitle(scrollOffset < -180 ? current.name : "")
@@ -423,7 +425,7 @@ struct ArtistDetailView: View {
 
   private func play(_ song: Song) {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: songs)
+    AudioPlayerManager.shared.play(song: song, context: songs)
   }
 
   @ViewBuilder
@@ -432,14 +434,12 @@ struct ArtistDetailView: View {
     let stretch = reduceMotion ? 0 : max(0, scrollOffset)
     let shrink = reduceMotion ? 0 : max(0, -scrollOffset * 0.4)
     let size = max(140, baseSize + stretch * 0.6 - shrink)
-    let blur = reduceMotion ? 0 : min(8, max(0, -scrollOffset / 30))
     let yOffset = reduceMotion ? 0 : (scrollOffset > 0 ? -scrollOffset / 2 : 0)
     let artworkOpacity = reduceMotion ? 1 : 1 - min(0.7, max(0, -scrollOffset / 250))
     ArtistAvatar(url: current.imageURL)
       .frame(width: size, height: size)
       .clipShape(Circle())
       .shadow(color: .black.opacity(0.3), radius: 16, x: 0, y: 8)
-      .blur(radius: blur)
       .opacity(artworkOpacity)
       .frame(width: width)
       .offset(y: yOffset)
@@ -454,7 +454,7 @@ struct ArtistDetailView: View {
     HStack(spacing: 12) {
       Button {
         if let first = songs.first {
-          audioManager.playInOrder(song: first, context: songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: songs)
         }
       } label: {
         LibraryActionButtonLabel(
@@ -466,7 +466,7 @@ struct ArtistDetailView: View {
       }
       .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
       Button {
-        audioManager.playShuffled(from: songs)
+        AudioPlayerManager.shared.playShuffled(from: songs)
       } label: {
         LibraryActionButtonLabel(
           symbol: "shuffle",
@@ -501,10 +501,12 @@ struct ArtistDetailView: View {
 
 private struct ArtistSongRow: View {
   let song: Song
+  /// Propagated from ArtistDetailView so large artist catalogs can use cheaper rows.
+  var showsArtwork = true
   let onPlay: () -> Void
 
   var body: some View {
-    SongRow(song: song, size: .regular)
+    SongRow(song: song, size: .regular, showsArtwork: showsArtwork)
       .contentShape(Rectangle())
       .onTapGesture {
         onPlay()
@@ -673,7 +675,6 @@ private struct ArtistDetailHintRow: View {
 
 private struct ArtistActionsMenu: View {
   let songs: [Song]
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @StateObject private var downloads = DownloadManager.shared
 
   private var pendingDownloads: [Song] {
@@ -700,7 +701,7 @@ private struct ArtistActionsMenu: View {
       Button {
         AppHaptic.selection.play()
         if let first = songs.first {
-          audioManager.playInOrder(song: first, context: songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: songs)
         }
       } label: {
         Label("Play", systemImage: "play.fill")
@@ -708,7 +709,7 @@ private struct ArtistActionsMenu: View {
 
       Button {
         AppHaptic.selection.play()
-        audioManager.playShuffled(from: songs)
+        AudioPlayerManager.shared.playShuffled(from: songs)
       } label: {
         Label("Shuffle", systemImage: "shuffle")
       }
@@ -743,4 +744,10 @@ private struct ArtistActionsMenu: View {
 private struct ArtistScrollOffsetKey: PreferenceKey {
   static var defaultValue: CGFloat = 0
   static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+private func quantizedScrollOffset(_ offset: CGFloat) -> CGFloat {
+  // Keep parallax/header state coarse; tiny offset changes are visually irrelevant
+  // but still cause SwiftUI to re-evaluate the detail view.
+  (offset / 8).rounded() * 8
 }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -3,11 +3,12 @@ import SwiftUI
 struct DownloadedSongsView: View {
   @StateObject private var downloads = DownloadManager.shared
   @StateObject private var recentlyPlayed = RecentlyPlayedStore.shared
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
   @State private var localSongs: [Song] = []
-  @State private var scrollOffset: CGFloat = 0
+  // Store only the navigation-bar threshold, not the raw offset, to avoid per-frame
+  // state updates while scrolling the downloaded list.
+  @State private var showsCollapsedTitle = false
   @State private var showRemoveAllConfirmation = false
 
   private var reduceMotion: Bool {
@@ -56,7 +57,6 @@ struct DownloadedSongsView: View {
                     }
                   } preview: {
                     SongContextPreview(song: song)
-                      .environmentObject(audioManager)
                   }
                 if idx < localSongs.count - 1 {
                   Divider().padding(.leading, 76)
@@ -69,8 +69,8 @@ struct DownloadedSongsView: View {
           .background(
             GeometryReader { proxy in
               Color.clear.preference(
-                key: DownloadedScrollOffsetKey.self,
-                value: proxy.frame(in: .named("downloadedScroll")).minY
+                key: DownloadedCollapsedTitleKey.self,
+                value: proxy.frame(in: .named("downloadedScroll")).minY < -180
               )
             }
           )
@@ -80,11 +80,14 @@ struct DownloadedSongsView: View {
       .scrollDismissesKeyboard(.interactively)
       .coordinateSpace(name: "downloadedScroll")
       .bottomChromeScrollTracking()
-      .onPreferenceChange(DownloadedScrollOffsetKey.self) { scrollOffset = $0 }
+      .onPreferenceChange(DownloadedCollapsedTitleKey.self) { collapsed in
+        guard showsCollapsedTitle != collapsed else { return }
+        showsCollapsedTitle = collapsed
+      }
     }
-    .navigationTitle(scrollOffset < -180 ? "Downloaded" : "")
+    .navigationTitle(showsCollapsedTitle ? "Downloaded" : "")
     .navigationBarTitleDisplayMode(.inline)
-    .toolbarBackground(scrollOffset < -180 ? .visible : .hidden, for: .navigationBar)
+    .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
     .toolbar {
       ToolbarItem(placement: .topBarTrailing) {
         if !localSongs.isEmpty {
@@ -105,7 +108,7 @@ struct DownloadedSongsView: View {
       Text("All offline songs on this device will be removed. You can download them again from song menus.")
     }
     .musicScreenBackground()
-    .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: scrollOffset < -180)
+    .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: showsCollapsedTitle)
     .animation(
       reduceMotion ? nil : .spring(response: 0.34, dampingFraction: 0.84),
       value: localSongs.map(\.id)
@@ -138,17 +141,12 @@ struct DownloadedSongsView: View {
 
   @ViewBuilder
   private func heroHeader(width: CGFloat) -> some View {
-    let baseSize: CGFloat = 240
-    let stretch = max(0, scrollOffset)
-    let shrink = max(0, -scrollOffset * 0.4)
-    let size = max(140, baseSize + stretch * 0.6 - shrink)
-    let blur = min(8, max(0, -scrollOffset / 30))
+    // This header intentionally stays fixed-size; animating blur/scale from raw
+    // scroll offset made the downloaded screen do extra work during every scroll tick.
     mosaicArtwork
-      .frame(width: size, height: size)
+      .frame(width: 240, height: 240)
       .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
       .shadow(color: .black.opacity(0.3), radius: 16, x: 0, y: 8)
-      .blur(radius: blur)
-      .opacity(1 - min(0.7, max(0, -scrollOffset / 250)))
       .frame(width: width)
       .padding(.top, 12)
   }
@@ -204,16 +202,16 @@ struct DownloadedSongsView: View {
 
   private func playInOrder() {
     guard let first = localSongs.first else { return }
-    audioManager.playInOrder(song: first, context: localSongs)
+    AudioPlayerManager.shared.playInOrder(song: first, context: localSongs)
   }
 
   private func shuffle() {
-    audioManager.playShuffled(from: localSongs)
+    AudioPlayerManager.shared.playShuffled(from: localSongs)
   }
 
   private func play(_ song: Song) {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: localSongs)
+    AudioPlayerManager.shared.play(song: song, context: localSongs)
   }
 
   private func removeDownload(_ song: Song) {
@@ -380,13 +378,12 @@ private struct DownloadedEmptyHintRow: View {
 private struct DownloadedSongMenuItems: View {
   let song: Song
   let onRemove: () -> Void
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @ObservedObject private var favorites = FavoritesManager.shared
 
   var body: some View {
     Button {
       AppHaptic.selection.play()
-      audioManager.playNext(song: song)
+      AudioPlayerManager.shared.playNext(song: song)
     } label: {
       Label("Play Next", systemImage: "text.insert")
     }
@@ -457,7 +454,11 @@ private struct DownloadedSongsMenu: View {
   }
 }
 
-private struct DownloadedScrollOffsetKey: PreferenceKey {
-  static var defaultValue: CGFloat = 0
-  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+/// Reports whether the downloaded header has crossed the title-collapse threshold.
+/// The Bool value keeps preference churn lower than sending the full scroll offset.
+private struct DownloadedCollapsedTitleKey: PreferenceKey {
+  static var defaultValue = false
+  static func reduce(value: inout Bool, nextValue: () -> Bool) {
+    value = value || nextValue()
+  }
 }

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -541,7 +541,6 @@ final class LibrarySongsViewModel: ObservableObject {
 
 struct LibrarySongsView: View {
   @StateObject private var viewModel = LibrarySongsViewModel()
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
 
@@ -559,6 +558,9 @@ struct LibrarySongsView: View {
   var body: some View {
     let songs = viewModel.displayedSongs
     let isSearching = !viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    // Once the library list gets large, omitting thumbnails removes a major source
+    // of row work: image decode, cache lookup, and extra view composition per cell.
+    let showsRowArtwork = songs.count <= 200
     List {
       if viewModel.isLoading && songs.isEmpty {
         skeletonRows
@@ -576,7 +578,7 @@ struct LibrarySongsView: View {
         }
         Section {
           ForEach(songs) { song in
-            SongRow(song: song, size: .regular)
+            SongRow(song: song, size: .regular, showsArtwork: showsRowArtwork)
               .id(song.id)
               .padding(.vertical, 6)
               .contentShape(Rectangle())
@@ -634,7 +636,7 @@ struct LibrarySongsView: View {
 
   private func play(_ song: Song, context: [Song]) {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: context)
+    AudioPlayerManager.shared.play(song: song, context: context)
   }
 
   private var sortMenu: some View {
@@ -662,14 +664,14 @@ struct LibrarySongsView: View {
     HStack(spacing: 12) {
       Button {
         if let first = songs.first {
-          audioManager.playInOrder(song: first, context: songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: songs)
         }
       } label: {
         LibraryActionButtonLabel(symbol: "play.fill", text: "Play", style: .tertiary)
       }
       .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
       Button {
-        audioManager.playShuffled(from: songs)
+        AudioPlayerManager.shared.playShuffled(from: songs)
       } label: {
         LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle", style: .tertiary)
       }
@@ -1037,7 +1039,6 @@ struct LibraryCollectionRow: View {
 struct LibraryCollectionDetailView: View {
   let kind: LibraryCollectionKind
   let collection: LibrarySongCollection
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
   @State private var scrollOffset: CGFloat = 0
@@ -1084,9 +1085,12 @@ struct LibraryCollectionDetailView: View {
           } else {
             actionButtons
               .padding(.horizontal)
+            // Collection detail screens can be arbitrarily long, so large ones use
+            // text-first rows to keep scrolling predictable on iPhone.
+            let showsRowArtwork = collection.songs.count <= 200
             LazyVStack(spacing: 0) {
               ForEach(collection.songs) { song in
-                SongRow(song: song, size: .regular)
+                SongRow(song: song, size: .regular, showsArtwork: showsRowArtwork)
                   .padding(.horizontal)
                   .padding(.vertical, 8)
                   .contentShape(Rectangle())
@@ -1113,7 +1117,7 @@ struct LibraryCollectionDetailView: View {
         )
       }
       .coordinateSpace(name: "libraryCollectionScroll")
-      .onPreferenceChange(LibraryCollectionScrollOffsetKey.self) { scrollOffset = $0 }
+      .onPreferenceChange(LibraryCollectionScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }
     }
     .navigationTitle(scrollOffset < -180 ? collection.title : "")
     .navigationBarTitleDisplayMode(.inline)
@@ -1140,7 +1144,7 @@ struct LibraryCollectionDetailView: View {
 
   private func play(_ song: Song) {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: collection.songs)
+    AudioPlayerManager.shared.play(song: song, context: collection.songs)
   }
 
   private func heroArtwork(width: CGFloat) -> some View {
@@ -1148,14 +1152,12 @@ struct LibraryCollectionDetailView: View {
     let stretch = reduceMotion ? 0 : max(0, scrollOffset)
     let shrink = reduceMotion ? 0 : max(0, -scrollOffset * 0.4)
     let size = max(140, baseSize + stretch * 0.6 - shrink)
-    let blur = reduceMotion ? 0 : min(8, max(0, -scrollOffset / 30))
     let yOffset = reduceMotion ? 0 : (scrollOffset > 0 ? -scrollOffset / 2 : 0)
     let artworkOpacity = reduceMotion ? 1 : 1 - min(0.7, max(0, -scrollOffset / 250))
     return LibraryCollectionArtwork(collection: collection, symbol: kind.symbol, cornerRadius: 14)
       .frame(width: size, height: size)
       .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
       .shadow(color: .black.opacity(0.3), radius: 16, x: 0, y: 8)
-      .blur(radius: blur)
       .opacity(artworkOpacity)
       .frame(width: width)
       .offset(y: yOffset)
@@ -1169,14 +1171,14 @@ struct LibraryCollectionDetailView: View {
     HStack(spacing: 12) {
       Button {
         if let first = collection.songs.first {
-          audioManager.playInOrder(song: first, context: collection.songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: collection.songs)
         }
       } label: {
         LibraryActionButtonLabel(symbol: "play.fill", text: "Play", style: .tertiary)
       }
       .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
       Button {
-        audioManager.playShuffled(from: collection.songs)
+        AudioPlayerManager.shared.playShuffled(from: collection.songs)
       } label: {
         LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle", style: .tertiary)
       }
@@ -1202,7 +1204,6 @@ private struct LibraryCollectionEmptyStateView: View {
 
 private struct LibraryCollectionActionsMenu: View {
   let collection: LibrarySongCollection
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @StateObject private var downloads = DownloadManager.shared
 
   private var pendingDownloads: [Song] {
@@ -1224,7 +1225,7 @@ private struct LibraryCollectionActionsMenu: View {
       Button {
         AppHaptic.selection.play()
         if let first = collection.songs.first {
-          audioManager.playInOrder(song: first, context: collection.songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: collection.songs)
         }
       } label: {
         Label("Play", systemImage: "play.fill")
@@ -1232,7 +1233,7 @@ private struct LibraryCollectionActionsMenu: View {
 
       Button {
         AppHaptic.selection.play()
-        audioManager.playShuffled(from: collection.songs)
+        AudioPlayerManager.shared.playShuffled(from: collection.songs)
       } label: {
         Label("Shuffle", systemImage: "shuffle")
       }
@@ -1325,6 +1326,12 @@ private struct LibraryCollectionArtwork: View {
 private struct LibraryCollectionScrollOffsetKey: PreferenceKey {
   static var defaultValue: CGFloat = 0
   static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+private func quantizedScrollOffset(_ offset: CGFloat) -> CGFloat {
+  // Bucket scroll offset changes so the parallax artwork and collapsed title do not
+  // trigger a full view update for every sub-pixel movement.
+  (offset / 8).rounded() * 8
 }
 
 private extension Song {

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct PlaylistDetailView: View {
   let playlist: Playlist
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
@@ -37,7 +36,7 @@ struct PlaylistDetailView: View {
       }
       .coordinateSpace(name: "playlistScroll")
       .bottomChromeScrollTracking()
-      .onPreferenceChange(ScrollOffsetKey.self) { scrollOffset = $0 }
+      .onPreferenceChange(ScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }
     }
     .navigationTitle(scrollOffset < -180 ? playlist.name : "")
     .navigationBarTitleDisplayMode(.inline)
@@ -146,12 +145,10 @@ struct PlaylistDetailView: View {
     let stretch = reduceMotion ? 0 : max(0, scrollOffset)
     let shrink = reduceMotion ? 0 : max(0, -scrollOffset * 0.4)
     let size = max(140, baseSize + stretch * 0.6 - shrink)
-    let blur = reduceMotion ? 0 : min(8, max(0, -scrollOffset / 30))
     let yOffset = reduceMotion ? 0 : (scrollOffset > 0 ? -scrollOffset / 2 : 0)
     let artworkOpacity = reduceMotion ? 1 : 1 - min(0.7, max(0, -scrollOffset / 250))
     return playlistArtwork(size: size)
     .shadow(color: .black.opacity(0.3), radius: 16, x: 0, y: 8)
-    .blur(radius: blur)
     .opacity(artworkOpacity)
     .frame(width: width)
     .offset(y: yOffset)
@@ -185,13 +182,16 @@ struct PlaylistDetailView: View {
   @ViewBuilder
   private func playlistSongsContent(songs: [Song], rowHorizontalPadding: CGFloat = AM.Spacing.screenMargin) -> some View {
     if !songs.isEmpty {
+      // On long playlists, thumbnail decoding and cache churn are more expensive than
+      // the metadata row itself, so keep the scrolling path text-first.
+      let showsRowArtwork = songs.count <= 200
       VStack(spacing: 0) {
         if !usesWideOverview {
           actionButtons(songs: songs)
         }
         LazyVStack(spacing: 0) {
           ForEach(songs) { song in
-            PlaylistRow(song: song, horizontalPadding: rowHorizontalPadding)
+            PlaylistRow(song: song, showsArtwork: showsRowArtwork, horizontalPadding: rowHorizontalPadding)
               .contentShape(Rectangle())
               .onTapGesture {
                 play(song, context: songs)
@@ -229,7 +229,7 @@ struct PlaylistDetailView: View {
       Button {
         if let first = songs.first {
           AppHaptic.selection.play()
-          audioManager.playInOrder(song: first, context: songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: songs)
         }
       } label: {
         LibraryActionButtonLabel(symbol: "play.fill", text: "Play")
@@ -238,7 +238,7 @@ struct PlaylistDetailView: View {
       .accessibilityLabel("Play playlist")
       Button {
         AppHaptic.selection.play()
-        audioManager.playShuffled(from: songs)
+        AudioPlayerManager.shared.playShuffled(from: songs)
       } label: {
         LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
       }
@@ -250,7 +250,7 @@ struct PlaylistDetailView: View {
 
   private func play(_ song: Song, context: [Song]) {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: context)
+    AudioPlayerManager.shared.play(song: song, context: context)
   }
 }
 
@@ -359,7 +359,6 @@ private struct PlaylistMoreMenu: View {
 struct PlaylistActionsMenuItems: View {
   let playlist: Playlist
   let songs: [Song]
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @StateObject private var downloads = DownloadManager.shared
   @ObservedObject private var savedStore: SavedPlaylistsStore = .shared
   private var pendingCount: Int {
@@ -378,7 +377,7 @@ struct PlaylistActionsMenuItems: View {
       Button {
         AppHaptic.selection.play()
         if let first = songs.first {
-          audioManager.playInOrder(song: first, context: songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: songs)
         }
       } label: {
         Label("Play", systemImage: "play.fill")
@@ -386,7 +385,7 @@ struct PlaylistActionsMenuItems: View {
 
       Button {
         AppHaptic.selection.play()
-        audioManager.playShuffled(from: songs)
+        AudioPlayerManager.shared.playShuffled(from: songs)
       } label: {
         Label("Shuffle", systemImage: "shuffle")
       }
@@ -437,12 +436,20 @@ private struct ScrollOffsetKey: PreferenceKey {
   static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
 }
 
+private func quantizedScrollOffset(_ offset: CGFloat) -> CGFloat {
+  // The hero/header only need coarse offset changes; 8-point buckets reduce redraws
+  // during high-velocity scrolling without making the parallax feel stepped.
+  (offset / 8).rounded() * 8
+}
+
 struct PlaylistRow: View {
   let song: Song
+  /// Propagated from the parent so large playlists can render cheaper rows.
+  var showsArtwork = true
   var horizontalPadding: CGFloat = AM.Spacing.screenMargin
 
   var body: some View {
-    SongRow(song: song, size: .regular, showsArtwork: true)
+    SongRow(song: song, size: .regular, showsArtwork: showsArtwork)
       .padding(.horizontal, horizontalPadding)
       .padding(.vertical, 8)
   }

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct RandomSongsView: View {
   @StateObject var viewModel = RandomSongsViewModel()
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
 
@@ -151,7 +150,7 @@ struct RandomSongsView: View {
       Button {
         guard let first = viewModel.songs.first else { return }
         AppHaptic.medium.play()
-        audioManager.playInOrder(song: first, context: viewModel.songs)
+        AudioPlayerManager.shared.playInOrder(song: first, context: viewModel.songs)
       } label: {
         LibraryActionButtonLabel(
           symbol: "play.fill",
@@ -164,7 +163,7 @@ struct RandomSongsView: View {
 
       Button {
         AppHaptic.selection.play()
-        audioManager.playShuffled(from: viewModel.songs)
+        AudioPlayerManager.shared.playShuffled(from: viewModel.songs)
       } label: {
         LibraryActionButtonLabel(
           symbol: "shuffle",
@@ -196,7 +195,7 @@ struct RandomSongsView: View {
 
   private func play(_ song: Song) {
     AppHaptic.selection.play()
-    audioManager.play(song: song, context: viewModel.songs)
+    AudioPlayerManager.shared.play(song: song, context: viewModel.songs)
   }
 
   private var songSkeletonList: some View {
@@ -437,7 +436,6 @@ private struct RandomSongsHintRow: View {
 private struct RandomSongsActionsMenu: View {
   let songs: [Song]
   let onRefresh: () -> Void
-  @EnvironmentObject private var audioManager: AudioPlayerManager
   @StateObject private var downloads = DownloadManager.shared
 
   private var pendingDownloads: [Song] {
@@ -473,7 +471,7 @@ private struct RandomSongsActionsMenu: View {
       Button {
         AppHaptic.selection.play()
         if let first = songs.first {
-          audioManager.playInOrder(song: first, context: songs)
+          AudioPlayerManager.shared.playInOrder(song: first, context: songs)
         }
       } label: {
         Label("Play", systemImage: "play.fill")
@@ -481,7 +479,7 @@ private struct RandomSongsActionsMenu: View {
 
       Button {
         AppHaptic.selection.play()
-        audioManager.playShuffled(from: songs)
+        AudioPlayerManager.shared.playShuffled(from: songs)
       } label: {
         Label("Shuffle", systemImage: "shuffle")
       }

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -642,7 +642,6 @@ struct VideoPlayerScreen: View {
   @State private var player: AVPlayer?
   @State private var appeared = false
   @StateObject private var similar = SimilarVideosViewModel()
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
   private let audioWillPlay = NotificationCenter.default.publisher(
@@ -777,7 +776,7 @@ struct VideoPlayerScreen: View {
 
   private func startPlaybackIfNeeded() {
     guard player == nil, let url = video.streamURL ?? video.embedURL else { return }
-    audioManager.pauseIfPlaying()
+    AudioPlayerManager.shared.pauseIfPlaying()
     let nextPlayer = AVPlayer(url: url)
     NotificationCenter.default.post(
       name: MediaPlaybackCoordinator.videoWillPlay, object: nil)

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -1,8 +1,47 @@
+import Combine
 import SwiftUI
+
+/// The radio screen only needs a few playback flags. Keeping this separate from
+/// AudioPlayerManager prevents progress and karaoke state updates from redrawing
+/// the whole ScrollView during fast inertial scrolling.
+@MainActor
+private final class RadioPlaybackState: ObservableObject {
+  static let shared = RadioPlaybackState()
+
+  @Published private(set) var currentSongID: String?
+  @Published private(set) var isPlaying = false
+  @Published private(set) var isBuffering = false
+  @Published private(set) var isRadioMode = false
+
+  private var cancellables = Set<AnyCancellable>()
+
+  private init(manager: AudioPlayerManager = .shared) {
+    manager.$currentSong
+      .map(\.?.id)
+      .removeDuplicates()
+      .sink { [weak self] in self?.currentSongID = $0 }
+      .store(in: &cancellables)
+
+    manager.$isPlaying
+      .removeDuplicates()
+      .sink { [weak self] in self?.isPlaying = $0 }
+      .store(in: &cancellables)
+
+    manager.$isBuffering
+      .removeDuplicates()
+      .sink { [weak self] in self?.isBuffering = $0 }
+      .store(in: &cancellables)
+
+    manager.$isRadioMode
+      .removeDuplicates()
+      .sink { [weak self] in self?.isRadioMode = $0 }
+      .store(in: &cancellables)
+  }
+}
 
 struct RadioView: View {
   @StateObject private var radio = RadioController.shared
-  @EnvironmentObject var audioManager: AudioPlayerManager
+  @ObservedObject private var playback = RadioPlaybackState.shared
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
@@ -10,7 +49,7 @@ struct RadioView: View {
   var body: some View {
     NavigationStack {
       ScrollView {
-        Group {
+        LazyVStack(spacing: 0) {
           if radio.nowPlaying == nil && radio.refreshErrorMessage != nil && !radio.isRefreshing {
             RadioUnavailableView(
               message: radio.refreshErrorMessage ?? "Radio metadata is temporarily unavailable.",
@@ -25,14 +64,15 @@ struct RadioView: View {
               .transition(.opacity)
           } else {
             radioOverview
-            .transition(.opacity)
+              .transition(.opacity)
           }
         }
-        .animation(radioContentAnimation, value: radio.nowPlaying == nil)
         .padding(.top, AM.Spacing.l)
         .padding(.bottom, AM.Spacing.l)
       }
       .tabBarScrollInset()
+      .scrollBounceBehavior(.basedOnSize)
+      .scrollDismissesKeyboard(.interactively)
       .musicScreenBackground()
       .navigationTitle("Radio")
       .navigationBarTitleDisplayMode(.large)
@@ -57,7 +97,6 @@ struct RadioView: View {
       .onAppear { radio.start() }
       .sheet(isPresented: $showingRadioSchedule) {
         RadioQueueView()
-          .environmentObject(audioManager)
           .presentationDetents([.medium, .large])
           .presentationDragIndicator(.visible)
       }
@@ -73,8 +112,8 @@ struct RadioView: View {
   }
 
   private func playOrPauseLiveStation() {
-    if audioManager.isRadioMode && audioManager.currentSong != nil {
-      audioManager.togglePlayPause()
+    if playback.isRadioMode && playback.currentSongID != nil {
+      AudioPlayerManager.shared.togglePlayPause()
     } else {
       radio.playLiveStream()
     }
@@ -83,10 +122,6 @@ struct RadioView: View {
   private func showLiveSchedule() {
     AppHaptic.selection.play()
     showingRadioSchedule = true
-  }
-
-  private var radioContentAnimation: Animation? {
-    reduceMotion ? nil : .easeInOut(duration: 0.4)
   }
 
   private var unavailableTransition: AnyTransition {
@@ -187,7 +222,7 @@ struct RadioView: View {
   private func stationCard(horizontalPadding: CGFloat = AM.Spacing.screenMargin) -> some View {
     let np = radio.nowPlaying
     let song = np?.nowPlaying?.song
-    let isLivePlaying = audioManager.isRadioMode && audioManager.isPlaying
+    let isLivePlaying = playback.isRadioMode && playback.isPlaying
     VStack(alignment: .leading, spacing: 12) {
       VStack(alignment: .leading, spacing: 4) {
         Text("Featured Episode")
@@ -203,62 +238,11 @@ struct RadioView: View {
       }
       .padding(.horizontal, horizontalPadding)
 
-      ZStack(alignment: .bottomLeading) {
-        Group {
-          if let art = song?.art, let url = URL(string: art) {
-            LoadingImage(url: url, cornerRadius: AM.Radius.hero, contentMode: .fill)
-          } else {
-            artPlaceholder
-          }
-        }
-        .frame(maxWidth: .infinity, minHeight: 236, maxHeight: 236)
-        .clipShape(RoundedRectangle(cornerRadius: AM.Radius.hero, style: .continuous))
-
-        LinearGradient(
-          colors: [.black.opacity(0.0), .black.opacity(0.52)],
-          startPoint: .center,
-          endPoint: .bottom
-        )
-        .clipShape(RoundedRectangle(cornerRadius: AM.Radius.hero, style: .continuous))
-
-        VStack(alignment: .leading, spacing: 8) {
-          RadioLiveBadge(isActive: isLivePlaying, reduceMotion: reduceMotion)
-          Text(song?.displayArtist ?? np?.station.description ?? "Live radio")
-            .font(.system(size: 17, weight: .medium))
-            .foregroundStyle(.white.opacity(0.9))
-            .lineLimit(1)
-        }
-        .padding(16)
-
-        Button {
-          AppHaptic.medium.play()
-          playOrPauseLiveStation()
-        } label: {
-          ZStack {
-            Circle()
-              .fill(.white)
-              .frame(width: 48, height: 48)
-            if audioManager.isBuffering && audioManager.isRadioMode && !audioManager.isPlaying {
-              LoadingIndicator(size: 28)
-            } else {
-              Image(systemName: isLivePlaying ? "pause.fill" : "play.fill")
-                .font(.system(size: 20, weight: .bold))
-                .foregroundColor(.black)
-                .offset(x: isLivePlaying ? 0 : 2)
-            }
-          }
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-        .buttonStyle(PressableButtonStyle(scale: 0.9, dim: 0.85))
-        .accessibilityLabel(isLivePlaying ? "Pause live station" : "Play live station")
-        .accessibilityValue(song?.displayTitle ?? np?.station.name ?? "Twinskaraoke Radio")
-        .accessibilityHint("Controls the live radio stream.")
-      }
-      .padding(.horizontal, horizontalPadding)
-      .amShadow(
-        audioManager.isPlaying && audioManager.isRadioMode
-          ? AM.Shadow.heroPlaying : AM.Shadow.heroIdle
+      radioHero(
+        song: song,
+        station: np?.station,
+        isLivePlaying: isLivePlaying,
+        horizontalPadding: horizontalPadding
       )
 
       RadioLiveStatusStrip(
@@ -273,7 +257,11 @@ struct RadioView: View {
         } label: {
           HStack(spacing: 12) {
             if let art = next.art, let url = URL(string: art) {
-              LoadingImage(url: url, cornerRadius: 6)
+              LoadingImage(
+                url: url,
+                cornerRadius: 6,
+                fixedDisplaySize: CGSize(width: 48, height: 48)
+              )
                 .frame(width: 48, height: 48)
                 .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
             } else {
@@ -329,6 +317,83 @@ struct RadioView: View {
       )
     }
   }
+
+  private func radioHero(
+    song: RadioNowPlaying.SongInfo?,
+    station: RadioNowPlaying.Station?,
+    isLivePlaying: Bool,
+    horizontalPadding: CGFloat
+  ) -> some View {
+    ZStack(alignment: .bottomLeading) {
+      Group {
+        if let art = song?.art, let url = URL(string: art) {
+          LoadingImage(
+            url: url,
+            cornerRadius: AM.Radius.hero,
+            contentMode: .fill,
+            fixedDisplaySize: CGSize(width: 390, height: 236)
+          )
+        } else {
+          artPlaceholder
+        }
+      }
+      .frame(maxWidth: .infinity, minHeight: 236, maxHeight: 236)
+
+      LinearGradient(
+        colors: [.black.opacity(0.0), .black.opacity(0.52)],
+        startPoint: .center,
+        endPoint: .bottom
+      )
+
+      VStack(alignment: .leading, spacing: 8) {
+        RadioLiveBadge(isActive: isLivePlaying)
+        Text(song?.displayArtist ?? station?.description ?? "Live radio")
+          .font(.system(size: 17, weight: .medium))
+          .foregroundStyle(.white.opacity(0.9))
+          .lineLimit(1)
+      }
+      .padding(16)
+
+      radioPlayButton(
+        isLivePlaying: isLivePlaying,
+        accessibilityValue: song?.displayTitle ?? station?.name ?? "Twinskaraoke Radio"
+      )
+      .padding(14)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+    }
+    .frame(maxWidth: .infinity, minHeight: 236, maxHeight: 236)
+    .clipShape(RoundedRectangle(cornerRadius: AM.Radius.hero, style: .continuous))
+    // Keep the hero in one composited layer. A large clipped image plus gradient,
+    // controls, and shadow is otherwise expensive during high-velocity scroll.
+    .compositingGroup()
+    .shadow(color: Color.appHeroShadowIdle, radius: 10, y: 5)
+    .padding(.horizontal, horizontalPadding)
+  }
+
+  private func radioPlayButton(isLivePlaying: Bool, accessibilityValue: String) -> some View {
+    Button {
+      AppHaptic.medium.play()
+      playOrPauseLiveStation()
+    } label: {
+      ZStack {
+        Circle()
+          .fill(.white)
+          .frame(width: 48, height: 48)
+        if playback.isBuffering && playback.isRadioMode && !playback.isPlaying {
+          LoadingIndicator(size: 28)
+        } else {
+          Image(systemName: isLivePlaying ? "pause.fill" : "play.fill")
+            .font(.system(size: 20, weight: .bold))
+            .foregroundColor(.black)
+            .offset(x: isLivePlaying ? 0 : 2)
+        }
+      }
+    }
+    .buttonStyle(PressableButtonStyle(scale: 0.9, dim: 0.85))
+    .accessibilityLabel(isLivePlaying ? "Pause live station" : "Play live station")
+    .accessibilityValue(accessibilityValue)
+    .accessibilityHint("Controls the live radio stream.")
+  }
   @ViewBuilder
   private var artPlaceholder: some View {
     LinearGradient(
@@ -350,17 +415,23 @@ struct RadioView: View {
         .padding(.horizontal, horizontalPadding)
       LazyVStack(spacing: 0) {
         ForEach(Array(history.prefix(10).enumerated()), id: \.offset) { _, item in
-          RadioHistoryRow(song: item.song)
-            .padding(.horizontal, horizontalPadding)
-            .padding(.vertical, 8)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Recently played")
-            .accessibilityValue("\(item.song.displayTitle), \(item.song.displayArtist)")
-            .contextMenu {
-              radioActions
-            } preview: {
-              RadioSongContextPreview(song: item.song)
-            }
+          Button {
+            showLiveSchedule()
+          } label: {
+            RadioHistoryRow(song: item.song)
+              .padding(.horizontal, horizontalPadding)
+              .padding(.vertical, 8)
+          }
+          .buttonStyle(PressableButtonStyle(scale: 0.98, dim: 0.78))
+          .accessibilityElement(children: .combine)
+          .accessibilityLabel("Recently played")
+          .accessibilityValue("\(item.song.displayTitle), \(item.song.displayArtist)")
+          .accessibilityHint("Shows the live radio schedule.")
+          .contextMenu {
+            radioActions
+          } preview: {
+            RadioSongContextPreview(song: item.song)
+          }
           Divider().padding(.leading, 76)
         }
       }
@@ -453,20 +524,14 @@ private struct RadioSectionHeader: View {
 
 private struct RadioLiveBadge: View {
   let isActive: Bool
-  let reduceMotion: Bool
 
   var body: some View {
     HStack(spacing: 5) {
       ZStack {
-        if isActive && !reduceMotion {
-          TimelineView(.animation(minimumInterval: 1.0 / 20.0)) { context in
-            Circle()
-              .fill(.white.opacity(livePulseOpacity(for: context.date)))
-              .scaleEffect(livePulseScale(for: context.date))
-          }
-          .frame(width: 12, height: 12)
+        Circle()
+          .fill(.white.opacity(isActive ? 0.26 : 0.12))
+          .frame(width: isActive ? 11 : 8, height: isActive ? 11 : 8)
           .accessibilityHidden(true)
-        }
         Circle()
           .fill(.white)
           .frame(width: 5, height: 5)
@@ -482,16 +547,6 @@ private struct RadioLiveBadge: View {
     .background(Capsule().fill(Color.appAccent))
     .accessibilityElement(children: .ignore)
     .accessibilityLabel(isActive ? "Live and playing" : "Live")
-  }
-
-  private func livePulseScale(for date: Date) -> CGFloat {
-    let phase = date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 1.4) / 1.4
-    return 0.72 + CGFloat(phase) * 1.08
-  }
-
-  private func livePulseOpacity(for date: Date) -> Double {
-    let phase = date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 1.4) / 1.4
-    return max(0, 0.34 * (1 - phase))
   }
 }
 
@@ -820,7 +875,11 @@ private struct RadioHistoryRow: View {
   var body: some View {
     HStack(spacing: 12) {
       if let art = song.art, let url = URL(string: art) {
-        LoadingImage(url: url, cornerRadius: 6)
+        LoadingImage(
+          url: url,
+          cornerRadius: 6,
+          fixedDisplaySize: CGSize(width: 48, height: 48)
+        )
           .frame(width: 48, height: 48)
           .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
       } else {
@@ -838,6 +897,9 @@ private struct RadioHistoryRow: View {
           .lineLimit(1)
       }
       Spacer()
+      Image(systemName: "chevron.right")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundColor(.secondary)
     }
   }
 }

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct SearchView: View {
   @StateObject var viewModel = SearchViewModel()
-  @EnvironmentObject var audioManager: AudioPlayerManager
+  // Search only needs the current song id to clear pending UI. Observing the full
+  // audio manager here would also subscribe the screen to progress ticks.
+  @ObservedObject private var playback = PlaybackRowState.shared
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
@@ -95,7 +97,7 @@ struct SearchView: View {
         placement: .navigationBarDrawer(displayMode: .always),
         prompt: "Songs, Artists, Lyrics, and More"
       )
-      .onChange(of: audioManager.currentSong?.id) { _, currentSongID in
+      .onChange(of: playback.currentSongID) { _, currentSongID in
         guard currentSongID == pendingSongID else { return }
         pendingSongID = nil
       }
@@ -109,7 +111,7 @@ struct SearchView: View {
 
   private func playSelection(_ song: Song) {
     guard pendingSongID == nil else { return }
-    guard audioManager.currentSong?.id != song.id else { return }
+    guard playback.currentSongID != song.id else { return }
     AppHaptic.selection.play()
     pendingSongID = song.id
     let context = viewModel.results
@@ -117,7 +119,7 @@ struct SearchView: View {
     playbackTask = Task { @MainActor in
       await Task.yield()
       guard !Task.isCancelled else { return }
-      audioManager.play(song: song, context: context)
+      AudioPlayerManager.shared.play(song: song, context: context)
       try? await Task.sleep(nanoseconds: 400_000_000)
       guard !Task.isCancelled, pendingSongID == song.id else { return }
       pendingSongID = nil
@@ -445,7 +447,6 @@ struct GenreDetailView: View {
   let genre: GenreSummary
   @ObservedObject var viewModel: GenresViewModel
   let palette: [Color]
-  @EnvironmentObject var audioManager: AudioPlayerManager
   @State private var isLoadingDetail = false
 
   var body: some View {

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -137,10 +137,15 @@ final class DownloadManager: ObservableObject {
   }
 
   func removeAll() {
-    for task in tasks.values { task.cancel() }
-    tasks = [:]
-    inProgress = []
-    progress = [:]
+    // Cancel in-flight tasks before deleting files; otherwise a finishing download
+    // can write metadata and reinsert its id after the user removed everything.
+    for task in tasks.values {
+      task.cancel()
+    }
+    tasks.removeAll()
+    inProgress.removeAll()
+    progress.removeAll()
+
     let fm = FileManager.default
     if let files = try? fm.contentsOfDirectory(at: cacheDir, includingPropertiesForKeys: nil) {
       for f in files { try? fm.removeItem(at: f) }
@@ -211,6 +216,9 @@ final class DownloadManager: ObservableObject {
     var seen = Set<String>()
 
     for song in knownSongs where downloadedIDs.contains(song.id) {
+      // Recently played playlists can contain the same downloaded song more than once.
+      // Keep the downloaded list one-row-per-id so SwiftUI row identity stays stable.
+      guard !seen.contains(song.id) else { continue }
       guard playableURL(for: song) != nil else { continue }
       songs.append(song)
       seen.insert(song.id)


### PR DESCRIPTION
## Summary
- Isolate high-frequency playback state from the root app shell and mini-player popup so playback progress no longer invalidates unrelated scrolling screens.
- Replace full audio-manager observation in song rows and action-only screens with small playback snapshots or direct shared actions.
- Reduce scroll-time image and layout work with fixed thumbnail sizes, large-list artwork suppression, and lighter Radio/downloaded/header rendering.
- Make Radio "New & Recent" rows tappable and prevent in-flight downloads from reappearing after "remove all".

## Why
Fast scrolling could still hitch because multiple non-player views observed `AudioPlayerManager`, including root popup progress updates. That meant normal playback ticks could trigger SwiftUI invalidation while the user was scrolling. Some screens also combined per-frame scroll offset updates with expensive blur, shadow, and image work.

## Details
- Added popup-specific and row-specific playback state snapshots with duplicate filtering and throttled mini-player progress.
- Removed action-only `AudioPlayerManager` environment subscriptions from non-player screens.
- Added fixed-size image rendering for common row/card thumbnails to avoid repeated `GeometryReader` work and unnecessary decode size.
- Quantized offset-driven headers and removed dynamic blur effects that were expensive during inertial scrolling.
- Simplified Radio hero composition and removed its continuous live badge timeline animation.
- Cancelled active download tasks before clearing all offline content.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
