### PR TITLE
Improve playback UI and artwork cache stability

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -10,54 +10,100 @@ import SwiftUI
 private final class PopupPlaybackState: ObservableObject {
   static let shared = PopupPlaybackState()
 
-  @Published private(set) var hasCurrentSong = false
-  @Published private(set) var title = ""
-  @Published private(set) var subtitle = ""
-  @Published private(set) var artwork: UIImage?
-  @Published private(set) var isPlaying = false
-  @Published private(set) var isRadioMode = false
+  var hasCurrentSong: Bool { snapshot.id != nil }
+  var title: String { snapshot.title }
+  var subtitle: String { snapshot.subtitle }
+  var artwork: UIImage? { snapshot.artwork }
+  var isPlaying: Bool { snapshot.isPlaying }
+  var isRadioMode: Bool { snapshot.isRadioMode }
 
+  @Published private var snapshot = PopupPlaybackSnapshot()
+  private var pendingSnapshot = PopupPlaybackSnapshot()
+  private var publishTask: Task<Void, Never>?
   private var cancellables = Set<AnyCancellable>()
 
   private init() {
     let manager = AudioPlayerManager.shared
     manager.$currentSong
-      .map { song in
-        PopupSongSnapshot(
-          id: song?.id,
-          title: song?.title ?? "",
-          subtitle: song?.displayArtist ?? ""
-        )
-      }
-      .removeDuplicates()
-      .sink { [weak self] snapshot in
-        self?.hasCurrentSong = snapshot.id != nil
-        self?.title = snapshot.title
-        self?.subtitle = snapshot.subtitle
+      .removeDuplicates(by: {
+        $0?.id == $1?.id
+          && $0?.title == $1?.title
+          && $0?.displayArtist == $1?.displayArtist
+      })
+      .sink { [weak self] song in
+        self?.updatePendingSnapshot { snapshot in
+          snapshot.id = song?.id
+          snapshot.title = song?.title ?? ""
+          snapshot.subtitle = song?.displayArtist ?? ""
+        }
       }
       .store(in: &cancellables)
 
     manager.$nowPlayingArtwork
       .removeDuplicates(by: { $0 === $1 })
-      .sink { [weak self] in self?.artwork = $0 }
+      .sink { [weak self] artwork in
+        self?.updatePendingSnapshot { snapshot in
+          snapshot.artwork = artwork
+        }
+      }
       .store(in: &cancellables)
 
     manager.$isPlaying
       .removeDuplicates()
-      .sink { [weak self] in self?.isPlaying = $0 }
+      .sink { [weak self] isPlaying in
+        self?.updatePendingSnapshot { snapshot in
+          snapshot.isPlaying = isPlaying
+        }
+      }
       .store(in: &cancellables)
 
     manager.$isRadioMode
       .removeDuplicates()
-      .sink { [weak self] isRadioMode in self?.isRadioMode = isRadioMode }
+      .sink { [weak self] isRadioMode in
+        self?.updatePendingSnapshot { snapshot in
+          snapshot.isRadioMode = isRadioMode
+        }
+      }
       .store(in: &cancellables)
+  }
+
+  private func updatePendingSnapshot(_ update: (inout PopupPlaybackSnapshot) -> Void) {
+    update(&pendingSnapshot)
+    scheduleSnapshotPublish()
+  }
+
+  private func scheduleSnapshotPublish() {
+    guard publishTask == nil else { return }
+    publishTask = Task { @MainActor [weak self] in
+      await Task.yield()
+      guard let self else { return }
+      let nextSnapshot = self.pendingSnapshot
+      self.publishTask = nil
+      guard !self.snapshot.matches(nextSnapshot) else { return }
+      // LNPopupUI stores title, image, and button data as SwiftUI preferences.
+      // Publishing one coalesced snapshot prevents rapid track changes from
+      // writing those preferences several times in a single render frame.
+      self.snapshot = nextSnapshot
+    }
   }
 }
 
-private struct PopupSongSnapshot: Equatable {
-  let id: String?
-  let title: String
-  let subtitle: String
+private struct PopupPlaybackSnapshot {
+  var id: String?
+  var title = ""
+  var subtitle = ""
+  var artwork: UIImage?
+  var isPlaying = false
+  var isRadioMode = false
+
+  func matches(_ other: PopupPlaybackSnapshot) -> Bool {
+    id == other.id
+      && title == other.title
+      && subtitle == other.subtitle
+      && artwork === other.artwork
+      && isPlaying == other.isPlaying
+      && isRadioMode == other.isRadioMode
+  }
 }
 
 #if canImport(UIKit)

--- a/Twinskaraoke/Components/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/RemoteArtworkImage.swift
@@ -78,12 +78,19 @@ struct RemoteArtworkImage: View {
 
   @ViewBuilder
   private func imageContent(size: CGSize) -> some View {
-    let pixelSize = NSValue(cgSize: thumbnailPixelSize(for: size))
+    let displaySize = sanitizedDisplaySize(size)
+    let pixelSize = NSValue(cgSize: thumbnailPixelSize(for: displaySize))
     let context: [SDWebImageContextOption: Any] =
       fullResolution
       ? [:] : [
         .imageThumbnailPixelSize: pixelSize,
-        .imageDecodeOptions: [SDImageCoderOption.decodeScaleFactor: 1.0]
+        .imageDecodeOptions: [SDImageCoderOption.decodeScaleFactor: 1.0],
+        // Thumbnail decode can leave SDWebImage without original bytes, forcing
+        // ImageIO to re-encode formats such as WebP for disk storage. Keep the
+        // thumbnail variant in memory and store/query the original bytes on disk.
+        .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
+        .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+        .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue)
       ]
     ZStack {
       if !transparentBackground {
@@ -98,7 +105,7 @@ struct RemoteArtworkImage: View {
           image
             .resizable()
             .aspectRatio(contentMode: contentMode)
-            .frame(width: size.width, height: size.height)
+            .frame(width: displaySize.width, height: displaySize.height)
             .clipped()
             .blur(radius: 2)
         } placeholder: {
@@ -114,7 +121,7 @@ struct RemoteArtworkImage: View {
           image
             .resizable()
             .aspectRatio(contentMode: contentMode)
-            .frame(width: size.width, height: size.height)
+            .frame(width: displaySize.width, height: displaySize.height)
             .clipped()
             .onAppear {
               markRendered(url)
@@ -148,12 +155,29 @@ struct RemoteArtworkImage: View {
 
   private func markFinishedAfterFailure(for failedURL: URL) {
     guard url == failedURL, !loadFailed else { return }
+    evictFailedImageCache(for: failedURL)
     Task { @MainActor in
       guard url == failedURL, !loadFailed else { return }
       withOptionalAnimation(AppMotion.spring(response: 0.12, dampingFraction: 0.9)) {
         loadFailed = true
       }
     }
+  }
+
+  private func evictFailedImageCache(for failedURL: URL) {
+    // A corrupt cached image will keep hitting ImageIO on every render. Remove
+    // both cache tiers so the next attempt has to fetch fresh bytes.
+    let cacheKey = failedURL.absoluteString
+    SDImageCache.shared.removeImageFromMemory(forKey: cacheKey)
+    SDImageCache.shared.removeImageFromDisk(forKey: cacheKey)
+  }
+
+  private func sanitizedDisplaySize(_ size: CGSize) -> CGSize {
+    // SwiftUI can briefly report non-finite geometry during aggressive layout
+    // churn. Clamp before using the values in fixed frames or decode requests.
+    let width = size.width.isFinite ? max(size.width, 1) : 1
+    let height = size.height.isFinite ? max(size.height, 1) : 1
+    return CGSize(width: width, height: height)
   }
 
   private func thumbnailPixelSize(for displaySize: CGSize) -> CGSize {

--- a/TwinskaraokeShared/Components/PressableButtonStyle.swift
+++ b/TwinskaraokeShared/Components/PressableButtonStyle.swift
@@ -91,12 +91,15 @@ private struct PressableButtonBody: View {
       .scaleEffect(reduceMotion ? 1.0 : (configuration.isPressed ? scale : 1.0))
       .opacity(currentOpacity)
       .animation(reduceMotion ? nil : animation, value: configuration.isPressed)
+      #if os(watchOS)
       .onChange(of: configuration.isPressed) { isPressed in
-        if isPressed && !wasPressed {
-          haptic?.play()
-        }
-        wasPressed = isPressed
+        updatePressState(isPressed)
       }
+      #else
+      .onChange(of: configuration.isPressed) { _, isPressed in
+        updatePressState(isPressed)
+      }
+      #endif
   }
 
   private var currentOpacity: Double {
@@ -106,6 +109,13 @@ private struct PressableButtonBody: View {
 
   private var animation: Animation {
     pressAnimation ?? AppMotion.spring(response: 0.32, dampingFraction: 0.7)
+  }
+
+  private func updatePressState(_ isPressed: Bool) {
+    if isPressed && !wasPressed {
+      haptic?.play()
+    }
+    wasPressed = isPressed
   }
 
   private var reduceMotion: Bool {


### PR DESCRIPTION
## Summary

This PR improves playback UI stability and reduces artwork-related rendering/cache noise observed while debugging on device.

## Changes

- Coalesces mini-player popup playback state into a single snapshot before publishing to SwiftUI.
- Reduces repeated LNPopupUI preference updates during rapid track changes and playback transitions.
- Hardens remote artwork rendering by clamping transient non-finite geometry before using it for frames or thumbnail decode requests.
- Keeps downsampled artwork thumbnail variants in memory while storing/querying original image bytes on disk.
- Evicts failed artwork cache entries so corrupt cached images do not repeatedly hit ImageIO on subsequent renders.
- Updates the shared pressable button state-change handler to use the modern iOS onChange closure while preserving watchOS compatibility.

## Why

Device logs showed artwork decode/cache failures from ImageIO, including WebP re-encoding failures and invalid frame dimensions during layout churn. The artwork cache path now avoids disk re-encoding of thumbnail variants while retaining original image disk caching, which reduces IO noise and avoids repeated failed decode attempts.

The popup playback state also emitted multiple independent SwiftUI updates for title, subtitle, artwork, playback state, and radio mode. Publishing those as one coalesced snapshot reduces preference churn in the popup bar during quick track changes.

## Validation

- Built the Twinskaraoke scheme for generic iOS with code signing disabled.
- Verified on-device debugger output no longer shows the previous WebP/ImageIO cache errors or invalid frame dimension warnings after the artwork changes.