### PR TITLE
Keep full player open across track changes

### DIFF
--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -227,9 +227,6 @@ struct FullScreenPlayerView: View {
         fetchCoverArtArtist(songID: id)
       }
     }
-    .onDisappear {
-      audioManager.showFullScreen = false
-    }
   }
   @ViewBuilder
   private func musicLayout(song: Song, metrics: PlayerLayoutMetrics) -> some View {


### PR DESCRIPTION
## Summary

Fixes a regression where the full-screen player could collapse back to the mini-player when pressing next or previous.

## Root Cause

A recent change reset AudioPlayerManager.showFullScreen from FullScreenPlayerView.onDisappear. That lifecycle event is not equivalent to an intentional user dismiss in this app because the player view is hosted inside LNPopupUI.

During next/previous navigation, especially when moving to queue items that have not been played yet, SwiftUI/LNPopupUI can briefly tear down and rebuild the full player content while metadata, artwork, and playback state update. The onDisappear handler interpreted that transient rebuild as a close event and set showFullScreen to false, collapsing the player.

## Changes

- Removes the onDisappear reset from FullScreenPlayerView.
- Keeps existing explicit close behavior intact through the dismiss control and popup binding.

## Impact

The full-screen player now remains open while changing tracks via next/previous, including transitions to unplayed queue items, while still allowing intentional user dismissal.

## Validation

- Built the Twinskaraoke scheme for generic iOS with code signing disabled.
- Verified on device that pressing next/previous no longer closes the full-screen player.