### PR TITLE
Improve ProMotion scrolling performance

### DIFF
--- a/Twinskaraoke/Components/AppTheme.swift
+++ b/Twinskaraoke/Components/AppTheme.swift
@@ -5,6 +5,26 @@ import SwiftUI
   import UIKit
 #endif
 
+enum DisplayRefreshRate {
+  /// Uses the active screen's advertised maximum so ProMotion devices can request
+  /// higher-frequency redraws while older devices naturally remain at 60 Hz.
+  static var maximumFramesPerSecond: Int {
+    #if canImport(UIKit)
+      max(UIScreen.main.maximumFramesPerSecond, 60)
+    #else
+      60
+    #endif
+  }
+
+  static var isHighRefreshDisplay: Bool {
+    maximumFramesPerSecond > 60
+  }
+
+  static var lightweightAnimationInterval: TimeInterval {
+    1.0 / Double(maximumFramesPerSecond)
+  }
+}
+
 enum AppearanceMode: String, CaseIterable {
   case system, light, dark
   var label: String {

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -68,6 +68,7 @@ struct AddToPlaylistSheet: View {
         .padding(.horizontal, 20)
         .padding(.bottom, 28)
       }
+      .smoothScrolling()
       .musicScreenBackground()
       .safeAreaInset(edge: .bottom) {
         if !manager.playlists.isEmpty {

--- a/Twinskaraoke/Components/LoadingImage.swift
+++ b/Twinskaraoke/Components/LoadingImage.swift
@@ -15,7 +15,9 @@ enum ImageCacheConfig {
     cfg.maxDiskAge = 30 * 24 * 60 * 60
     SDImageCache.shared.clearMemory()
     let dl = SDWebImageDownloader.shared
-    dl.config.maxConcurrentDownloads = 6
+    // Keep network/decode concurrency below the point where image work can steal
+    // main-thread time from touch tracking on ProMotion devices.
+    dl.config.maxConcurrentDownloads = 4
     dl.requestModifier = SDWebImageDownloaderRequestModifier { request in
       var r = request
       r.cachePolicy = .returnCacheDataElseLoad
@@ -126,7 +128,7 @@ struct LoadingImage: View {
         .onSuccess { _, _, _ in
           markRendered(url)
         }
-        .transition(.opacity.animation(.easeOut(duration: 0.15)))
+        .transition(.opacity.animation(AppMotion.easeOut(duration: 0.15)))
       }
 
     }
@@ -134,7 +136,7 @@ struct LoadingImage: View {
 
   private func markRendered(_ loadedURL: URL) {
     guard renderedFullURL != loadedURL || !fullLoaded || loadFailed else { return }
-    withAnimation(.easeOut(duration: 0.12)) {
+    withAnimation(AppMotion.easeOut(duration: 0.12)) {
       renderedFullURL = loadedURL
       fullLoaded = true
       loadFailed = false
@@ -142,7 +144,7 @@ struct LoadingImage: View {
   }
 
   private func markFinishedAfterFailure() {
-    withAnimation(.easeOut(duration: 0.12)) {
+    withAnimation(AppMotion.easeOut(duration: 0.12)) {
       loadFailed = true
     }
   }
@@ -213,7 +215,7 @@ struct LoadingIndicator: View {
     .frame(width: containerSize, height: containerSize)
     .contentShape(Rectangle())
     .animation(
-      reduceMotion ? nil : .linear(duration: 0.82).repeatForever(autoreverses: false),
+      reduceMotion ? nil : AppMotion.linear(duration: 0.82).repeatForever(autoreverses: false),
       value: isAnimating
     )
     .onAppear {
@@ -266,6 +268,7 @@ struct MusicSkeletonShimmer: ViewModifier {
   var isActive: Bool
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
+  @ObservedObject private var scrollState = ScrollPerformanceState.shared
   @State private var phase: CGFloat = -0.8
 
   func body(content: Content) -> some View {
@@ -281,33 +284,33 @@ struct MusicSkeletonShimmer: ViewModifier {
         .allowsHitTesting(false)
       }
       .onAppear {
-        guard effectiveActive else {
-          phase = -0.8
-          return
-        }
-        withAnimation(.linear(duration: 1.65).repeatForever(autoreverses: false)) {
-          phase = 1.8
-        }
+        restartIfNeeded(active: effectiveActive)
       }
       .onChange(of: effectiveActive) { _, effectiveActive in
-        if effectiveActive {
-          phase = -0.8
-          withAnimation(.linear(duration: 1.65).repeatForever(autoreverses: false)) {
-            phase = 1.8
-          }
-        } else {
-          withAnimation(nil) {
-            phase = -0.8
-          }
-        }
+        restartIfNeeded(active: effectiveActive)
       }
   }
 
   private var effectiveActive: Bool {
-    isActive && !AppMotion.reduceMotion(
-      systemReduceMotion: systemReduceMotion,
-      respectPreference: respectReducedMotion
-    )
+    isActive
+      && !scrollState.isScrolling
+      && !AppMotion.reduceMotion(
+        systemReduceMotion: systemReduceMotion,
+        respectPreference: respectReducedMotion
+      )
+  }
+
+  private func restartIfNeeded(active: Bool) {
+    if active {
+      phase = -0.8
+      withAnimation(AppMotion.linear(duration: 1.65).repeatForever(autoreverses: false)) {
+        phase = 1.8
+      }
+    } else {
+      withAnimation(nil) {
+        phase = -0.8
+      }
+    }
   }
 
   private func shimmer(width: CGFloat) -> some View {

--- a/Twinskaraoke/Components/Player/EqualizerBars.swift
+++ b/Twinskaraoke/Components/Player/EqualizerBars.swift
@@ -10,8 +10,12 @@ struct EqualizerBars: View {
   var body: some View {
     GeometryReader { geo in
       let barWidth = geo.size.width / 5
-      TimelineView(.animation(minimumInterval: 1.0 / 30, paused: !shouldAnimateBars)) {
-        context in
+      TimelineView(
+        .animation(
+          minimumInterval: DisplayRefreshRate.lightweightAnimationInterval,
+          paused: !shouldAnimateBars
+        )
+      ) { context in
         let elapsed = max(0, context.date.timeIntervalSince(startDate))
         HStack(alignment: .bottom, spacing: barWidth / 2) {
           ForEach(0..<3) { i in

--- a/Twinskaraoke/Components/PressableButtonStyle.swift
+++ b/Twinskaraoke/Components/PressableButtonStyle.swift
@@ -48,6 +48,29 @@ enum AppMotion {
   static func reduceMotion(systemReduceMotion: Bool, respectPreference: Bool) -> Bool {
     respectPreference && systemReduceMotion
   }
+
+  /// Keep interactive animations perceptually crisp on high-refresh displays while
+  /// preserving the same behavior on older 60 Hz devices.
+  static func duration(_ seconds: TimeInterval) -> TimeInterval {
+    guard DisplayRefreshRate.isHighRefreshDisplay else { return seconds }
+    return seconds * 0.92
+  }
+
+  static func easeInOut(duration seconds: TimeInterval) -> Animation {
+    .easeInOut(duration: duration(seconds))
+  }
+
+  static func easeOut(duration seconds: TimeInterval) -> Animation {
+    .easeOut(duration: duration(seconds))
+  }
+
+  static func linear(duration seconds: TimeInterval) -> Animation {
+    .linear(duration: duration(seconds))
+  }
+
+  static func spring(response: TimeInterval, dampingFraction: Double) -> Animation {
+    .spring(response: duration(response), dampingFraction: dampingFraction)
+  }
 }
 
 struct PressableButtonStyle: ButtonStyle {
@@ -79,7 +102,7 @@ private struct PressableButtonBody: View {
       .scaleEffect(reduceMotion ? 1.0 : (configuration.isPressed ? scale : 1.0))
       .opacity(configuration.isPressed ? dim : 1.0)
       .animation(
-        reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.7),
+        reduceMotion ? nil : AppMotion.spring(response: 0.32, dampingFraction: 0.7),
         value: configuration.isPressed)
       .onChange(of: configuration.isPressed) { _, isPressed in
         if isPressed && !wasPressed {

--- a/Twinskaraoke/Components/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/ScrollOptimization.swift
@@ -1,14 +1,81 @@
+import Combine
 import SwiftUI
 
-/// Smooth scrolling optimizations for SwiftUI ScrollView and List
-extension View {
-  /// Apply optimized scroll configuration for smooth scrolling
-  func smoothScrolling() -> some View {
-    self
-      .scrollBounceBehavior(.basedOnSize)
-      .scrollDismissesKeyboard(.interactively)
+@MainActor
+final class ScrollPerformanceState: ObservableObject {
+  static let shared = ScrollPerformanceState()
+
+  @Published private(set) var isScrolling = false
+
+  private var activeScrollIDs = Set<UUID>()
+  private var scrollEndTask: Task<Void, Never>?
+
+  private init() {}
+
+  /// Publish only scroll start/end transitions. Per-frame scroll offsets stay out of
+  /// SwiftUI state so image placeholders and row chrome do not invalidate every frame.
+  func update(id: UUID, isScrolling scrolling: Bool) {
+    if scrolling {
+      scrollEndTask?.cancel()
+      scrollEndTask = nil
+      activeScrollIDs.insert(id)
+    } else {
+      activeScrollIDs.remove(id)
+    }
+    scheduleScrollStateUpdate()
   }
 
+  private func scheduleScrollStateUpdate() {
+    scrollEndTask?.cancel()
+    if !activeScrollIDs.isEmpty {
+      setScrolling(true)
+      return
+    }
+    scrollEndTask = Task { [weak self] in
+      try? await Task.sleep(nanoseconds: 140_000_000)
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        self?.setScrolling(false)
+      }
+    }
+  }
+
+  private func setScrolling(_ scrolling: Bool) {
+    guard isScrolling != scrolling else { return }
+    isScrolling = scrolling
+  }
+}
+
+/// Smooth scrolling optimizations for SwiftUI ScrollView and List.
+extension View {
+  /// Apply scroll defaults that match native-feeling touch tracking and mark active
+  /// scrolls so decorative work can pause during high-velocity gestures.
+  func smoothScrolling() -> some View {
+    modifier(SmoothScrollingModifier())
+  }
+
+}
+
+private struct SmoothScrollingModifier: ViewModifier {
+  @State private var scrollID = UUID()
+
+  func body(content: Content) -> some View {
+    let configured = content
+      .scrollBounceBehavior(.basedOnSize)
+      .scrollDismissesKeyboard(.interactively)
+
+    if #available(iOS 18.0, *) {
+      configured
+        .onScrollPhaseChange { _, phase in
+          ScrollPerformanceState.shared.update(id: scrollID, isScrolling: phase.isScrolling)
+        }
+        .onDisappear {
+          ScrollPerformanceState.shared.update(id: scrollID, isScrolling: false)
+        }
+    } else {
+      configured
+    }
+  }
 }
 
 /// Preference-based scroll tracking should publish coarse changes only; sub-point

--- a/Twinskaraoke/Features/Account/LoginSheet.swift
+++ b/Twinskaraoke/Features/Account/LoginSheet.swift
@@ -38,7 +38,7 @@ struct LoginSheet: View {
         .padding(.bottom, 40)
         .frame(maxWidth: .infinity)
       }
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .background(Color(.systemGroupedBackground).ignoresSafeArea())
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/Twinskaraoke/Features/Account/ProfileDetailView.swift
+++ b/Twinskaraoke/Features/Account/ProfileDetailView.swift
@@ -81,6 +81,7 @@ struct ProfileDetailView: View {
     }
     .frame(maxWidth: .infinity)
     .scrollIndicators(.hidden)
+    .smoothScrolling()
     .musicScreenBackground()
     .navigationTitle("Profile")
     .navigationBarTitleDisplayMode(.inline)

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -39,7 +39,7 @@ struct HomeView: View {
         .padding(.top, AM.Spacing.l)
         .padding(.bottom, AM.Spacing.l)
       }
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .tabBarScrollInset()
       .musicScreenBackground()
       .navigationTitle("Home")
@@ -220,7 +220,7 @@ struct NewView: View {
         .padding(.top, AM.Spacing.m)
         .padding(.bottom, AM.Spacing.l)
       }
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .tabBarScrollInset()
       .musicScreenBackground()
       .navigationTitle("New")
@@ -451,7 +451,7 @@ struct PlaylistListView: View {
           .padding(.vertical, AM.Spacing.m)
       }
     }
-    .scrollDismissesKeyboard(.interactively)
+    .smoothScrolling()
     .navigationTitle(title)
     .navigationBarTitleDisplayMode(.inline)
     .searchable(
@@ -1384,7 +1384,7 @@ struct BrowseSongCollectionView: View {
           }
         )
       }
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .coordinateSpace(name: "browseScroll")
       .onPreferenceChange(BrowseScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }
     }

--- a/Twinskaraoke/Features/Library/ArtDetailView.swift
+++ b/Twinskaraoke/Features/Library/ArtDetailView.swift
@@ -46,6 +46,7 @@ struct ArtDetailView: View {
       }
       .padding(.bottom, 24)
     }
+    .smoothScrolling()
     .navigationTitle(artist.name)
     .navigationBarTitleDisplayMode(.inline)
     .background {

--- a/Twinskaraoke/Features/Library/ArtGalleryView.swift
+++ b/Twinskaraoke/Features/Library/ArtGalleryView.swift
@@ -97,6 +97,7 @@ struct ArtGalleryView: View {
         .padding(.vertical, 16)
       }
     }
+    .smoothScrolling()
     .navigationTitle("Art Gallery")
     .navigationBarTitleDisplayMode(.large)
     .refreshable {

--- a/Twinskaraoke/Features/Library/ArtistArtsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistArtsView.swift
@@ -70,6 +70,7 @@ struct ArtistArtsView: View {
       }
       .padding(.bottom, 16)
     }
+    .smoothScrolling()
     .navigationTitle(artist.name)
     .navigationBarTitleDisplayMode(.inline)
     .animation(

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -385,6 +385,7 @@ struct ArtistDetailView: View {
         )
       }
       .scrollIndicators(.hidden)
+      .smoothScrolling()
       .coordinateSpace(name: "artistScroll")
       .onPreferenceChange(ArtistScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }
     }

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -100,7 +100,7 @@ struct CreatePlaylistSheet: View {
         .padding(.horizontal, 20)
         .padding(.bottom, 28)
       }
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .musicScreenBackground()
       .navigationTitle("New Playlist")
       .navigationBarTitleDisplayMode(.inline)

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -76,8 +76,7 @@ struct DownloadedSongsView: View {
           )
         }
       }
-      .scrollBounceBehavior(.basedOnSize)
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .coordinateSpace(name: "downloadedScroll")
       .bottomChromeScrollTracking()
       .onPreferenceChange(DownloadedCollapsedTitleKey.self) { collapsed in

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -125,7 +125,7 @@ struct LibraryView: View {
         .padding(.bottom, AM.Spacing.l)
       }
       .scrollIndicators(.hidden)
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .tabBarScrollInset()
       .musicScreenBackground()
       .navigationTitle("Library")
@@ -711,7 +711,7 @@ struct LibrarySongsView: View {
     }
     .listStyle(.plain)
     .scrollContentBackground(.hidden)
-    .scrollDismissesKeyboard(.interactively)
+    .smoothScrolling()
     .musicScreenBackground()
     .navigationTitle("Songs")
     .navigationBarTitleDisplayMode(.large)
@@ -1050,7 +1050,7 @@ struct LibraryCollectionListView: View {
     }
     .listStyle(.plain)
     .scrollContentBackground(.hidden)
-    .scrollDismissesKeyboard(.interactively)
+    .smoothScrolling()
     .musicScreenBackground()
     .navigationTitle(kind.title)
     .navigationBarTitleDisplayMode(.large)
@@ -1209,6 +1209,7 @@ struct LibraryCollectionDetailView: View {
           }
         )
       }
+      .smoothScrolling()
       .coordinateSpace(name: "libraryCollectionScroll")
       .onPreferenceChange(LibraryCollectionScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }
     }
@@ -1574,6 +1575,7 @@ struct PlaylistsGridScreen: View {
         }
       }
     }
+    .smoothScrolling()
     .navigationTitle("Playlists")
     .searchable(
       text: $searchText,

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -34,6 +34,7 @@ struct PlaylistDetailView: View {
           }
         )
       }
+      .smoothScrolling()
       .coordinateSpace(name: "playlistScroll")
       .bottomChromeScrollTracking()
       .onPreferenceChange(ScrollOffsetKey.self) { scrollOffset = quantizedScrollOffset($0) }

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -68,6 +68,7 @@ struct RandomSongsView: View {
       .animation(reduceMotion ? nil : .easeInOut(duration: 0.22), value: viewModel.isLoading)
     }
     .bottomChromeScrollTracking()
+    .smoothScrolling()
     .scrollIndicators(.hidden)
     .musicScreenBackground()
     .navigationTitle("Random")

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -213,6 +213,7 @@ struct VideoGalleryView: View {
       }
     }
     .scrollIndicators(.hidden)
+    .smoothScrolling()
     .musicScreenBackground()
     .navigationTitle("Video Gallery")
     .navigationBarTitleDisplayMode(.large)
@@ -670,6 +671,7 @@ struct VideoPlayerScreen: View {
         }
       }
     }
+    .smoothScrolling()
     .musicScreenBackground()
     .navigationTitle(video.songTitle ?? "Video")
     .navigationBarTitleDisplayMode(.inline)

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -827,7 +827,9 @@ struct FullScreenPlayerView: View {
               .padding(3)
               .transition(.opacity)
           } else {
-            TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+            TimelineView(
+              .animation(minimumInterval: DisplayRefreshRate.lightweightAnimationInterval)
+            ) { context in
               Circle()
                 .trim(from: 0, to: 0.82)
                 .stroke(Color.appAccent, style: StrokeStyle(lineWidth: 2, lineCap: .round))

--- a/Twinskaraoke/Features/Player/LyricsView.swift
+++ b/Twinskaraoke/Features/Player/LyricsView.swift
@@ -167,7 +167,12 @@ struct LyricsBouncingDots: View {
       }
       .animation(.easeOut(duration: 0.18), value: progress)
     } else {
-      TimelineView(.animation(minimumInterval: 1.0 / 15.0, paused: !isActive)) { context in
+      TimelineView(
+        .animation(
+          minimumInterval: DisplayRefreshRate.lightweightAnimationInterval,
+          paused: !isActive
+        )
+      ) { context in
         let t = context.date.timeIntervalSince(loopPhase)
           .truncatingRemainder(dividingBy: loopCycle)
         HStack(spacing: dotSize * 0.55) {

--- a/Twinskaraoke/Features/Radio/RadioQueueView.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueView.swift
@@ -88,6 +88,7 @@ struct RadioQueueView: View {
           .animation(scheduleAnimation(duration: 0.28), value: currentSong?.displayTitle)
           .animation(scheduleAnimation(duration: 0.24), value: history.count)
         }
+        .smoothScrolling()
         .refreshable { await radio.refresh() }
       }
     }
@@ -337,7 +338,9 @@ private struct RadioQueueLivePill: View {
     HStack(spacing: 5) {
       ZStack {
         if isPlaying && !reduceMotion {
-          TimelineView(.animation(minimumInterval: 1.0 / 18.0)) { context in
+          TimelineView(
+            .animation(minimumInterval: DisplayRefreshRate.lightweightAnimationInterval)
+          ) { context in
             Circle()
               .fill(Color.white.opacity(pulseOpacity(for: context.date)))
               .scaleEffect(pulseScale(for: context.date))

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -71,8 +71,7 @@ struct RadioView: View {
         .padding(.bottom, AM.Spacing.l)
       }
       .tabBarScrollInset()
-      .scrollBounceBehavior(.basedOnSize)
-      .scrollDismissesKeyboard(.interactively)
+      .smoothScrolling()
       .musicScreenBackground()
       .navigationTitle("Radio")
       .navigationBarTitleDisplayMode(.large)

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -72,7 +72,7 @@ struct SearchView: View {
           }
           .listStyle(.plain)
           .scrollContentBackground(.hidden)
-          .scrollDismissesKeyboard(.interactively)
+          .smoothScrolling()
           .scrollIndicators(.hidden)
           .frame(maxWidth: resultsMaxWidth)
           .frame(maxWidth: .infinity)
@@ -269,8 +269,7 @@ private struct BrowseCategoriesView: View {
       .padding(.top, AM.Spacing.s)
       .padding(.bottom, AM.Spacing.l)
     }
-    .scrollBounceBehavior(.basedOnSize)
-    .scrollDismissesKeyboard(.interactively)
+    .smoothScrolling()
     .bottomChromeScrollTracking()
     .musicScreenBackground()
     .scrollIndicators(.hidden)
@@ -562,7 +561,7 @@ private struct GenreDetailLoadingView: View {
       }
       .padding(.bottom, AM.Spacing.l)
     }
-    .scrollBounceBehavior(.basedOnSize)
+    .smoothScrolling()
     .bottomChromeScrollTracking()
     .tabBarScrollInset()
     .accessibilityLabel("Loading \(genre.name) songs")
@@ -640,7 +639,7 @@ private struct SearchResultsLoadingView: View {
       .padding(.top, 8)
       .padding(.bottom, AM.Spacing.l)
     }
-    .scrollBounceBehavior(.basedOnSize)
+    .smoothScrolling()
     .bottomChromeScrollTracking()
     .scrollIndicators(.hidden)
     .tabBarScrollInset()
@@ -876,7 +875,7 @@ private struct SearchCategoryLoadingView: View {
       }
       .padding(.bottom, AM.Spacing.l)
     }
-    .scrollBounceBehavior(.basedOnSize)
+    .smoothScrolling()
     .bottomChromeScrollTracking()
     .tabBarScrollInset()
     .accessibilityLabel("Loading \(title) songs")

--- a/Twinskaraoke/Info.plist
+++ b/Twinskaraoke/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
## Summary

This PR improves scrolling and animation smoothness across the app, with special attention to ProMotion-capable iPhones while preserving compatibility with older 60 Hz devices.

## Changes

- Opts iPhone into shorter frame durations with `CADisableMinimumFrameDurationOnPhone`.
- Adds shared display refresh helpers so lightweight UI timelines can use the active screen refresh rate.
- Updates equalizer, lyrics, translation, and radio live-pill timelines to use the display-aware interval instead of fixed low-frequency intervals.
- Adds a shared smooth scrolling modifier that centralizes bounce behavior, keyboard dismissal, and iOS scroll phase tracking.
- Tracks active scroll state per scroll view instance and cleans up when scroll views disappear.
- Pauses skeleton shimmer while the user is actively scrolling to reduce decorative animation work during fast flings.
- Applies the shared scroll behavior across the main vertical app surfaces, search/loading states, library/detail views, media galleries, radio queue, and relevant sheets.
- Reduces concurrent image download/decode pressure to help preserve frame time during image-heavy scrolling.
- Keeps reduced-motion behavior intact.

## Impact

The app should feel smoother during vertical scrolling and lightweight animations on ProMotion devices, while older devices continue to use normal 60 Hz behavior. Image-heavy lists and grids should also do less competing visual work while the user is actively scrolling.

## Validation

- `git diff --check`
- `plutil -lint Twinskaraoke/Info.plist`
- `xcodebuild -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`\n- Manual device smoke test confirmed the app still works after the scrolling changes.