### PR TITLE
Fix download validation and Wi-Fi repair

### DIFF
--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -1093,12 +1093,15 @@ class AudioPlayerManager: ObservableObject {
                   playbackURL.isFileURL,
                   DownloadManager.shared.isDownloaded(song.id)
         {
-            DebugLogger.log(
-                "Removing suspect downloaded audio after premature end for \(song.id)",
-                category: .cache
-            )
-            DownloadManager.shared.remove(songID: song.id)
-            currentPlaybackURL = nil
+            if DownloadManager.shared.repairIfDownloadedFileIsBroken(for: song) {
+                currentPlaybackURL = nil
+            } else {
+                DebugLogger.log(
+                    "Ignoring stale premature-end callback for valid download \(song.id)",
+                    category: .playback
+                )
+                return true
+            }
         }
 
         if let remoteURL = song.audioURL {

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -199,6 +199,7 @@ final class DownloadManager: ObservableObject {
         tasks.removeAll()
         inProgress.removeAll()
         progress.removeAll()
+        pendingWiFiRepairs.removeAll()
 
         let fm = FileManager.default
         if let files = try? fm.contentsOfDirectory(at: cacheDir, includingPropertiesForKeys: nil) {
@@ -368,13 +369,20 @@ final class DownloadManager: ObservableObject {
     }
 
     private func discardBrokenDownloadAndScheduleRepair(for song: Song, reason: String) {
+        let repairSong: Song? = if song.audioURL != nil {
+            song
+        } else if let persistedSong = readMetadata(for: song.id), persistedSong.audioURL != nil {
+            persistedSong
+        } else {
+            nil
+        }
         DebugLogger.log(
             "Removing confirmed broken download for \(song.id): \(reason)",
             category: .cache
         )
         removeBrokenAudioFiles(for: song)
-        guard song.audioURL != nil else { return }
-        pendingWiFiRepairs[song.id] = song
+        guard let repairSong else { return }
+        pendingWiFiRepairs[song.id] = repairSong
         startPendingWiFiRepairsIfPossible()
     }
 
@@ -386,7 +394,9 @@ final class DownloadManager: ObservableObject {
         try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(song.id).mp3"))
         try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(song.id).source"))
         downloadedIDs.remove(song.id)
-        writeMetadata(for: song)
+        if song.audioURL != nil {
+            writeMetadata(for: song)
+        }
     }
 
     private func startNetworkMonitoring() {

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import Network
 import SwiftUI
 
 @MainActor
@@ -17,12 +18,18 @@ final class DownloadManager: ObservableObject {
     @Published private(set) var progress: [String: Double] = [:]
     private let cacheDir: URL
     private var tasks: [String: URLSessionDownloadTask] = [:]
+    private var pendingWiFiRepairs: [String: Song] = [:]
+    private var isWiFiAvailable = false
+    private let networkMonitor = NWPathMonitor()
+    private let networkMonitorQueue = DispatchQueue(label: "DownloadManager.NetworkMonitor")
+
     private init() {
         cacheDir = FileManager.default
             .urls(for: .documentDirectory, in: .userDomainMask).first!
             .appendingPathComponent("Downloads")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
         refreshExistingDownloads()
+        startNetworkMonitoring()
         DebugLogger.log(
             "DownloadManager init — \(downloadedIDs.count) existing downloads",
             category: .network
@@ -54,18 +61,31 @@ final class DownloadManager: ObservableObject {
         files(for: songID).source
     }
 
+    nonisolated static func durationAppearsComplete(
+        actualDuration: TimeInterval,
+        expectedDuration: TimeInterval?
+    ) -> Bool {
+        guard actualDuration.isFinite, actualDuration > 1.0 else { return false }
+        guard let expectedDuration, expectedDuration.isFinite, expectedDuration > 1.0 else {
+            return true
+        }
+
+        // Catalog durations are rounded and can differ slightly from decoded media duration.
+        // A longer file is complete; only a materially shorter file indicates truncation.
+        let tolerance = max(5.0, min(15.0, expectedDuration * 0.03))
+        return actualDuration + tolerance >= expectedDuration
+    }
+
     private nonisolated static func isValidDownloadedAudio(
         at url: URL,
         expectedDuration: TimeInterval? = nil
     ) -> Bool {
         guard AudioCacheStore.isPlayableAudioFile(at: url) else { return false }
-        guard let expectedDuration, expectedDuration.isFinite, expectedDuration > 1.0 else {
-            return true
-        }
         let actualDuration = AudioCacheStore.audioDuration(at: url)
-        guard actualDuration.isFinite, actualDuration > 1.0 else { return false }
-        let tolerance: TimeInterval = 2.0
-        return abs(actualDuration - expectedDuration) <= tolerance
+        return durationAppearsComplete(
+            actualDuration: actualDuration,
+            expectedDuration: expectedDuration
+        )
     }
 
     private nonisolated static func downloadedByteCount(at url: URL) -> Int {
@@ -84,6 +104,7 @@ final class DownloadManager: ObservableObject {
         guard let remote = song.audioURL else { return }
         if isDownloaded(song.id), playableURL(for: song) != nil { return }
         guard !isDownloading(song.id) else { return }
+        pendingWiFiRepairs.removeValue(forKey: song.id)
         DebugLogger.log("Starting download: \(song.id)", category: .network)
         inProgress.insert(song.id)
         progress[song.id] = 0
@@ -157,6 +178,7 @@ final class DownloadManager: ObservableObject {
 
     func remove(songID: String) {
         cancel(songID: songID)
+        pendingWiFiRepairs.removeValue(forKey: songID)
         let songFiles = files(for: songID)
         try? FileManager.default.removeItem(at: songFiles.directory)
         try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(songID).mp3"))
@@ -204,7 +226,13 @@ final class DownloadManager: ObservableObject {
             if hasValidDownload(for: songID) {
                 ids.insert(songID)
             } else {
-                try? fm.removeItem(at: entry)
+                let repairSong = readMetadata(for: songID)
+                if let repairSong, repairSong.audioURL != nil {
+                    removeBrokenAudioFiles(for: repairSong)
+                    pendingWiFiRepairs[songID] = repairSong
+                } else {
+                    try? fm.removeItem(at: entry)
+                }
             }
         }
         downloadedIDs = ids
@@ -220,16 +248,20 @@ final class DownloadManager: ObservableObject {
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
         guard Self.isValidDownloadedAudio(at: songFiles.audio, expectedDuration: expectedDuration) else {
             DebugLogger.log("Discarding invalid downloaded audio for \(song.id)", category: .cache)
-            remove(songID: song.id)
+            discardBrokenDownloadAndScheduleRepair(for: song, reason: "file validation failed")
             return nil
         }
         guard let cached = readSourceURL(for: song.id) else {
-            DebugLogger.log(
-                "Discarding downloaded audio without source metadata for \(song.id)",
-                category: .cache
-            )
-            remove(songID: song.id)
-            return nil
+            if let expected = song.audioURL {
+                writeSourceURL(expected, for: song.id)
+                writeMetadata(for: song)
+                downloadedIDs.insert(song.id)
+                DebugLogger.log(
+                    "Repaired missing download source metadata for \(song.id)",
+                    category: .cache
+                )
+            }
+            return songFiles.audio
         }
         guard let expected = song.audioURL?.absoluteString else {
             return songFiles.audio
@@ -239,10 +271,31 @@ final class DownloadManager: ObservableObject {
                 "Discarding downloaded audio for \(song.id) due to source mismatch",
                 category: .cache
             )
-            remove(songID: song.id)
+            discardBrokenDownloadAndScheduleRepair(for: song, reason: "source URL changed")
             return nil
         }
         return songFiles.audio
+    }
+
+    /// Returns true only when the on-disk download is conclusively invalid and was removed.
+    /// Playback callbacks alone are not evidence that a download is corrupt.
+    @discardableResult
+    func repairIfDownloadedFileIsBroken(for song: Song) -> Bool {
+        guard isDownloaded(song.id) else { return false }
+        let songFiles = files(for: song.id)
+        guard FileManager.default.fileExists(atPath: songFiles.audio.path) else {
+            discardBrokenDownloadAndScheduleRepair(for: song, reason: "audio file is missing")
+            return true
+        }
+        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+        guard !Self.isValidDownloadedAudio(
+            at: songFiles.audio,
+            expectedDuration: expectedDuration
+        ) else {
+            return false
+        }
+        discardBrokenDownloadAndScheduleRepair(for: song, reason: "file validation failed")
+        return true
     }
 
     func downloadedSongs(knownSongs: [Song] = []) -> [Song] {
@@ -270,10 +323,24 @@ final class DownloadManager: ObservableObject {
     private func hasValidDownload(for songID: String) -> Bool {
         let songFiles = files(for: songID)
         guard FileManager.default.fileExists(atPath: songFiles.audio.path) else { return false }
-        let metadataDuration = readMetadata(for: songID)?.duration ?? 0
+        let metadata = readMetadata(for: songID)
+        let metadataDuration = metadata?.duration ?? 0
         let expectedDuration = metadataDuration > 0 ? TimeInterval(metadataDuration) : nil
-        return readSourceURL(for: songID) != nil
-            && Self.isValidDownloadedAudio(at: songFiles.audio, expectedDuration: expectedDuration)
+        guard Self.isValidDownloadedAudio(
+            at: songFiles.audio,
+            expectedDuration: expectedDuration
+        ) else {
+            return false
+        }
+
+        guard let cachedSource = readSourceURL(for: songID) else {
+            if let remoteURL = metadata?.audioURL {
+                writeSourceURL(remoteURL, for: songID)
+            }
+            return true
+        }
+        guard let expectedSource = metadata?.audioURL?.absoluteString else { return true }
+        return cachedSource == expectedSource
     }
 
     private func readSourceURL(for songID: String) -> String? {
@@ -284,6 +351,63 @@ final class DownloadManager: ObservableObject {
         }
         let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         return normalized.isEmpty ? nil : normalized
+    }
+
+    private func writeSourceURL(_ remoteURL: URL, for songID: String) {
+        let source = sourceURL(for: songID)
+        ensureSongDirectory(for: songID)
+        try? FileManager.default.removeItem(at: source)
+        FileManager.default.createFile(
+            atPath: source.path,
+            contents: remoteURL.absoluteString.data(using: .utf8)
+        )
+    }
+
+    private func discardBrokenDownloadAndScheduleRepair(for song: Song, reason: String) {
+        DebugLogger.log(
+            "Removing confirmed broken download for \(song.id): \(reason)",
+            category: .cache
+        )
+        removeBrokenAudioFiles(for: song)
+        guard song.audioURL != nil else { return }
+        pendingWiFiRepairs[song.id] = song
+        startPendingWiFiRepairsIfPossible()
+    }
+
+    private func removeBrokenAudioFiles(for song: Song) {
+        cancel(songID: song.id)
+        let songFiles = files(for: song.id)
+        try? FileManager.default.removeItem(at: songFiles.audio)
+        try? FileManager.default.removeItem(at: songFiles.source)
+        try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(song.id).mp3"))
+        try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(song.id).source"))
+        downloadedIDs.remove(song.id)
+        writeMetadata(for: song)
+    }
+
+    private func startNetworkMonitoring() {
+        networkMonitor.pathUpdateHandler = { [weak self] path in
+            let hasWiFi = path.status == .satisfied && path.usesInterfaceType(.wifi)
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                isWiFiAvailable = hasWiFi
+                startPendingWiFiRepairsIfPossible()
+            }
+        }
+        networkMonitor.start(queue: networkMonitorQueue)
+    }
+
+    private func startPendingWiFiRepairsIfPossible() {
+        guard isWiFiAvailable, !pendingWiFiRepairs.isEmpty else { return }
+        let repairs = Array(pendingWiFiRepairs.values)
+        pendingWiFiRepairs.removeAll()
+        DebugLogger.log(
+            "Wi-Fi available — repairing \(repairs.count) broken download(s)",
+            category: .network
+        )
+        for song in repairs {
+            download(song: song)
+        }
     }
 
     private func writeMetadata(for song: Song) {

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -36,6 +36,10 @@ final class DownloadManager: ObservableObject {
         )
     }
 
+    deinit {
+        networkMonitor.cancel()
+    }
+
     private func files(for songID: String) -> SongFiles {
         let directory = cacheDir.appendingPathComponent(songID, isDirectory: true)
         return SongFiles(

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Download validation")
+struct DownloadManagerTests {
+    @Test("Catalog rounding and longer files are accepted")
+    func durationAcceptsHealthyFiles() {
+        #expect(
+            DownloadManager.durationAppearsComplete(
+                actualDuration: 198,
+                expectedDuration: 200
+            )
+        )
+        #expect(
+            DownloadManager.durationAppearsComplete(
+                actualDuration: 205,
+                expectedDuration: 200
+            )
+        )
+        #expect(
+            DownloadManager.durationAppearsComplete(
+                actualDuration: 180,
+                expectedDuration: nil
+            )
+        )
+    }
+
+    @Test("Truncated and unreadable files are rejected")
+    func durationRejectsBrokenFiles() {
+        #expect(
+            !DownloadManager.durationAppearsComplete(
+                actualDuration: 120,
+                expectedDuration: 200
+            )
+        )
+        #expect(
+            !DownloadManager.durationAppearsComplete(
+                actualDuration: 0,
+                expectedDuration: 200
+            )
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- validate downloaded audio from its header and measured duration before removing it
- tolerate catalog duration rounding and valid files that are longer than catalog metadata
- ignore stale premature-end callbacks when the downloaded file is healthy
- repair missing source metadata in place instead of deleting healthy audio
- retain metadata for confirmed broken downloads and automatically replace them when Wi-Fi is available
- add focused duration-classification tests

## Why

The premature playback-end recovery path treated an early AVEngine completion callback as proof that a downloaded file was corrupt. Crossfade handoff can produce that callback for healthy files, causing valid downloads to be removed. Existing duration validation also required an unnecessarily exact duration match.

The new path separates playback events from file-integrity evidence. Removal now requires explicit header/duration validation failure or a stale source URL.

## Impact

Healthy downloads remain available through crossfade handoffs. Confirmed truncated or stale downloads are removed from playback selection and re-downloaded automatically on Wi-Fi, with repair metadata retained across relaunches.

## Validation

- `xcodebuild -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- build succeeded
- focused test execution is currently blocked by pre-existing stale references in `SongModelTests` (`oss` and `downloadCoverImageURL`)

## Summary by Sourcery

Refine downloaded audio validation and introduce automatic Wi‑Fi-based repair for confirmed broken downloads while preserving healthy files across playback edge cases.

Bug Fixes:
- Relax duration validation to accept catalog rounding differences and healthy files longer than catalog metadata.
- Prevent valid downloaded audio from being deleted in response to stale premature-end playback callbacks.
- Repair missing download source metadata in place instead of discarding healthy audio files.
- Ensure stale or mismatched download metadata does not incorrectly mark valid downloads as broken.

Enhancements:
- Track pending download repairs and automatically re-download confirmed broken audio when Wi‑Fi becomes available using network path monitoring.
- Centralize download integrity checks into reusable helpers that distinguish conclusively broken files from healthy ones.
- Retain and refresh per-song metadata when removing corrupted audio so repairs can be scheduled intelligently.

Tests:
- Add focused tests for duration classification to verify healthy versus truncated audio detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback recovery for cached audio that is incomplete or corrupted, including attempts to repair downloaded files before falling back.
  * Strengthened cached-audio validation with duration-aware tolerance to reduce false removals.
  * Deferred repair work until Wi‑Fi is available when needed, and improved handling when cached sources are missing or don’t match expected content.
* **Tests**
  * Added tests covering the duration-based completeness validation logic for cached audio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->