### PR TITLE
Fix mini-player popup gesture handling

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -72,6 +72,48 @@ private struct PopupSongSnapshot: Equatable {
   let subtitle: String
 }
 
+#if canImport(UIKit)
+  @MainActor
+  private final class PopupOpenIntentGate: NSObject, UIGestureRecognizerDelegate {
+    static let shared = PopupOpenIntentGate()
+
+    private static let touchRecognizerName = "Twinskaraoke.IntentionalMiniPlayerOpen"
+    private var openIntentExpiresAt = Date.distantPast
+
+    func consumeIntent() -> Bool {
+      guard Date() <= openIntentExpiresAt else { return false }
+      openIntentExpiresAt = .distantPast
+      return true
+    }
+
+    func installTouchRecognizer(on popupBar: LNPopupBar) {
+      let alreadyInstalled = popupBar.gestureRecognizers?.contains {
+        $0.name == Self.touchRecognizerName
+      } ?? false
+      guard !alreadyInstalled else { return }
+
+      let recognizer = UILongPressGestureRecognizer(target: self, action: #selector(markIntentionalMiniPlayerTouch(_:)))
+      recognizer.name = Self.touchRecognizerName
+      recognizer.minimumPressDuration = 0
+      recognizer.cancelsTouchesInView = false
+      recognizer.delegate = self
+      popupBar.addGestureRecognizer(recognizer)
+    }
+
+    @objc private func markIntentionalMiniPlayerTouch(_ recognizer: UILongPressGestureRecognizer) {
+      guard recognizer.state == .began else { return }
+      openIntentExpiresAt = Date().addingTimeInterval(0.35)
+    }
+
+    nonisolated func gestureRecognizer(
+      _ gestureRecognizer: UIGestureRecognizer,
+      shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+      true
+    }
+  }
+#endif
+
 struct ContentView: View {
   var body: some View {
     PopupHostView()
@@ -424,7 +466,16 @@ private struct PopupModifier: ViewModifier {
         isBarPresented: .constant(popupState.hasCurrentSong),
         isPopupOpen: Binding(
           get: { AudioPlayerManager.shared.showFullScreen },
-          set: { AudioPlayerManager.shared.showFullScreen = $0 }
+          set: { isOpen in
+            if isOpen {
+              #if canImport(UIKit)
+                let isIntentionalOpen =
+                  AudioPlayerManager.shared.showFullScreen || PopupOpenIntentGate.shared.consumeIntent()
+                guard isIntentionalOpen else { return }
+              #endif
+            }
+            AudioPlayerManager.shared.showFullScreen = isOpen
+          }
         )
       ) {
         PopupContent(popupState: popupState)
@@ -438,6 +489,10 @@ private struct PopupModifier: ViewModifier {
         popupBar.accessibilityIdentifier = "MiniPlayerBar"
         popupBar.accessibilityLabel = "Now Playing"
         popupBar.accessibilityHint = "Opens the full-screen player."
+        // LNPopupUI's drag recognizer can report an open during unrelated root
+        // navigation and system gestures. This touch marker lets the binding accept
+        // deliberate mini-player opens while LNPopupUI still owns the transition.
+        PopupOpenIntentGate.shared.installTouchRecognizer(on: popupBar)
       }
   }
 }


### PR DESCRIPTION
## Summary

- Guard mini-player popup expansion so unrelated navigation and system gestures cannot open the full player.
- Preserve LNPopupUI drag handling for normal full-player interactions.
- Add an intentional mini-player touch marker that recognizes simultaneously with LNPopupUI so tapping the mini-player still opens the full player.

## Root Cause

The app bound LNPopupUI popup-open state directly to `AudioPlayerManager.showFullScreen`. LNPopupUI can report an open transition from its gesture handling, so unrelated touches, root navigation, account actions, or app-switcher gestures could promote the mini-player into the full player.

## Validation

- `git diff --check -- Twinskaraoke/App/ContentView.swift`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`

## Manual Device Check

- Tapping the mini-player opens and stays in the full player while audio is playing.
- Full-player drag/dismiss gestures still work.
- Tapping playlists/account or opening the iOS app switcher does not auto-expand the mini-player.