### PR TITLE
Fix popup intent and layout warnings

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -115,6 +115,7 @@ private struct PopupPlaybackSnapshot {
     private static let defaultTrailingControlHitWidth: CGFloat = 132
     private static let radioTrailingControlHitWidth: CGFloat = 192
     private static let tapMovementTolerance: CGFloat = 12
+    private static let visibleBarHitHeight: CGFloat = 116
     private var touchStartLocation: CGPoint?
     private var openIntentExpiresAt = Date.distantPast
     private var suppressOpenExpiresAt = Date.distantPast
@@ -162,6 +163,7 @@ private struct PopupPlaybackSnapshot {
       case .began:
         touchStartLocation = location
         guard Date() > suppressOpenExpiresAt,
+          isVisibleMiniPlayerTouch(location, in: popupBar),
           !isTrailingControlTouch(location, in: popupBar)
         else {
           openIntentExpiresAt = .distantPast
@@ -184,6 +186,22 @@ private struct PopupPlaybackSnapshot {
       default:
         break
       }
+    }
+
+    private func isVisibleMiniPlayerTouch(_ location: CGPoint, in popupBar: LNPopupBar) -> Bool {
+      let bounds = popupBar.bounds
+      guard bounds.width.isFinite, bounds.height.isFinite, bounds.width > 0, bounds.height > 0 else {
+        return false
+      }
+
+      // LNPopupUI can keep a larger transparent gesture surface around the
+      // floating bar. Treat only the visible bottom strip as a deliberate
+      // mini-player touch so unrelated UI taps cannot arm a popup-open intent.
+      let visibleHeight = min(bounds.height, Self.visibleBarHitHeight)
+      return location.x >= bounds.minX
+        && location.x <= bounds.maxX
+        && location.y >= bounds.maxY - visibleHeight
+        && location.y <= bounds.maxY
     }
 
     private func isTrailingControlTouch(_ location: CGPoint, in popupBar: LNPopupBar) -> Bool {

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -20,16 +20,17 @@ struct DownloadedSongsView: View {
 
   var body: some View {
     GeometryReader { geo in
+      let viewportSize = sanitizedViewportSize(geo.size)
       ScrollView {
         if localSongs.isEmpty {
           DownloadedEmptyStateView {
             refresh()
           }
-            .frame(width: geo.size.width, height: geo.size.height - 100)
+            .frame(width: viewportSize.width, height: max(viewportSize.height - 100, 1))
             .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
         } else {
           VStack(spacing: 18) {
-            heroHeader(width: geo.size.width)
+            heroHeader(width: viewportSize.width)
             VStack(spacing: 4) {
               Text("Downloaded")
                 .font(.title2.bold())
@@ -119,6 +120,15 @@ struct DownloadedSongsView: View {
     }
     .onAppear { refresh() }
     .onChange(of: downloads.downloadedIDs) { _, _ in refresh() }
+  }
+
+  private func sanitizedViewportSize(_ size: CGSize) -> CGSize {
+    // GeometryReader can briefly report zero, negative, or non-finite dimensions
+    // during navigation/layout transitions. Clamp before passing values to
+    // frame modifiers so SwiftUI never receives an invalid frame dimension.
+    let width = size.width.isFinite ? max(size.width, 1) : 1
+    let height = size.height.isFinite ? max(size.height, 1) : 1
+    return CGSize(width: width, height: height)
   }
 
   private var downloadedSubtitle: String {

--- a/Twinskaraoke/Services/RadioController.swift
+++ b/Twinskaraoke/Services/RadioController.swift
@@ -90,7 +90,6 @@ final class RadioController: ObservableObject {
     defer { isRefreshing = false }
 
     let maxRetries = 3
-    var lastError: Error?
 
     for attempt in 0..<maxRetries {
       do {
@@ -111,7 +110,6 @@ final class RadioController: ObservableObject {
         return
       } catch {
         guard !Task.isCancelled else { return }
-        lastError = error
         if attempt < maxRetries - 1 {
           let delay = Double(1 << attempt)
           try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))


### PR DESCRIPTION
## Summary

This fixes a set of UI stability issues found while testing the player and cleaning up Xcode warnings:

- restricts LNPopupUI open-intent detection to the visible mini-player strip
- clamps Downloaded Songs geometry before passing it into SwiftUI frame modifiers
- removes an unused RadioController retry error variable that produced a compiler warning

## Root Cause

LNPopupUI can keep a larger transparent gesture surface around the floating popup bar. The app used a zero-duration gesture recognizer to detect intentional mini-player taps, but the recognizer accepted any touch inside the popup bar bounds. On devices/layouts where that bounds rect is larger than the visible mini-player, unrelated UI taps could arm the popup-open intent and cause the full player to open unexpectedly.

The Downloaded Songs empty state also passed raw `GeometryReader` dimensions into `.frame(...)`, subtracting a fixed offset from the reported height. During transient SwiftUI layout passes, that height can briefly be zero, invalid, or smaller than the offset, which triggers invalid frame dimension warnings.

RadioController kept a `lastError` variable during metadata retries, but the value was never read because the user-facing fallback message is intentionally generic.

## Changes

- Added visible mini-player hit testing before arming popup-open intents.
- Kept trailing control suppression intact so playback controls remain usable without opening the full player.
- Sanitized Downloaded Songs viewport dimensions and clamped empty-state height to a valid positive value.
- Removed the unused RadioController retry error storage without changing retry behavior or final error messaging.

## Validation

- `xcodebuild -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -destination generic/platform=iOS build CODE_SIGNING_ALLOWED=NO`
