### PR TITLE
Refresh playlist download menu state

### DIFF
--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -364,20 +364,14 @@ struct PlaylistActionsMenuItems: View {
     @ObservedObject private var savedStore: SavedPlaylistsStore = .shared
     @ObservedObject private var downloads = DownloadManager.shared
 
-    private var pendingSongs: [Song] {
-        songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
-    }
-
-    private var inFlightCount: Int {
-        songs.filter { downloads.isDownloading($0.id) }.count
-    }
-
-    private var pendingCount: Int {
-        pendingSongs.count
-    }
-
-    private var allDownloaded: Bool {
-        !songs.isEmpty && pendingCount == 0 && inFlightCount == 0
+    private var downloadState: (pendingSongs: [Song], inFlightCount: Int) {
+        songs.reduce(into: (pendingSongs: [], inFlightCount: 0)) { state, song in
+            if downloads.isDownloading(song.id) {
+                state.inFlightCount += 1
+            } else if !downloads.isDownloaded(song.id) {
+                state.pendingSongs.append(song)
+            }
+        }
     }
 
     private var canSaveToLibrary: Bool {
@@ -389,6 +383,12 @@ struct PlaylistActionsMenuItems: View {
     }
 
     var body: some View {
+        let downloadState = downloadState
+        let pendingCount = downloadState.pendingSongs.count
+        let allDownloaded = !songs.isEmpty
+            && pendingCount == 0
+            && downloadState.inFlightCount == 0
+
         if !songs.isEmpty {
             Button {
                 AppHaptic.selection.play()
@@ -423,8 +423,8 @@ struct PlaylistActionsMenuItems: View {
         }
 
         if !songs.isEmpty {
-            if inFlightCount > 0 {
-                Label("Downloading \(inFlightCount)…", systemImage: "arrow.down.circle")
+            if downloadState.inFlightCount > 0 {
+                Label("Downloading \(downloadState.inFlightCount)…", systemImage: "arrow.down.circle")
             } else if allDownloaded {
                 Button(role: .destructive) {
                     AppHaptic.warning.play()
@@ -437,7 +437,7 @@ struct PlaylistActionsMenuItems: View {
             } else {
                 Button {
                     AppHaptic.success.play()
-                    for s in pendingSongs {
+                    for s in downloadState.pendingSongs {
                         DownloadManager.shared.download(song: s)
                     }
                 } label: {

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -362,8 +362,16 @@ struct PlaylistActionsMenuItems: View {
     let playlist: Playlist
     let songs: [Song]
     @ObservedObject private var savedStore: SavedPlaylistsStore = .shared
-    private let pendingSongs: [Song]
-    private let inFlightCount: Int
+    @ObservedObject private var downloads = DownloadManager.shared
+
+    private var pendingSongs: [Song] {
+        songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
+    }
+
+    private var inFlightCount: Int {
+        songs.filter { downloads.isDownloading($0.id) }.count
+    }
+
     private var pendingCount: Int {
         pendingSongs.count
     }
@@ -378,15 +386,6 @@ struct PlaylistActionsMenuItems: View {
 
     private var isSaved: Bool {
         savedStore.isSaved(playlist)
-    }
-
-    init(playlist: Playlist, songs: [Song]) {
-        self.playlist = playlist
-        self.songs = songs
-
-        let downloads = DownloadManager.shared
-        pendingSongs = songs.filter { !downloads.isDownloaded($0.id) && !downloads.isDownloading($0.id) }
-        inFlightCount = songs.filter { downloads.isDownloading($0.id) }.count
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

- observe `DownloadManager` from the playlist actions menu
- recompute pending and in-progress songs whenever download state changes
- update the menu to **Remove Downloads** immediately after all playlist songs finish downloading

## Root cause

The menu captured pending-song and in-flight counts once during initialization. Download completion published new state, but the menu did not observe it, so the stale **Download** action remained until navigation recreated the playlist view.

## Impact

Playlist download actions now stay synchronized with completed and active downloads without requiring users to leave and reopen the playlist.

## Validation

- reproduced the original stale-menu behavior and confirmed the fix in the app
- Swift syntax parse completed successfully
- `git diff --check` completed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the playlist download indicators to refresh live as download progress changes.
  * “Downloading …” and pending song counts now reflect the current download status rather than a previously captured snapshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->