### PR TITLE
Improve artwork prefetching and popup presentation isolation

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -121,6 +121,19 @@ private struct PopupPlaybackSnapshot {
     }
 }
 
+@MainActor
+final class PopupPresentationState: ObservableObject {
+    static let shared = PopupPresentationState()
+
+    // Keep popup expansion isolated from playback churn. AudioPlayerManager emits
+    // frequent song, artwork, clock, and buffering updates; tying LNPopupUI's
+    // expanded binding to that object makes unrelated playback/UI refreshes more
+    // likely to be interpreted as presentation changes.
+    @Published var isExpanded = false
+
+    private init() {}
+}
+
 #if canImport(UIKit)
     @MainActor
     final class PopupOpenIntentGate: NSObject, UIGestureRecognizerDelegate {
@@ -603,25 +616,26 @@ private extension RootSection {
 
 private struct PopupModifier: ViewModifier {
     @ObservedObject private var popupState = PopupPlaybackState.shared
+    @ObservedObject private var presentationState = PopupPresentationState.shared
 
     func body(content: Content) -> some View {
         content
             .popup(
                 isBarPresented: .constant(popupState.hasCurrentSong),
                 isPopupOpen: Binding(
-                    get: { AudioPlayerManager.shared.showFullScreen },
+                    get: { presentationState.isExpanded },
                     set: { isOpen in
                         if isOpen {
                             #if canImport(UIKit)
                                 let isIntentionalOpen =
-                                    AudioPlayerManager.shared.showFullScreen || PopupOpenIntentGate.shared.consumeIntent()
+                                    presentationState.isExpanded || PopupOpenIntentGate.shared.consumeIntent()
                                 guard isIntentionalOpen else {
-                                    AudioPlayerManager.shared.showFullScreen = false
+                                    presentationState.isExpanded = false
                                     return
                                 }
                             #endif
                         }
-                        AudioPlayerManager.shared.showFullScreen = isOpen
+                        presentationState.isExpanded = isOpen
                     }
                 )
             ) {

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -153,16 +153,23 @@ final class PopupPresentationState: ObservableObject {
         private static let tapMovementTolerance: CGFloat = 12
         private static let visibleBarHitHeight: CGFloat = 116
         private static let openIntentWindow: TimeInterval = 0.45
+        private static let openDragReleaseWindow: TimeInterval = 1.2
         private var touchStartLocation: CGPoint?
+        private var isOpenDragActive = false
         private var openIntentExpiresAt = Date.distantPast
         private var suppressOpenExpiresAt = Date.distantPast
 
         func consumeIntent() -> Bool {
             guard Date() > suppressOpenExpiresAt else {
+                isOpenDragActive = false
                 openIntentExpiresAt = .distantPast
                 return false
             }
             suppressOpenExpiresAt = .distantPast
+            if isOpenDragActive {
+                openIntentExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
+                return true
+            }
             guard Date() <= openIntentExpiresAt else {
                 openIntentExpiresAt = .distantPast
                 return false
@@ -172,6 +179,7 @@ final class PopupPresentationState: ObservableObject {
         }
 
         func suppressNextOpen() {
+            isOpenDragActive = false
             openIntentExpiresAt = .distantPast
             suppressOpenExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
         }
@@ -198,6 +206,7 @@ final class PopupPresentationState: ObservableObject {
 
             switch recognizer.state {
             case .began:
+                isOpenDragActive = false
                 guard Date() > suppressOpenExpiresAt,
                       isVisibleMiniPlayerTouch(location, in: popupBar),
                       !isTrailingControlTouch(location, in: popupBar)
@@ -218,14 +227,23 @@ final class PopupPresentationState: ObservableObject {
                 // Keep the intent alive while LNPopupUI's own drag recognizer moves
                 // the popup; otherwise the binding rejects the open and collapses it.
                 if isIntentionalOpenDrag(from: touchStartLocation, to: location) {
+                    isOpenDragActive = true
                     openIntentExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
                 } else if distance(from: touchStartLocation, to: location) > Self.tapMovementTolerance {
+                    isOpenDragActive = false
                     openIntentExpiresAt = .distantPast
                 }
             case .ended:
                 touchStartLocation = nil
+                if isOpenDragActive {
+                    // Slow drags can hover at the top before LNPopupUI commits the
+                    // final open state. Keep a short release grace for that handoff.
+                    isOpenDragActive = false
+                    openIntentExpiresAt = Date().addingTimeInterval(Self.openDragReleaseWindow)
+                }
             case .cancelled, .failed:
                 touchStartLocation = nil
+                isOpenDragActive = false
                 openIntentExpiresAt = .distantPast
             default:
                 break

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -129,9 +129,17 @@ final class PopupPresentationState: ObservableObject {
     // frequent song, artwork, clock, and buffering updates; tying LNPopupUI's
     // expanded binding to that object makes unrelated playback/UI refreshes more
     // likely to be interpreted as presentation changes.
-    @Published var isExpanded = false
+    @Published private(set) var isExpanded = false
 
     private init() {}
+
+    func setExpanded(_ isExpanded: Bool) {
+        self.isExpanded = isExpanded
+    }
+
+    func collapse() {
+        setExpanded(false)
+    }
 }
 
 #if canImport(UIKit)
@@ -630,12 +638,12 @@ private struct PopupModifier: ViewModifier {
                                 let isIntentionalOpen =
                                     presentationState.isExpanded || PopupOpenIntentGate.shared.consumeIntent()
                                 guard isIntentionalOpen else {
-                                    presentationState.isExpanded = false
+                                    presentationState.collapse()
                                     return
                                 }
                             #endif
                         }
-                        presentationState.isExpanded = isOpen
+                        presentationState.setExpanded(isOpen)
                     }
                 )
             ) {

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -152,6 +152,7 @@ final class PopupPresentationState: ObservableObject {
         private static let radioTrailingControlHitWidth: CGFloat = 192
         private static let tapMovementTolerance: CGFloat = 12
         private static let visibleBarHitHeight: CGFloat = 116
+        private static let openIntentWindow: TimeInterval = 0.45
         private var touchStartLocation: CGPoint?
         private var openIntentExpiresAt = Date.distantPast
         private var suppressOpenExpiresAt = Date.distantPast
@@ -172,7 +173,7 @@ final class PopupPresentationState: ObservableObject {
 
         func suppressNextOpen() {
             openIntentExpiresAt = .distantPast
-            suppressOpenExpiresAt = Date().addingTimeInterval(0.45)
+            suppressOpenExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
         }
 
         func installTouchRecognizer(on popupBar: LNPopupBar) {
@@ -197,21 +198,28 @@ final class PopupPresentationState: ObservableObject {
 
             switch recognizer.state {
             case .began:
-                touchStartLocation = location
                 guard Date() > suppressOpenExpiresAt,
                       isVisibleMiniPlayerTouch(location, in: popupBar),
                       !isTrailingControlTouch(location, in: popupBar)
                 else {
+                    touchStartLocation = nil
                     openIntentExpiresAt = .distantPast
                     return
                 }
-                openIntentExpiresAt = Date().addingTimeInterval(0.45)
+                touchStartLocation = location
+                openIntentExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
             case .changed:
                 guard let touchStartLocation else {
                     openIntentExpiresAt = .distantPast
                     return
                 }
-                if distance(from: touchStartLocation, to: location) > Self.tapMovementTolerance {
+
+                // A swipe up from the mini-player is an intentional open gesture.
+                // Keep the intent alive while LNPopupUI's own drag recognizer moves
+                // the popup; otherwise the binding rejects the open and collapses it.
+                if isIntentionalOpenDrag(from: touchStartLocation, to: location) {
+                    openIntentExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
+                } else if distance(from: touchStartLocation, to: location) > Self.tapMovementTolerance {
                     openIntentExpiresAt = .distantPast
                 }
             case .ended:
@@ -230,14 +238,15 @@ final class PopupPresentationState: ObservableObject {
                 return false
             }
 
-            // LNPopupUI can keep a larger transparent gesture surface around the
-            // floating bar. Treat only the visible bottom strip as a deliberate
-            // mini-player touch so unrelated UI taps cannot arm a popup-open intent.
+            // Floating LNPopupUI bars live at the top of a taller transparent host
+            // view whose lower extension can overlap the tab bar. Anchor the
+            // accepted area to the visible top strip so Home/Library taps and
+            // nearby navigation hits cannot arm a popup-open intent.
             let visibleHeight = min(bounds.height, Self.visibleBarHitHeight)
             return location.x >= bounds.minX
                 && location.x <= bounds.maxX
-                && location.y >= bounds.maxY - visibleHeight
-                && location.y <= bounds.maxY
+                && location.y >= bounds.minY
+                && location.y <= bounds.minY + visibleHeight
         }
 
         private func isTrailingControlTouch(_ location: CGPoint, in popupBar: LNPopupBar) -> Bool {
@@ -257,6 +266,13 @@ final class PopupPresentationState: ObservableObject {
 
         private func distance(from start: CGPoint, to end: CGPoint) -> CGFloat {
             hypot(end.x - start.x, end.y - start.y)
+        }
+
+        private func isIntentionalOpenDrag(from start: CGPoint, to current: CGPoint) -> Bool {
+            let deltaX = current.x - start.x
+            let deltaY = current.y - start.y
+            guard deltaY < -Self.tapMovementTolerance else { return false }
+            return abs(deltaY) >= abs(deltaX) * 0.75
         }
 
         nonisolated func gestureRecognizer(

--- a/Twinskaraoke/Components/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/RemoteArtworkImage.swift
@@ -7,8 +7,8 @@ enum ImageCacheConfig {
         guard !didApply else { return }
         didApply = true
         let cfg = SDImageCache.shared.config
-        cfg.maxMemoryCost = 32 * 1024 * 1024
-        cfg.maxMemoryCount = 48
+        cfg.maxMemoryCost = 64 * 1024 * 1024
+        cfg.maxMemoryCount = 96
         cfg.maxDiskSize = 256 * 1024 * 1024
         cfg.shouldCacheImagesInMemory = true
         cfg.shouldUseWeakMemoryCache = true
@@ -128,7 +128,8 @@ struct RemoteArtworkImage: View {
                 .onFailure { _ in
                     markFinishedAfterFailure(for: url)
                 }
-                .onSuccess { _, _, _ in
+                .onSuccess { _, _, cacheType in
+                    ArtworkLoadMetrics.shared.record(url: url, cacheType: cacheType)
                     markRendered(url)
                 }
                 .transition(.opacity.animation(AppMotion.spring(response: 0.15, dampingFraction: 0.9)))
@@ -181,6 +182,38 @@ struct RemoteArtworkImage: View {
         let h = max(displaySize.height, 1) * scale
         let cap = ImageCacheConfig.thumbnailPixelSize
         return CGSize(width: min(w, cap.width), height: min(h, cap.height))
+    }
+}
+
+@MainActor
+private final class ArtworkLoadMetrics {
+    static let shared = ArtworkLoadMetrics()
+    private var totalLoads = 0
+    private var memoryHits = 0
+    private var diskHits = 0
+    private var networkLoads = 0
+    private var lastReport = Date.distantPast
+
+    func record(url _: URL, cacheType: SDImageCacheType) {
+        totalLoads += 1
+        switch cacheType {
+        case .memory:
+            memoryHits += 1
+        case .disk:
+            diskHits += 1
+        case .none:
+            networkLoads += 1
+        default:
+            break
+        }
+
+        let now = Date()
+        guard totalLoads >= 20, now.timeIntervalSince(lastReport) > 20 else { return }
+        lastReport = now
+        DebugLogger.log(
+            "Artwork loads: total=\(totalLoads), memory=\(memoryHits), disk=\(diskHits), network=\(networkLoads)",
+            category: .cache
+        )
     }
 }
 

--- a/Twinskaraoke/Components/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/RemoteArtworkImage.swift
@@ -129,7 +129,7 @@ struct RemoteArtworkImage: View {
                     markFinishedAfterFailure(for: url)
                 }
                 .onSuccess { _, _, cacheType in
-                    ArtworkLoadMetrics.shared.record(url: url, cacheType: cacheType)
+                    ArtworkLoadMetrics.shared.record(cacheType: cacheType)
                     markRendered(url)
                 }
                 .transition(.opacity.animation(AppMotion.spring(response: 0.15, dampingFraction: 0.9)))
@@ -194,7 +194,7 @@ private final class ArtworkLoadMetrics {
     private var networkLoads = 0
     private var lastReport = Date.distantPast
 
-    func record(url _: URL, cacheType: SDImageCacheType) {
+    func record(cacheType: SDImageCacheType) {
         totalLoads += 1
         switch cacheType {
         case .memory:
@@ -210,8 +210,16 @@ private final class ArtworkLoadMetrics {
         let now = Date()
         guard totalLoads >= 20, now.timeIntervalSince(lastReport) > 20 else { return }
         lastReport = now
+        let reportedTotal = totalLoads
+        let reportedMemory = memoryHits
+        let reportedDisk = diskHits
+        let reportedNetwork = networkLoads
+        totalLoads = 0
+        memoryHits = 0
+        diskHits = 0
+        networkLoads = 0
         DebugLogger.log(
-            "Artwork loads: total=\(totalLoads), memory=\(memoryHits), disk=\(diskHits), network=\(networkLoads)",
+            "Artwork loads: total=\(reportedTotal), memory=\(reportedMemory), disk=\(reportedDisk), network=\(reportedNetwork)",
             category: .cache
         )
     }

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -47,6 +47,13 @@ struct HomeView: View {
                 }
             }
             .refreshable { viewModel.fetchHomeData(force: true) }
+            .onChange(of: viewModel.isLoading) { _, isLoading in
+                guard !isLoading else { return }
+                prefetchVisibleArtwork()
+            }
+            .onAppear {
+                prefetchVisibleArtwork()
+            }
         }
     }
 
@@ -152,6 +159,20 @@ struct HomeView: View {
         if !viewModel.suggestions.isEmpty { return viewModel.suggestions }
         if !viewModel.newReleases.isEmpty { return viewModel.newReleases }
         return viewModel.trending
+    }
+
+    private func prefetchVisibleArtwork() {
+        let songs =
+            [homeHeroSong, homeSecondarySong].compactMap { $0 }
+            + Array(viewModel.suggestions.prefix(8))
+            + Array(viewModel.newReleases.prefix(8))
+            + Array(viewModel.trending.prefix(8))
+        ArtworkPrefetcher.shared.prefetchSongs(songs, limit: 18, reason: "home songs")
+        ArtworkPrefetcher.shared.prefetchPlaylists(
+            Array((recentlyPlayed.playlists + viewModel.recentPlaylists).prefix(8)),
+            limit: 12,
+            reason: "home playlists"
+        )
     }
 
     @ViewBuilder

--- a/Twinskaraoke/Features/Home/NewView.swift
+++ b/Twinskaraoke/Features/Home/NewView.swift
@@ -47,6 +47,13 @@ struct NewView: View {
                 }
             }
             .refreshable { viewModel.fetchHomeData(force: true) }
+            .onChange(of: viewModel.isLoading) { _, isLoading in
+                guard !isLoading else { return }
+                prefetchVisibleArtwork()
+            }
+            .onAppear {
+                prefetchVisibleArtwork()
+            }
         }
     }
 
@@ -157,5 +164,18 @@ struct NewView: View {
         .padding(.horizontal, AM.Spacing.screenMargin)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("New.WideOverview")
+    }
+
+    private func prefetchVisibleArtwork() {
+        let songs =
+            [viewModel.newReleases.first, viewModel.trending.first].compactMap { $0 }
+            + Array(viewModel.newReleases.prefix(12))
+            + Array(viewModel.trending.prefix(8))
+        ArtworkPrefetcher.shared.prefetchSongs(songs, limit: 18, reason: "new songs")
+        ArtworkPrefetcher.shared.prefetchPlaylists(
+            Array((viewModel.recentPlaylists + recentlyPlayed.playlists).prefix(8)),
+            limit: 12,
+            reason: "new playlists"
+        )
     }
 }

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -87,7 +87,19 @@ struct PlaylistListView: View {
             if let apiURL {
                 loader.bootstrap(initial: playlists, urlBuilder: apiURL)
             }
+            prefetchArtwork()
         }
+        .onChange(of: displayedPlaylists.map(\.id)) { _, _ in
+            prefetchArtwork()
+        }
+    }
+
+    private func prefetchArtwork() {
+        ArtworkPrefetcher.shared.prefetchPlaylists(
+            Array(displayedPlaylists.prefix(12)),
+            limit: 12,
+            reason: "playlist list"
+        )
     }
 }
 
@@ -133,6 +145,11 @@ final class PlaylistListLoader: ObservableObject {
                 if !items.isEmpty {
                     let existing = Set(self.playlists.map(\.id))
                     self.playlists += items.filter { !existing.contains($0.id) }
+                    ArtworkPrefetcher.shared.prefetchPlaylists(
+                        Array(items.prefix(12)),
+                        limit: 12,
+                        reason: "playlist list page"
+                    )
                     self.canLoadMore = items.count >= self.pageSize
                 } else {
                     self.canLoadMore = false

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -89,7 +89,7 @@ struct PlaylistListView: View {
             }
             prefetchArtwork()
         }
-        .onChange(of: displayedPlaylists.map(\.id)) { _, _ in
+        .onChange(of: Array(displayedPlaylists.prefix(12)).map(\.id)) { _, _ in
             prefetchArtwork()
         }
     }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -198,6 +198,11 @@ struct DownloadedSongsView: View {
     private func refresh() {
         let cached = recentlyPlayed.playlists.flatMap { $0.songListDTOs ?? [] }
         let songs = downloads.downloadedSongs(knownSongs: cached)
+        ArtworkPrefetcher.shared.prefetchSongs(
+            Array(songs.prefix(18)),
+            limit: 18,
+            reason: "downloaded songs"
+        )
         if reduceMotion {
             localSongs = songs
         } else {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -584,6 +584,11 @@ final class LibrarySongsViewModel: ObservableObject {
         if !pageSongs.isEmpty || replace {
             self.page = page
         }
+        ArtworkPrefetcher.shared.prefetchSongs(
+            Array(pageSongs.prefix(18)),
+            limit: 18,
+            reason: replace ? "library songs initial" : "library songs page"
+        )
     }
 
     private static func decodeSongs(from data: Data?) -> [Song] {
@@ -688,6 +693,13 @@ struct LibrarySongsView: View {
         }
         .task {
             viewModel.loadIfNeeded()
+        }
+        .onChange(of: songs.map(\.id)) { _, _ in
+            ArtworkPrefetcher.shared.prefetchSongs(
+                Array(songs.prefix(18)),
+                limit: 18,
+                reason: "library visible songs"
+            )
         }
         .animation(listAnimation, value: songs.map(\.id))
         .animation(listAnimation, value: viewModel.sort)

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -694,7 +694,7 @@ struct LibrarySongsView: View {
         .task {
             viewModel.loadIfNeeded()
         }
-        .onChange(of: songs.map(\.id)) { _, _ in
+        .onChange(of: Array(songs.prefix(18)).map(\.id)) { _, _ in
             ArtworkPrefetcher.shared.prefetchSongs(
                 Array(songs.prefix(18)),
                 limit: 18,

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -76,11 +76,24 @@ struct PlaylistDetailView: View {
         .onAppear {
             loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
             RecentlyPlayedStore.shared.record(playlist)
+            prefetchArtwork(songs: songs)
+        }
+        .onChange(of: songs.map(\.id)) { _, _ in
+            prefetchArtwork(songs: songs)
         }
         .onChange(of: favorites.favoriteIDs) { _, _ in
             guard playlist.isFavorites else { return }
             loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
         }
+    }
+
+    private func prefetchArtwork(songs: [Song]) {
+        ArtworkPrefetcher.shared.prefetchPlaylists([playlist], limit: 6, reason: "playlist cover")
+        ArtworkPrefetcher.shared.prefetchSongs(
+            Array(songs.prefix(18)),
+            limit: 18,
+            reason: "playlist songs"
+        )
     }
 
     @ViewBuilder

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -78,7 +78,7 @@ struct PlaylistDetailView: View {
             RecentlyPlayedStore.shared.record(playlist)
             prefetchArtwork(songs: songs)
         }
-        .onChange(of: songs.map(\.id)) { _, _ in
+        .onChange(of: Array(songs.prefix(18)).map(\.id)) { _, _ in
             prefetchArtwork(songs: songs)
         }
         .onChange(of: favorites.favoriteIDs) { _, _ in

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -137,6 +137,7 @@ private struct PlayerLayoutMetrics {
 
 struct FullScreenPlayerView: View {
     @EnvironmentObject var audioManager: AudioPlayerManager
+    @ObservedObject private var popupPresentation = PopupPresentationState.shared
     @ObservedObject private var favorites = FavoritesManager.shared
     @Environment(\.dismiss) private var dismiss
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
@@ -263,7 +264,7 @@ struct FullScreenPlayerView: View {
         .onChange(of: audioManager.isRadioMode) { _, isRadio in
             if isRadio { showLyrics = false }
         }
-        .onChange(of: audioManager.showFullScreen) { _, isShown in
+        .onChange(of: popupPresentation.isExpanded) { _, isShown in
             if !isShown { dismiss() }
         }
         .onChange(of: audioManager.aiEnabled) { _, enabled in
@@ -495,7 +496,7 @@ struct FullScreenPlayerView: View {
     private var dismissBar: some View {
         Button {
             AppHaptic.light.play()
-            audioManager.showFullScreen = false
+            popupPresentation.isExpanded = false
         } label: {
             Capsule()
                 .fill(Color.primary.opacity(0.35))

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -496,7 +496,7 @@ struct FullScreenPlayerView: View {
     private var dismissBar: some View {
         Button {
             AppHaptic.light.play()
-            popupPresentation.isExpanded = false
+            popupPresentation.collapse()
         } label: {
             Capsule()
                 .fill(Color.primary.opacity(0.35))

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -118,6 +118,13 @@ struct SearchView: View {
                 guard currentSongID == pendingSongID else { return }
                 pendingSongID = nil
             }
+            .onChange(of: viewModel.results.map(\.id)) { _, _ in
+                ArtworkPrefetcher.shared.prefetchSongs(
+                    Array(viewModel.results.prefix(18)),
+                    limit: 18,
+                    reason: "search results"
+                )
+            }
             .onDisappear {
                 playbackTask?.cancel()
                 playbackTask = nil

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -118,7 +118,7 @@ struct SearchView: View {
                 guard currentSongID == pendingSongID else { return }
                 pendingSongID = nil
             }
-            .onChange(of: viewModel.results.map(\.id)) { _, _ in
+            .onChange(of: Array(viewModel.results.prefix(18)).map(\.id)) { _, _ in
                 ArtworkPrefetcher.shared.prefetchSongs(
                     Array(viewModel.results.prefix(18)),
                     limit: 18,

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SDWebImage
+import SDWebImageSwiftUI
+
+@MainActor
+final class ArtworkPrefetcher {
+    static let shared = ArtworkPrefetcher()
+
+    private let prefetcher = SDWebImagePrefetcher.shared
+    private var recentlyRequested: [String: Date] = [:]
+    private let reuseWindow: TimeInterval = 45
+
+    private init() {
+        prefetcher.maxConcurrentPrefetchCount = 2
+    }
+
+    func prefetchSongs(_ songs: [Song], limit: Int = 18, reason: String) {
+        prefetch(urls: songs.compactMap(\.imageURL), limit: limit, reason: reason)
+    }
+
+    func prefetchPlaylists(_ playlists: [Playlist], limit: Int = 12, reason: String) {
+        let urls = playlists.flatMap { playlist -> [URL] in
+            var values: [URL] = []
+            if let imageURL = playlist.imageURL {
+                values.append(imageURL)
+            }
+            values.append(contentsOf: playlist.initialMosaicArtworkURLs)
+            return values
+        }
+        prefetch(urls: urls, limit: limit, reason: reason)
+    }
+
+    func prefetch(urls: [URL], limit: Int = 18, reason: String) {
+        let selected = freshUniqueURLs(from: urls, limit: limit)
+        guard !selected.isEmpty else { return }
+
+        let context: [SDWebImageContextOption: Any] = [
+            .imageThumbnailPixelSize: NSValue(cgSize: ImageCacheConfig.thumbnailPixelSize),
+            .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
+            .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+            .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+        ]
+
+        DebugLogger.log(
+            "Prefetching \(selected.count) artwork images for \(reason)",
+            category: .cache
+        )
+
+        prefetcher.prefetchURLs(
+            selected,
+            options: [.lowPriority, .retryFailed, .scaleDownLargeImages],
+            context: context,
+            progress: nil
+        ) { finished, skipped in
+            DebugLogger.log(
+                "Artwork prefetch complete for \(reason): finished=\(finished), skipped=\(skipped)",
+                category: .cache
+            )
+        }
+    }
+
+    private func freshUniqueURLs(from urls: [URL], limit: Int) -> [URL] {
+        let now = Date()
+        recentlyRequested = recentlyRequested.filter { now.timeIntervalSince($0.value) < reuseWindow }
+
+        var seen = Set<String>()
+        var result: [URL] = []
+        for url in urls {
+            let key = url.absoluteString
+            guard seen.insert(key).inserted else { continue }
+            guard recentlyRequested[key] == nil else { continue }
+            recentlyRequested[key] = now
+            result.append(url)
+            if result.count == limit { break }
+        }
+        return result
+    }
+}

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -60,6 +60,7 @@ final class ArtworkPrefetcher {
     }
 
     private func freshUniqueURLs(from urls: [URL], limit: Int) -> [URL] {
+        guard limit > 0 else { return [] }
         let now = Date()
         recentlyRequested = recentlyRequested.filter { now.timeIntervalSince($0.value) < reuseWindow }
 

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -335,7 +335,6 @@ class AudioPlayerManager: ObservableObject {
     }
 
     @Published var queue: [Song] = []
-    @Published var showFullScreen = false
     @Published var isEditingProgress = false
     @Published var volume: Double = 1.0
     @Published var isUserScrubbingVolume: Bool = false

--- a/Twinskaraoke/Services/Radio/RadioController.swift
+++ b/Twinskaraoke/Services/Radio/RadioController.swift
@@ -97,6 +97,7 @@ final class RadioController: ObservableObject {
                 let (data, _) = try await URLSession.shared.data(from: Self.metadataURL)
                 let np = try JSONDecoder().decode(RadioNowPlaying.self, from: data)
                 nowPlaying = np
+                prefetchArtwork(from: np)
                 refreshErrorMessage = nil
                 lastUpdated = Date()
                 if AudioPlayerManager.shared.isRadioMode, let info = np.nowPlaying?.song {
@@ -131,6 +132,18 @@ final class RadioController: ObservableObject {
             info.artist ?? "",
             info.art ?? "",
         ].joined(separator: "|")
+    }
+
+    private func prefetchArtwork(from metadata: RadioNowPlaying) {
+        let urls =
+            [
+                metadata.nowPlaying?.song.art,
+                metadata.playingNext?.song.art,
+            ].compactMap { $0.flatMap(URL.init(string:)) }
+            + (metadata.songHistory ?? [])
+                .prefix(8)
+                .compactMap { $0.song.art.flatMap(URL.init(string:)) }
+        ArtworkPrefetcher.shared.prefetch(urls: urls, limit: 10, reason: "radio metadata")
     }
 
     private func applyUITestFixture() {


### PR DESCRIPTION
## Summary

This updates artwork loading and mini-player popup presentation behavior.

### Artwork loading

- Adds a shared `ArtworkPrefetcher` built on `SDWebImagePrefetcher`.
- Warms artwork using the same stable source URLs the UI already renders, avoiding dynamic per-view URL variants that can miss caches and slow image loading.
- Hooks prefetching into the main high-traffic surfaces: Home, New, playlist lists/details, downloaded songs, library songs, search results, and radio metadata.
- Increases the artwork memory cache budget so recently viewed covers survive normal navigation and scrolling better.
- Adds aggregate artwork load metrics so device testing can distinguish memory, disk, and network artwork loads.

### Popup presentation fix

- Moves the popup expanded/open state out of `AudioPlayerManager` and into a dedicated `PopupPresentationState`.
- Keeps LNPopupUI presentation state isolated from frequent playback updates such as current song, artwork, buffering, play state, and clock changes.
- Preserves the existing intentional mini-player touch gate, including visible-bar bounds checks and suppression for trailing mini-player controls.

## Root Cause

The full-player popup expansion state was stored on the playback manager, which is one of the noisiest observable objects in the app. Playback and artwork updates could cause broad view refreshes around the same object that LNPopupUI used for popup expansion, making unrelated UI interactions more likely to be interpreted as popup presentation changes.

The fix separates presentation state from playback state, so only the popup binding and explicit dismiss action can mutate the expanded state.

## Validation

Built successfully with:

```sh
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -destination generic/platform=iOS build CODE_SIGNING_ALLOWED=NO
```

Also verified locally that the Xcode project metadata and signing-related project changes are not included in this PR.

## Summary by Sourcery

Improve artwork loading performance and popup presentation stability by introducing centralized artwork prefetching and isolating popup expansion state from the audio player.

New Features:
- Add a shared ArtworkPrefetcher for songs, playlists, and arbitrary artwork URLs across high-traffic views.
- Add aggregate artwork load metrics to distinguish memory, disk, and network image loads during runtime.

Bug Fixes:
- Ensure full-screen player dismissal and popup open/close behavior rely on dedicated presentation state rather than noisy playback updates.

Enhancements:
- Increase SDWebImage in-memory artwork cache capacity to keep more recently viewed covers readily available.
- Integrate artwork prefetching into home, new releases, playlist lists/details, library songs, search results, downloaded songs, and radio metadata flows.
- Decouple LNPopupUI popup expansion state from AudioPlayerManager via a dedicated PopupPresentationState to reduce unintended presentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added proactive artwork prefetching across Home, New, Search, playlists, library, downloads, radio, and the full-screen player to reduce image loading delays.
  * Increased in-memory artwork cache capacity and introduced aggregated artwork load metrics (memory/disk/none) for monitoring.
* **Bug Fixes**
  * Improved mini-player/popup expand & dismiss reliability by separating popup expansion state from playback updates.
  * Refined “intentional open” gesture handling (hit testing, movement tolerance, and brief release grace) to prevent unintended popup openings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->