### PR TITLE
Align profile storage limits with the website

### DIFF
--- a/Twinskaraoke/Features/Account/StorageSection.swift
+++ b/Twinskaraoke/Features/Account/StorageSection.swift
@@ -4,36 +4,36 @@ struct StorageSection: View {
     let limits: UploadLimits
     private static let byteFormatter: ByteCountFormatter = {
         let f = ByteCountFormatter()
-        f.allowedUnits = [.useMB, .useGB]
+        f.allowedUnits = [.useBytes, .useKB, .useMB, .useGB]
         f.countStyle = .binary
         return f
     }()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Library")
+            Text("Storage & Limits")
                 .font(.headline)
             VStack(spacing: 14) {
                 StorageMeterRow(
+                    icon: "music.note",
+                    label: "Songs Uploaded",
+                    valueText: "\(limits.currentSongCount)/\(limits.maxSongs)",
+                    ratio: ratio(limits.currentSongCount, limits.maxSongs),
+                    barHeight: 4
+                )
+                Divider()
+                StorageMeterRow(
                     icon: "internaldrive",
-                    label: "Storage",
+                    label: "Storage Used",
                     valueText: storageValueText,
                     ratio: storageRatio,
                     barHeight: 6
                 )
                 Divider()
                 StorageMeterRow(
-                    icon: "music.note",
-                    label: "Songs",
-                    valueText: "\(limits.currentSongCount) / \(limits.maxSongs)",
-                    ratio: ratio(limits.currentSongCount, limits.maxSongs),
-                    barHeight: 4
-                )
-                Divider()
-                StorageMeterRow(
                     icon: "music.note.list",
                     label: "Playlists",
-                    valueText: "\(limits.currentPlaylistCount) / \(limits.playlistLimit)",
+                    valueText: "\(limits.currentPlaylistCount)/\(limits.playlistLimit)",
                     ratio: ratio(limits.currentPlaylistCount, limits.playlistLimit),
                     barHeight: 4
                 )
@@ -54,7 +54,9 @@ struct StorageSection: View {
     }
 
     private var storageValueText: String {
-        let used = Self.byteFormatter.string(fromByteCount: limits.usedStorageBytes)
+        let used = limits.usedStorageBytes == 0
+            ? "0 B"
+            : Self.byteFormatter.string(fromByteCount: limits.usedStorageBytes)
         let max = Self.byteFormatter.string(fromByteCount: limits.maxStorageBytes)
         return "\(used) / \(max)"
     }
@@ -98,10 +100,10 @@ private struct SongsPerPlaylistRow: View {
                 .font(.subheadline.bold())
                 .foregroundStyle(.secondary)
                 .frame(width: 24, height: 28)
-            Text("Songs per playlist")
+            Text("Songs per Playlist")
                 .font(.subheadline)
             Spacer()
-            Text("up to \(limit)")
+            Text("\(limit)")
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(.secondary)
         }


### PR DESCRIPTION
## Summary

- rename the profile section to **Storage & Limits**
- match the website's row labels, ordering, and quota formatting
- display zero storage usage as `0 B`
- allow byte and kilobyte units for small non-zero storage usage

## Root cause

The profile labeled values returned by `/api/user/upload-limits` as general library statistics. This made uploaded-song and storage quotas appear inconsistent with the Library screen, which also includes virtual and saved content.

## Impact

The iOS profile now presents the same upload and playlist limits as the website, including **Songs Uploaded**, **Storage Used**, **Playlists**, and **Songs per Playlist**.

## Validation

- Swift syntax parse completed successfully
- `git diff --check` completed successfully

## Summary by Sourcery

Align the account Storage section UI and labels with the website’s storage and upload limits view.

New Features:
- Display a Songs Uploaded meter alongside storage and playlist limits in the profile Storage & Limits section.

Enhancements:
- Rename the Library section to Storage & Limits and update row labels and value formatting to match the website, including Songs per Playlist text.
- Adjust storage formatting to show zero usage as 0 B and allow byte/KB units for small non-zero values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the account storage panel to a new “Storage & Limits” layout with clearer labels and reordered stats.
  * Refined how storage values are shown, including tighter formatting and clearer zero-storage display.
  * Adjusted the “Songs per Playlist” row to use simpler wording and display the limit more directly.

* **Bug Fixes**
  * Improved storage unit display so smaller values now show in bytes and kilobytes as well as larger units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->