### PR TITLE
Stabilize playback recovery and fix flickering transparent menus

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -14,7 +14,6 @@ private final class PopupPlaybackState: ObservableObject {
   @Published private(set) var title = ""
   @Published private(set) var subtitle = ""
   @Published private(set) var artwork: UIImage?
-  @Published private(set) var progress: Float = 0
   @Published private(set) var isPlaying = false
   @Published private(set) var isRadioMode = false
 
@@ -42,13 +41,6 @@ private final class PopupPlaybackState: ObservableObject {
       .sink { [weak self] in self?.artwork = $0 }
       .store(in: &cancellables)
 
-    PlaybackClock.shared.$progress
-      .throttle(for: .milliseconds(350), scheduler: RunLoop.main, latest: true)
-      .map { Float(min(max($0, 0), 1)) }
-      .removeDuplicates()
-      .sink { [weak self] in self?.progress = $0 }
-      .store(in: &cancellables)
-
     manager.$isPlaying
       .removeDuplicates()
       .sink { [weak self] in self?.isPlaying = $0 }
@@ -56,12 +48,7 @@ private final class PopupPlaybackState: ObservableObject {
 
     manager.$isRadioMode
       .removeDuplicates()
-      .sink { [weak self] isRadioMode in
-        self?.isRadioMode = isRadioMode
-        if isRadioMode {
-          self?.progress = 0
-        }
-      }
+      .sink { [weak self] isRadioMode in self?.isRadioMode = isRadioMode }
       .store(in: &cancellables)
   }
 }
@@ -481,7 +468,11 @@ private struct PopupModifier: ViewModifier {
         PopupContent(popupState: popupState)
       }
       .popupBarStyle(.floating)
-      .popupBarProgressViewStyle(popupState.isRadioMode ? .none : .bottom)
+      // Do not drive LNPopupUI's bar progress while playback is active. That
+      // preference update invalidates the root popup host repeatedly and causes
+      // iOS transparent context menus to flicker. Full-screen progress still
+      // observes PlaybackClock directly.
+      .popupBarProgressViewStyle(.none)
       .popupCloseButtonStyle(.none)
       .popupInteractionStyle(.drag)
       .popupBarMarqueeScrollEnabled(false)
@@ -513,11 +504,6 @@ private struct PopupContent: View {
           subtitle: popupState.subtitle)
       )
       .modifier(PopupImageModifier(artwork: popupState.artwork))
-      .modifier(
-        PopupProgressModifier(
-          progress: popupState.isRadioMode ? 0 : popupState.progress
-        )
-      )
       .popupBarButtons({
         PopupBarTrailingItems(
           isPlaying: popupState.isPlaying,
@@ -550,18 +536,6 @@ private struct PopupImageModifier: ViewModifier, Equatable {
     } else {
       content.popupImage(Image(systemName: "music.note"))
     }
-  }
-}
-
-private struct PopupProgressModifier: ViewModifier, Equatable {
-  let progress: Float
-
-  static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs.progress == rhs.progress
-  }
-
-  func body(content: Content) -> some View {
-    content.popupProgress(progress)
   }
 }
 

--- a/Twinskaraoke/Components/SongRow.swift
+++ b/Twinskaraoke/Components/SongRow.swift
@@ -103,7 +103,10 @@ struct SongRow: View {
           RoundedRectangle(cornerRadius: size.cornerRadius, style: .continuous)
             .fill(Color.appArtworkOverlay)
             .frame(width: size.artSize, height: size.artSize)
-          EqualizerBars(isAnimating: playback.isPlaying)
+          // Keep row indicators static. Context menus on iOS are translucent and
+          // flicker if the list behind them keeps repainting via TimelineView while
+          // playback is active.
+          EqualizerBars(isAnimating: false)
             .frame(width: size.indicatorSize, height: size.indicatorSize)
             .foregroundColor(.primary)
         }
