### PR TITLE
Fix radio featured header alignment

### DIFF
--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -155,7 +155,9 @@ struct RadioView: View {
   private var compactRadioOverview: some View {
     VStack(spacing: AM.Spacing.shelfSpacing) {
       refreshBanner(horizontalPadding: AM.Spacing.screenMargin)
-      stationCard()
+      stationCard(horizontalPadding: 0)
+        .padding(.horizontal, AM.Spacing.screenMargin)
+        .frame(maxWidth: .infinity, alignment: .leading)
       if let history = radio.nowPlaying?.songHistory, !history.isEmpty {
         historySection(history: history)
       }
@@ -236,20 +238,18 @@ struct RadioView: View {
           .lineLimit(2)
           .accessibilityIdentifier("Radio.FeaturedEpisode.Title")
       }
-      .padding(.horizontal, horizontalPadding)
+      .padding(.leading, AM.Spacing.screenMargin)
 
       radioHero(
         song: song,
         station: np?.station,
-        isLivePlaying: isLivePlaying,
-        horizontalPadding: horizontalPadding
+        isLivePlaying: isLivePlaying
       )
 
       RadioLiveStatusStrip(
         isPlaying: isLivePlaying,
         listenerCount: np?.listeners?.unique,
         lastUpdated: radio.lastUpdated)
-      .padding(.horizontal, horizontalPadding)
 
       if let next = np?.playingNext?.song {
         Button {
@@ -299,7 +299,6 @@ struct RadioView: View {
         .accessibilityLabel("Up Next")
         .accessibilityValue("\(next.displayTitle), \(next.displayArtist)")
         .accessibilityHint("Shows the live radio schedule.")
-        .padding(.horizontal, horizontalPadding)
         .contextMenu {
           radioActions
         } preview: {
@@ -307,6 +306,7 @@ struct RadioView: View {
         }
       }
     }
+    .padding(.horizontal, horizontalPadding)
     .contextMenu {
       radioActions
     } preview: {
@@ -321,8 +321,7 @@ struct RadioView: View {
   private func radioHero(
     song: RadioNowPlaying.SongInfo?,
     station: RadioNowPlaying.Station?,
-    isLivePlaying: Bool,
-    horizontalPadding: CGFloat
+    isLivePlaying: Bool
   ) -> some View {
     ZStack(alignment: .bottomLeading) {
       Group {
@@ -367,7 +366,6 @@ struct RadioView: View {
     // controls, and shadow is otherwise expensive during high-velocity scroll.
     .compositingGroup()
     .shadow(color: Color.appHeroShadowIdle, radius: 10, y: 5)
-    .padding(.horizontal, horizontalPadding)
   }
 
   private func radioPlayButton(isLivePlaying: Bool, accessibilityValue: String) -> some View {


### PR DESCRIPTION
## Summary

- Align the compact Radio featured header with the page content rail.
- Keep the featured label and title inset inside the station block so they no longer clip into the left screen edge.
- Preserve the corrected hero/status layout and keep local project signing settings out of the change.

## Root Cause

The compact Radio station header was expanding to full width before the content rail inset was applied. That left the label/title stack positioned too far left compared with the rest of the Radio page content.

## Validation

- `git diff --check -- Twinskaraoke/Features/Radio/RadioView.swift`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`