@@ -374,8 +377,20 @@ private struct MusicGridCardShadow: ViewModifier {
 struct SongActionsMenuItems: View {
   let song: Song
   let onAddToPlaylist: () -> Void
-  @StateObject private var downloads = DownloadManager.shared
+  private let isDownloaded: Bool
+  private let isDownloading: Bool
   @ObservedObject private var favorites = FavoritesManager.shared
+
+  init(song: Song, onAddToPlaylist: @escaping () -> Void) {
+    self.song = song
+    self.onAddToPlaylist = onAddToPlaylist
+    // Snapshot download state when the menu is built. Observing live download
+    // progress from inside transparent iOS menus can cause the same preference
+    // churn/flicker as playback progress did in the popup bar.
+    let downloads = DownloadManager.shared
+    self.isDownloaded = downloads.isDownloaded(song.id)
+    self.isDownloading = downloads.isDownloading(song.id)
+  }
 
   var body: some View {
     Button {
@@ -410,24 +425,24 @@ struct SongActionsMenuItems: View {
 
     Divider()
 
-    if downloads.isDownloaded(song.id) {
+    if isDownloaded {
       Button(role: .destructive) {
         AppHaptic.warning.play()
-        downloads.remove(songID: song.id)
+        DownloadManager.shared.remove(songID: song.id)
       } label: {
         Label("Remove Download", systemImage: "trash")
       }
-    } else if downloads.isDownloading(song.id) {
+    } else if isDownloading {
       Button {
         AppHaptic.selection.play()
-        downloads.cancel(songID: song.id)
+        DownloadManager.shared.cancel(songID: song.id)
       } label: {
         Label("Cancel Download", systemImage: "xmark.circle")
       }
     } else {
       Button {
         AppHaptic.success.play()
-        downloads.download(song: song)
+        DownloadManager.shared.download(song: song)
       } label: {
         Label("Download", systemImage: "arrow.down.circle")
       }
@@ -437,12 +452,11 @@ struct SongActionsMenuItems: View {
 
 struct SongContextPreview: View {
   let song: Song
-  @ObservedObject private var playback = PlaybackRowState.shared
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       LoadingImage(
-        url: playback.displayImageURL(for: song),
+        url: song.imageURL,
         cornerRadius: 10,
         fixedDisplaySize: CGSize(width: 220, height: 220)
       )

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -642,15 +642,8 @@ private struct ArtistDetailHintRow: View {
 
 private struct ArtistActionsMenu: View {
   let songs: [Song]
-  @StateObject private var downloads = DownloadManager.shared
-
-  private var pendingDownloads: [Song] {
-    songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
-  }
-
-  private var downloadingCount: Int {
-    songs.filter { downloads.isDownloading($0.id) }.count
-  }
+  private let pendingDownloads: [Song]
+  private let downloadingCount: Int
 
   private var allDownloaded: Bool {
     !songs.isEmpty && pendingDownloads.isEmpty && downloadingCount == 0
@@ -659,6 +652,15 @@ private struct ArtistActionsMenu: View {
   private var downloadTitle: String {
     let downloadedCount = songs.count - pendingDownloads.count - downloadingCount
     return downloadedCount > 0 ? "Download Remaining" : "Download"
+  }
+
+  init(songs: [Song]) {
+    self.songs = songs
+    // Snapshot download state for transparent menu stability. Live progress
+    // updates can otherwise invalidate an open menu repeatedly.
+    let downloads = DownloadManager.shared
+    self.pendingDownloads = songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
+    self.downloadingCount = songs.filter { downloads.isDownloading($0.id) }.count
   }
 
   var body: some View {
@@ -689,7 +691,7 @@ private struct ArtistActionsMenu: View {
         Button(role: .destructive) {
           AppHaptic.warning.play()
           for song in songs {
-            downloads.remove(songID: song.id)
+            DownloadManager.shared.remove(songID: song.id)
           }
         } label: {
           Label("Remove Downloads", systemImage: "trash")
@@ -698,7 +700,7 @@ private struct ArtistActionsMenu: View {
         Button {
           AppHaptic.success.play()
           for song in pendingDownloads {
-            downloads.download(song: song)
+            DownloadManager.shared.download(song: song)
           }
         } label: {
           Label(downloadTitle, systemImage: "arrow.down.circle")

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -1300,18 +1300,20 @@ private struct LibraryCollectionEmptyStateView: View {
 
 private struct LibraryCollectionActionsMenu: View {
   let collection: LibrarySongCollection
-  @StateObject private var downloads = DownloadManager.shared
-
-  private var pendingDownloads: [Song] {
-    collection.songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
-  }
-
-  private var downloadingCount: Int {
-    collection.songs.filter { downloads.isDownloading($0.id) }.count
-  }
+  private let pendingDownloads: [Song]
+  private let downloadingCount: Int
 
   private var allDownloaded: Bool {
     !collection.songs.isEmpty && pendingDownloads.isEmpty && downloadingCount == 0
+  }
+
+  init(collection: LibrarySongCollection) {
+    self.collection = collection
+    // Snapshot download state for transparent menu stability. Download progress
+    // can publish frequently while a menu is open.
+    let downloads = DownloadManager.shared
+    self.pendingDownloads = collection.songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
+    self.downloadingCount = collection.songs.filter { downloads.isDownloading($0.id) }.count
   }
 
   var body: some View {
@@ -1342,7 +1344,7 @@ private struct LibraryCollectionActionsMenu: View {
         Button(role: .destructive) {
           AppHaptic.warning.play()
           for song in collection.songs {
-            downloads.remove(songID: song.id)
+            DownloadManager.shared.remove(songID: song.id)
           }
         } label: {
           Label("Remove Downloads", systemImage: "trash")
@@ -1351,7 +1353,7 @@ private struct LibraryCollectionActionsMenu: View {
         Button {
           AppHaptic.success.play()
           for song in pendingDownloads {
-            downloads.download(song: song)
+            DownloadManager.shared.download(song: song)
           }
         } label: {
           let label =

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -349,19 +349,26 @@ private struct PlaylistMoreMenu: View {
 struct PlaylistActionsMenuItems: View {
   let playlist: Playlist
   let songs: [Song]
-  @StateObject private var downloads = DownloadManager.shared
   @ObservedObject private var savedStore: SavedPlaylistsStore = .shared
-  private var pendingCount: Int {
-    songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }.count
-  }
-  private var inFlightCount: Int {
-    songs.filter { downloads.isDownloading($0.id) }.count
-  }
+  private let pendingSongs: [Song]
+  private let inFlightCount: Int
+  private var pendingCount: Int { pendingSongs.count }
   private var allDownloaded: Bool {
     !songs.isEmpty && pendingCount == 0 && inFlightCount == 0
   }
   private var canSaveToLibrary: Bool { !playlist.isFavorites && !playlist.isPersonal }
   private var isSaved: Bool { savedStore.isSaved(playlist) }
+
+  init(playlist: Playlist, songs: [Song]) {
+    self.playlist = playlist
+    self.songs = songs
+    // Keep menu content as a snapshot so active download progress does not
+    // continuously redraw transparent context/menu surfaces.
+    let downloads = DownloadManager.shared
+    self.pendingSongs = songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
+    self.inFlightCount = songs.filter { downloads.isDownloading($0.id) }.count
+  }
+
   var body: some View {
     if !songs.isEmpty {
       Button {
@@ -402,15 +409,15 @@ struct PlaylistActionsMenuItems: View {
       } else if allDownloaded {
         Button(role: .destructive) {
           AppHaptic.warning.play()
-          for s in songs { downloads.remove(songID: s.id) }
+          for s in songs { DownloadManager.shared.remove(songID: s.id) }
         } label: {
           Label("Remove Downloads", systemImage: "trash")
         }
       } else {
         Button {
           AppHaptic.success.play()
-          for s in songs where !downloads.isDownloaded(s.id) && !downloads.isDownloading(s.id) {
-            downloads.download(song: s)
+          for s in pendingSongs {
+            DownloadManager.shared.download(song: s)
           }
         } label: {
           let label = pendingCount < songs.count ? "Download Remaining" : "Download"

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -387,15 +387,8 @@ private struct RandomSongsHintRow: View {
 private struct RandomSongsActionsMenu: View {
   let songs: [Song]
   let onRefresh: () -> Void
-  @StateObject private var downloads = DownloadManager.shared
-
-  private var pendingDownloads: [Song] {
-    songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
-  }
-
-  private var downloadingCount: Int {
-    songs.filter { downloads.isDownloading($0.id) }.count
-  }
+  private let pendingDownloads: [Song]
+  private let downloadingCount: Int
 
   private var allDownloaded: Bool {
     !songs.isEmpty && pendingDownloads.isEmpty && downloadingCount == 0
@@ -404,6 +397,16 @@ private struct RandomSongsActionsMenu: View {
   private var downloadTitle: String {
     let downloadedCount = songs.count - pendingDownloads.count - downloadingCount
     return downloadedCount > 0 ? "Download Remaining" : "Download"
+  }
+
+  init(songs: [Song], onRefresh: @escaping () -> Void) {
+    self.songs = songs
+    self.onRefresh = onRefresh
+    // Snapshot download state for menu stability; live progress updates belong
+    // in rows, not in transparent menu content.
+    let downloads = DownloadManager.shared
+    self.pendingDownloads = songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
+    self.downloadingCount = songs.filter { downloads.isDownloading($0.id) }.count
   }
 
   var body: some View {
@@ -443,7 +446,7 @@ private struct RandomSongsActionsMenu: View {
         Button(role: .destructive) {
           AppHaptic.warning.play()
           for song in songs {
-            downloads.remove(songID: song.id)
+            DownloadManager.shared.remove(songID: song.id)
           }
         } label: {
           Label("Remove Downloads", systemImage: "trash")
@@ -452,7 +455,7 @@ private struct RandomSongsActionsMenu: View {
         Button {
           AppHaptic.success.play()
           for song in pendingDownloads {
-            downloads.download(song: song)
+            DownloadManager.shared.download(song: song)
           }
         } label: {
           Label(downloadTitle, systemImage: "arrow.down.circle")

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -282,7 +282,6 @@ struct FullScreenPlayerView: View {
                 songActions(song: song)
               } preview: {
                 SongContextPreview(song: song)
-                  .environmentObject(audioManager)
               }
             Spacer(minLength: metrics.artworkBottomSpacer)
             titleRow(song: song, metrics: metrics)
@@ -326,7 +325,6 @@ struct FullScreenPlayerView: View {
             songActions(song: song)
           } preview: {
             SongContextPreview(song: song)
-              .environmentObject(audioManager)
           }
         titleRow(song: song, metrics: metrics, horizontalPadding: 0)
       }
@@ -374,7 +372,6 @@ struct FullScreenPlayerView: View {
           songActions(song: song)
         } preview: {
           SongContextPreview(song: song)
-            .environmentObject(audioManager)
         }
         .padding(.bottom, 24)
 
@@ -660,7 +657,6 @@ struct FullScreenPlayerView: View {
       songActions(song: song)
     } preview: {
       SongContextPreview(song: song)
-        .environmentObject(audioManager)
     }
     .padding(.horizontal, horizontalPadding ?? metrics.horizontalPadding)
   }

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -241,7 +241,9 @@ struct QueueView: View {
           .lineLimit(1)
       }
       Spacer()
-      EqualizerBars(isAnimating: audioManager.isPlaying)
+      // Keep context-menu-backed rows static while playback is active; animated
+      // TimelineView content behind translucent menus can cause menu flicker.
+      EqualizerBars(isAnimating: false)
         .frame(width: 16, height: 16)
         .foregroundColor(.appAccent)
     }
@@ -257,7 +259,6 @@ struct QueueView: View {
       }
     } preview: {
       SongContextPreview(song: current)
-        .environmentObject(audioManager)
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Now Playing")
@@ -378,7 +379,6 @@ struct QueueRow: View {
       }
     } preview: {
       SongContextPreview(song: song)
-        .environmentObject(audioManager)
     }
     .sheet(isPresented: $showAddToPlaylist) {
       AddToPlaylistSheet(song: song)

--- a/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
+++ b/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
@@ -16,7 +16,6 @@ struct RadioPlayerLayout: View {
           radioActions
         } preview: {
           SongContextPreview(song: song)
-            .environmentObject(audioManager)
         }
       Spacer(minLength: 28)
       headerRow
@@ -25,7 +24,6 @@ struct RadioPlayerLayout: View {
           radioActions
         } preview: {
           SongContextPreview(song: song)
-            .environmentObject(audioManager)
         }
       Spacer(minLength: 24)
       playStopButton

--- a/Twinskaraoke/Features/Radio/RadioQueueView.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueView.swift
@@ -338,14 +338,12 @@ private struct RadioQueueLivePill: View {
     HStack(spacing: 5) {
       ZStack {
         if isPlaying && !reduceMotion {
-          TimelineView(
-            .animation(minimumInterval: DisplayRefreshRate.lightweightAnimationInterval)
-          ) { context in
-            Circle()
-              .fill(Color.white.opacity(pulseOpacity(for: context.date)))
-              .scaleEffect(pulseScale(for: context.date))
-          }
-          .frame(width: 11, height: 11)
+          // Keep the live pill stable inside the queue sheet. It sits near
+          // translucent context menus, where frame-driven redraws can flicker
+          // while playback is active.
+          Circle()
+            .fill(Color.white.opacity(0.28))
+            .frame(width: 11, height: 11)
         }
         Circle()
           .fill(.white)
@@ -361,16 +359,6 @@ private struct RadioQueueLivePill: View {
     .padding(.vertical, 4)
     .background(Capsule().fill(Color.appAccent))
     .accessibilityHidden(true)
-  }
-
-  private func pulseScale(for date: Date) -> CGFloat {
-    let phase = date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 1.25) / 1.25
-    return 0.75 + CGFloat(phase) * 1.0
-  }
-
-  private func pulseOpacity(for date: Date) -> Double {
-    let phase = date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 1.25) / 1.25
-    return max(0, 0.32 * (1 - phase))
   }
 }
 
@@ -446,7 +434,9 @@ private struct RadioQueueTrackRow: View {
       }
       Spacer()
       if isCurrent {
-        EqualizerBars(isAnimating: isPlaying)
+        // Keep row-level menu backdrops stable. The live player screen still has
+        // motion, but context-menu rows should not repaint continuously.
+        EqualizerBars(isAnimating: false)
           .frame(width: 18, height: 18)
           .foregroundColor(.appAccent)
       }

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -37,10 +37,16 @@ private final class AudioDownloadSession: NSObject, URLSessionDataDelegate {
   private var task: URLSessionDataTask?
   private var session: URLSession?
   private var hasReportedPlayableFallback = false
+  private var expectedContentLength: Int64 = NSURLSessionTransferSizeUnknown
   private let stateLock = NSLock()
   private var isCancelled = false
   var onCompletion: ((URL?) -> Void)?
   var onPlayableFallbackReady: ((URL) -> Void)?
+
+  private var partialFileSize: Int {
+    (try? partialURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+  }
+
   init(songID: String) {
     self.songID = songID
     let songFiles = AudioCacheStore.files(for: songID)
@@ -99,8 +105,17 @@ private final class AudioDownloadSession: NSObject, URLSessionDataDelegate {
     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
   ) {
     guard AudioCacheStore.acceptsAudioResponse(response) else {
+      DebugLogger.log(
+        "Audio cache download rejected for \(songID): \(response.mimeType ?? "unknown MIME")",
+        category: .cache)
       completionHandler(.cancel)
       return
+    }
+    if let http = response as? HTTPURLResponse {
+      expectedContentLength = response.expectedContentLength
+      DebugLogger.log(
+        "Audio cache download response for \(songID): HTTP \(http.statusCode), expectedBytes=\(response.expectedContentLength)",
+        category: .cache)
     }
     completionHandler(.allow)
   }
@@ -123,36 +138,64 @@ private final class AudioDownloadSession: NSObject, URLSessionDataDelegate {
     session.invalidateAndCancel()
     guard !cancelled else { return }
     if error != nil {
+      DebugLogger.log(
+        "Audio cache download failed for \(songID): bytes=\(partialFileSize), error=\(error?.localizedDescription ?? "unknown")",
+        category: .cache)
       try? FileManager.default.removeItem(at: partialURL)
       AudioCacheStore.writeMainSourceURL(nil, for: songID)
       DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
       return
     }
     if let http = task.response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+      DebugLogger.log(
+        "Audio cache download failed for \(songID): HTTP \(http.statusCode), bytes=\(partialFileSize)",
+        category: .cache)
       try? FileManager.default.removeItem(at: partialURL)
       AudioCacheStore.writeMainSourceURL(nil, for: songID)
       DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
       return
     }
     guard let validRemoteURL = remoteURL else {
+      DebugLogger.log(
+        "Audio cache download failed for \(songID): missing remote URL, bytes=\(partialFileSize)",
+        category: .cache)
       try? FileManager.default.removeItem(at: partialURL)
       AudioCacheStore.writeMainSourceURL(nil, for: songID)
       DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
       return
     }
     guard AudioCacheStore.isPlayableAudioFile(at: partialURL) else {
+      DebugLogger.log(
+        "Audio cache download produced unplayable file for \(songID): bytes=\(partialFileSize)",
+        category: .cache)
       try? FileManager.default.removeItem(at: partialURL)
       AudioCacheStore.writeMainSourceURL(nil, for: songID)
       DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
       return
     }
     try? FileManager.default.removeItem(at: finalURL)
+    let completedBytes = partialFileSize
+    if expectedContentLength > 0 && Int64(completedBytes) < expectedContentLength {
+      DebugLogger.log(
+        "Audio cache download incomplete for \(songID): bytes=\(completedBytes), expectedBytes=\(expectedContentLength)",
+        category: .cache)
+      try? FileManager.default.removeItem(at: partialURL)
+      AudioCacheStore.writeMainSourceURL(nil, for: songID)
+      DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
+      return
+    }
     do {
       try FileManager.default.moveItem(at: partialURL, to: finalURL)
       AudioCacheStore.writeMainSourceURL(validRemoteURL, for: songID)
+      DebugLogger.log(
+        "Audio cache download completed for \(songID): bytes=\(completedBytes)",
+        category: .cache)
       let final = finalURL
       DispatchQueue.main.async { [weak self] in self?.onCompletion?(final) }
     } catch {
+      DebugLogger.log(
+        "Audio cache download move failed for \(songID): \(error.localizedDescription)",
+        category: .cache)
       try? FileManager.default.removeItem(at: partialURL)
       AudioCacheStore.writeMainSourceURL(nil, for: songID)
       DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
@@ -490,6 +533,7 @@ class AudioPlayerManager: ObservableObject {
   private var quickCutGeneration: UInt64 = 0
   private var separationGeneration: UInt64 = 0
   private var transitionTimeoutGeneration: UInt64 = 0
+  private var activeCrossfadePlan: TransitionCoordinator.TransitionPlan?
   private var suppressPlaybackEndedUntil: Date = .distantPast
   private var wasPlayingBeforeInterruption = false
 
@@ -575,6 +619,7 @@ class AudioPlayerManager: ObservableObject {
         DebugLogger.log("Ignoring suppressed playback-ended callback", category: .playback)
         return
       }
+      if self.handlePrematurePlaybackEndIfNeeded(source: "AVEngine") { return }
       self.playNextOrRandom()
     }
     avEngine.onCrossfadeCompleted = { [weak self] in
@@ -868,6 +913,93 @@ class AudioPlayerManager: ObservableObject {
     suppressPlaybackEndedUntil = Date().addingTimeInterval(seconds)
   }
 
+  private func playbackSourceDescription(_ url: URL?) -> String {
+    guard let url else { return "none" }
+    if url.isFileURL {
+      if url.path.hasPrefix(AudioPlayerManager.audioCacheDir.path) {
+        return url.pathExtension == "partial"
+          ? "audio-cache-partial/\(url.lastPathComponent)"
+          : "audio-cache/\(url.lastPathComponent)"
+      }
+      return "file/\(url.lastPathComponent)"
+    }
+    let host = url.host ?? "unknown-host"
+    let fileName = url.lastPathComponent.isEmpty ? "stream" : url.lastPathComponent
+    return "remote/\(host)/\(fileName)"
+  }
+
+  private func streamItemDiagnostics() -> String {
+    guard let player = streamPlayer, let item = player.currentItem else { return "stream=none" }
+    let duration = item.duration.seconds
+    let durationText = duration.isFinite ? String(format: "%.2f", duration) : "unknown"
+    let loadedRanges = item.loadedTimeRanges
+      .map { $0.timeRangeValue }
+      .map { range -> String in
+        let start = range.start.seconds
+        let end = CMTimeAdd(range.start, range.duration).seconds
+        guard start.isFinite, end.isFinite else { return "unknown" }
+        return String(format: "%.2f-%.2f", start, end)
+      }
+      .joined(separator: ",")
+    let status: String
+    switch item.status {
+    case .unknown: status = "unknown"
+    case .readyToPlay: status = "ready"
+    case .failed: status = "failed"
+    @unknown default: status = "unknown-default"
+    }
+    let itemError = item.error?.localizedDescription ?? "none"
+    let playerError = player.error?.localizedDescription ?? "none"
+    return "streamDuration=\(durationText), loaded=[\(loadedRanges)], itemStatus=\(status), itemError=\(itemError), playerError=\(playerError)"
+  }
+
+  private func handlePrematurePlaybackEndIfNeeded(source: String) -> Bool {
+    guard let song = currentSong, !isRadioMode else { return false }
+    let expectedDuration = TimeInterval(song.duration)
+    guard expectedDuration.isFinite, expectedDuration > 15 else { return false }
+    let elapsed = activePlaybackTime(for: song)
+    guard elapsed.isFinite else { return false }
+    let minimumExpectedElapsed = min(8.0, max(3.0, expectedDuration * 0.08))
+    guard elapsed < minimumExpectedElapsed else { return false }
+
+    DebugLogger.log(
+      "Ignoring premature playback end from \(source) for \(song.id): elapsed=\(elapsed), expected=\(expectedDuration), source=\(playbackSourceDescription(currentPlaybackURL)), \(streamItemDiagnostics())",
+      category: .playback)
+    suppressPlaybackEndedCallbacks(for: 2.0)
+
+    if let playbackURL = currentPlaybackURL,
+      playbackURL.path.hasPrefix(AudioPlayerManager.audioCacheDir.path)
+    {
+      DebugLogger.log(
+        "Removing suspect cached audio after premature end for \(song.id)",
+        category: .cache)
+      AudioCacheStore.removeSongCache(for: song.id)
+      currentPlaybackURL = nil
+    } else if let playbackURL = currentPlaybackURL,
+      playbackURL.isFileURL,
+      DownloadManager.shared.isDownloaded(song.id)
+    {
+      DebugLogger.log(
+        "Removing suspect downloaded audio after premature end for \(song.id)",
+        category: .cache)
+      DownloadManager.shared.remove(songID: song.id)
+      currentPlaybackURL = nil
+    }
+
+    if let remoteURL = song.audioURL {
+      avEngine.stop()
+      startStreamPlayback(
+        url: remoteURL,
+        songID: song.id,
+        startAt: max(0, elapsed),
+        autoplay: isPlaybackRequested
+      )
+    } else {
+      setPlaybackState(playing: false, buffering: false)
+    }
+    return true
+  }
+
   private func keepPreparedStems(for song: Song? = nil) -> Bool {
     guard aiEnabled, aiAutoAnalyze, !isRadioMode else { return false }
     let targetID = song?.id ?? currentSong?.id
@@ -995,6 +1127,7 @@ class AudioPlayerManager: ObservableObject {
 
   private func cancelPendingTransitionWork(resetVolume: Bool = true) {
     transitionTimeoutGeneration &+= 1
+    activeCrossfadePlan = nil
     cancelQuickCutTimer(resetVolume: resetVolume)
     avEngine.cancelCrossfade()
     streamFadeTimer?.invalidate()
@@ -1813,6 +1946,9 @@ class AudioPlayerManager: ObservableObject {
   ) {
     stopStreamPlayer()
     currentPlaybackURL = url
+    DebugLogger.log(
+      "Starting stream playback for \(songID): source=\(playbackSourceDescription(url)), startAt=\(startAt), autoplay=\(autoplay)",
+      category: .playback)
     configureAudioSessionCategory()
     activateAudioSession()
     let item = AVPlayerItem(url: url)
@@ -1842,6 +1978,7 @@ class AudioPlayerManager: ObservableObject {
         guard self.quickCutTimer == nil else { return }
         guard !self.suppressTransitionAfterSeek else { return }
         guard !self.isPlaybackEndedCallbackSuppressed else { return }
+        if self.handlePrematurePlaybackEndIfNeeded(source: "Stream AVPlayer") { return }
         self.playNextOrRandom()
       }
     }
@@ -2491,6 +2628,7 @@ class AudioPlayerManager: ObservableObject {
     #if canImport(UIKit)
       beginTrackTransitionBackgroundTask()
     #endif
+    activeCrossfadePlan = plan
     configureAudioSessionCategory()
     activateAudioSession()
     DebugLogger.log(
@@ -2564,6 +2702,7 @@ class AudioPlayerManager: ObservableObject {
           timer.invalidate()
           self.quickCutTimer = nil
           DebugLogger.log("Quick cut transition complete -> play(\(song.id))", category: .playback)
+          self.activeCrossfadePlan = nil
           self.transitionCoordinator.reset()
           self.avEngine.setMasterVolume(0)
           self.play(song: song, resetTransitionVolume: false)
@@ -2576,7 +2715,15 @@ class AudioPlayerManager: ObservableObject {
   }
 
   private func transitionCoordinatorDidFinish() {
-    guard case .crossfading(let plan) = transitionCoordinator.state else {
+    let plan: TransitionCoordinator.TransitionPlan
+    if case .crossfading(let currentPlan) = transitionCoordinator.state {
+      plan = currentPlan
+    } else if let retainedPlan = activeCrossfadePlan {
+      plan = retainedPlan
+      DebugLogger.log(
+        "Completing retained crossfade plan for \(retainedPlan.nextSong.id) after coordinator reset",
+        category: .playback)
+    } else {
       transitionCoordinator.reset()
       return
     }
@@ -2587,6 +2734,7 @@ class AudioPlayerManager: ObservableObject {
       DebugLogger.log(
         "Transition completion recovery next=\(plan.nextSong.id), audioURL=\(avEngine.currentURL?.lastPathComponent ?? "nil"), expected=\(plan.nextFileURL.lastPathComponent), duration=\(handoffDuration), playing=\(avEngine.isPlaying)",
         category: .playback)
+      activeCrossfadePlan = nil
       play(song: plan.nextSong, resetTransitionVolume: true)
       return
     }
@@ -2616,6 +2764,7 @@ class AudioPlayerManager: ObservableObject {
       "Transition complete next=\(song.id), audioURL=\(avEngine.currentURL?.lastPathComponent ?? "nil"), time=\(avEngine.currentTime), duration=\(avEngine.duration), playing=\(avEngine.isPlaying)",
       category: .playback)
     updateNowPlayingInfo(reloadArtwork: true)
+    activeCrossfadePlan = nil
     transitionCoordinator.reset()
     let protectedIDs = activeSongIDs()
     CacheManager.shared.enforceMusicCacheLimits(excluding: protectedIDs)

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -175,7 +175,10 @@ final class TransitionCoordinator {
           rampStyle = .linear
         } else {
           let result = Self.computeFade(outBPM: outBPM, inBPM: inBPM)
-          fadeDuration = result.duration
+          // Beat-aware Auto Mix can naturally choose long phrase-aligned fades.
+          // Keep it bounded by the user's crossfade setting so the visible handoff
+          // does not make the next track appear to start many seconds in.
+          fadeDuration = min(result.duration, max(1.0, crossfadeSeconds))
           rampStyle = result.style
         }
       } else {

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -237,6 +237,13 @@ nonisolated enum AudioCacheStore {
     if let expectedDuration, expectedDuration > 0 {
       guard let actualURL = playableURL(for: songFiles.main) else { return false }
       let actualDuration = getAudioDuration(at: actualURL)
+      guard actualDuration.isFinite, actualDuration > 1.0 else {
+        DebugLogger.log(
+          "Discarding audio cache for \(songID) because duration could not be measured",
+          category: .cache)
+        removeSongCache(for: songID)
+        return false
+      }
       let tolerance: TimeInterval = 2.0
       if actualDuration > 0, abs(actualDuration - expectedDuration) > tolerance {
         DebugLogger.log(

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -52,6 +52,24 @@ final class DownloadManager: ObservableObject {
     files(for: songID).source
   }
 
+  nonisolated private static func isValidDownloadedAudio(
+    at url: URL,
+    expectedDuration: TimeInterval? = nil
+  ) -> Bool {
+    guard AudioCacheStore.isPlayableAudioFile(at: url) else { return false }
+    guard let expectedDuration, expectedDuration.isFinite, expectedDuration > 1.0 else {
+      return true
+    }
+    let actualDuration = AudioCacheStore.audioDuration(at: url)
+    guard actualDuration.isFinite, actualDuration > 1.0 else { return false }
+    let tolerance: TimeInterval = 2.0
+    return abs(actualDuration - expectedDuration) <= tolerance
+  }
+
+  nonisolated private static func downloadedByteCount(at url: URL) -> Int {
+    (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+  }
+
   func isDownloaded(_ songID: String) -> Bool {
     downloadedIDs.contains(songID)
   }
@@ -72,8 +90,13 @@ final class DownloadManager: ObservableObject {
     ensureSongDirectory(for: songID)
     let task = URLSession.shared.downloadTask(with: remote) { [weak self] tempURL, response, error in
       var moved = false
+      let expectedBytes = response?.expectedContentLength ?? NSURLSessionTransferSizeUnknown
+      let downloadedBytes = tempURL.map { Self.downloadedByteCount(at: $0) } ?? 0
+      let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+      let hasCompleteByteCount = expectedBytes <= 0 || Int64(downloadedBytes) >= expectedBytes
       if let tempURL, error == nil, AudioCacheStore.acceptsAudioResponse(response),
-        AudioCacheStore.isPlayableAudioFile(at: tempURL)
+        hasCompleteByteCount,
+        Self.isValidDownloadedAudio(at: tempURL, expectedDuration: expectedDuration)
       {
         do {
           try FileManager.default.createDirectory(
@@ -94,7 +117,9 @@ final class DownloadManager: ObservableObject {
           try? FileManager.default.removeItem(at: tempURL)
         }
         if error == nil {
-          DebugLogger.log("Download rejected invalid audio response for \(songID)", category: .network)
+          DebugLogger.log(
+            "Download rejected invalid audio for \(songID): bytes=\(downloadedBytes), expectedBytes=\(expectedBytes)",
+            category: .network)
         }
       }
       Task { @MainActor [weak self, moved, song, songID] in
@@ -186,7 +211,8 @@ final class DownloadManager: ObservableObject {
       downloadedIDs.remove(song.id)
       return nil
     }
-    guard AudioCacheStore.isPlayableAudioFile(at: songFiles.audio) else {
+    let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+    guard Self.isValidDownloadedAudio(at: songFiles.audio, expectedDuration: expectedDuration) else {
       DebugLogger.log("Discarding invalid downloaded audio for \(song.id)", category: .cache)
       remove(songID: song.id)
       return nil
@@ -238,8 +264,10 @@ final class DownloadManager: ObservableObject {
   private func hasValidDownload(for songID: String) -> Bool {
     let songFiles = files(for: songID)
     guard FileManager.default.fileExists(atPath: songFiles.audio.path) else { return false }
+    let metadataDuration = readMetadata(for: songID)?.duration ?? 0
+    let expectedDuration = metadataDuration > 0 ? TimeInterval(metadataDuration) : nil
     return readSourceURL(for: songID) != nil
-      && AudioCacheStore.isPlayableAudioFile(at: songFiles.audio)
+      && Self.isValidDownloadedAudio(at: songFiles.audio, expectedDuration: expectedDuration)
   }
 
   private func readSourceURL(for songID: String) -> String? {


### PR DESCRIPTION
- Guard against corrupted or incomplete cached audio by validating cached and downloaded files before playback, rejecting suspicious durations, and removing bad local files when AVEngine reports a premature end.

- Recover from unexpected early playback-end callbacks by suppressing false queue advances, logging the source, removing suspect cache/download entries, and resuming the remote stream from the observed playback time instead of skipping the song.

- Retain crossfade handoff plans across coordinator resets so completed AVEngine handoffs still update the visible current song and playback metadata, and cap beat-aware Auto Mix fades to the configured crossfade duration.

- Stop transparent iOS menus from flickering by removing playback-progress updates from LNPopupUI popup preferences, keeping menu-adjacent indicators static, making context previews data-only, and snapshotting download state inside menu content.