### PR TITLE
Improve artwork, downloads, and iOS media controls

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -92,7 +92,7 @@ private final class PopupPlaybackState: ObservableObject {
     private func scheduleSnapshotPublish() {
         guard publishTask == nil else { return }
         publishTask = Task { @MainActor [weak self] in
-            await Task.yield()
+            try? await Task.sleep(nanoseconds: 33_000_000)
             guard let self else { return }
             let nextSnapshot = pendingSnapshot
             publishTask = nil

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -55,8 +55,11 @@ struct RemoteArtworkImage: View {
             if let lowResURL, !fullLoaded {
                 WebImage(
                     url: lowResURL,
-                    options: [.retryFailed, .scaleDownLargeImages, .fromCacheOnly],
-                    context: [.imageThumbnailPixelSize: NSValue(cgSize: CGSize(width: 120, height: 120))]
+                    options: [.scaleDownLargeImages, .fromCacheOnly],
+                    context: [
+                        .imageThumbnailPixelSize: NSValue(cgSize: CGSize(width: 120, height: 120)),
+                        .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
+                    ]
                 ) { image in
                     image
                         .resizable()
@@ -68,7 +71,7 @@ struct RemoteArtworkImage: View {
                     Color.clear
                 }
             }
-            if let url, !loadFailed {
+            if let url, !loadFailed, !ArtworkFailureBackoff.shared.isBlocked(url) {
                 WebImage(
                     url: url,
                     options: ImageCacheConfig.defaultOptions,
@@ -85,8 +88,8 @@ struct RemoteArtworkImage: View {
                 } placeholder: {
                     Color.clear
                 }
-                .onFailure { _ in
-                    markFinishedAfterFailure(for: url)
+                .onFailure { error in
+                    markFinishedAfterFailure(for: url, error: error)
                 }
                 .onSuccess { _, _, cacheType in
                     ArtworkLoadMetrics.shared.record(cacheType: cacheType)
@@ -106,11 +109,17 @@ struct RemoteArtworkImage: View {
                 fullLoaded = true
                 loadFailed = false
             }
+            ArtworkFailureBackoff.shared.clear(loadedURL)
         }
     }
 
-    private func markFinishedAfterFailure(for failedURL: URL) {
+    private func markFinishedAfterFailure(for failedURL: URL, error: Error) {
         guard url == failedURL, !loadFailed else { return }
+        DebugLogger.log(
+            "Artwork load failed for \(failedURL.absoluteString): \(error.localizedDescription)",
+            category: .cache
+        )
+        ArtworkFailureBackoff.shared.recordFailure(failedURL)
         evictFailedImageCache(for: failedURL)
         Task { @MainActor in
             guard url == failedURL, !loadFailed else { return }
@@ -142,6 +151,35 @@ struct RemoteArtworkImage: View {
         let h = max(displaySize.height, 1) * scale
         let cap = ImageCacheConfig.thumbnailPixelSize
         return CGSize(width: min(w, cap.width), height: min(h, cap.height))
+    }
+}
+
+final class ArtworkFailureBackoff {
+    static let shared = ArtworkFailureBackoff()
+
+    private let cooldown: TimeInterval = 300
+    private let lock = NSLock()
+    private var blockedUntil: [URL: Date] = [:]
+
+    func isBlocked(_ url: URL) -> Bool {
+        let now = Date()
+        lock.lock()
+        defer { lock.unlock() }
+        blockedUntil = blockedUntil.filter { $0.value > now }
+        guard let until = blockedUntil[url] else { return false }
+        return until > now
+    }
+
+    func recordFailure(_ url: URL) {
+        lock.lock()
+        blockedUntil[url] = Date().addingTimeInterval(cooldown)
+        lock.unlock()
+    }
+
+    func clear(_ url: URL) {
+        lock.lock()
+        blockedUntil.removeValue(forKey: url)
+        lock.unlock()
     }
 }
 

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -115,8 +115,9 @@ struct RemoteArtworkImage: View {
 
     private func markFinishedAfterFailure(for failedURL: URL, error: Error) {
         guard url == failedURL, !loadFailed else { return }
+        let safeURL = Self.redactedURLString(failedURL)
         DebugLogger.log(
-            "Artwork load failed for \(failedURL.absoluteString): \(error.localizedDescription)",
+            "Artwork load failed for \(safeURL): \(error.localizedDescription)",
             category: .cache
         )
         ArtworkFailureBackoff.shared.recordFailure(failedURL)
@@ -126,7 +127,20 @@ struct RemoteArtworkImage: View {
             withOptionalAnimation(AppMotion.spring(response: 0.12, dampingFraction: 0.9)) {
                 loadFailed = true
             }
+            try? await Task.sleep(nanoseconds: ArtworkFailureBackoff.shared.cooldownNanoseconds)
+            guard url == failedURL, loadFailed else { return }
+            ArtworkFailureBackoff.shared.clear(failedURL)
+            withOptionalAnimation(AppMotion.spring(response: 0.12, dampingFraction: 0.9)) {
+                loadFailed = false
+            }
         }
+    }
+
+    private static func redactedURLString(_ url: URL) -> String {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.query = nil
+        components?.fragment = nil
+        return components?.string ?? url.lastPathComponent
     }
 
     private func evictFailedImageCache(for failedURL: URL) {
@@ -160,6 +174,10 @@ final class ArtworkFailureBackoff {
     private let cooldown: TimeInterval = 300
     private let lock = NSLock()
     private var blockedUntil: [URL: Date] = [:]
+
+    var cooldownNanoseconds: UInt64 {
+        UInt64(cooldown * 1_000_000_000)
+    }
 
     func isBlocked(_ url: URL) -> Bool {
         let now = Date()

--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 #if canImport(UIKit)
+    import SDWebImage
     import SDWebImageSwiftUI
 #endif
 
@@ -65,7 +66,12 @@ struct PlayerAmbientBackground: View {
                 WebImage(
                     url: artworkURL,
                     options: ImageCacheConfig.defaultOptions,
-                    context: [.imageThumbnailPixelSize: pixelSize]
+                    context: [
+                        .imageThumbnailPixelSize: pixelSize,
+                        .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
+                        .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+                        .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+                    ]
                 ) { image in
                     image
                         .resizable()
@@ -165,8 +171,13 @@ struct PlayerAmbientBackground: View {
             let pixelSize = NSValue(cgSize: CGSize(width: 96, height: 96))
             SDWebImageManager.shared.loadImage(
                 with: url,
-                options: [.retryFailed, .scaleDownLargeImages],
-                context: [.imageThumbnailPixelSize: pixelSize],
+                options: [.scaleDownLargeImages],
+                context: [
+                    .imageThumbnailPixelSize: pixelSize,
+                    .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
+                    .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+                    .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+                ],
                 progress: nil
             ) { image, _, _, _, _, _ in
                 guard let image else { return }

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -7,10 +7,6 @@ struct BrowseSongCollectionView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var scrollOffset: CGFloat = 0
 
-    private var showsArtwork: Bool {
-        songs.count <= 200
-    }
-
     private func usesWideOverview(availableWidth: CGFloat) -> Bool {
         AM.Layout.usesWideCanvas(
             horizontalSizeClass: horizontalSizeClass,
@@ -157,7 +153,7 @@ struct BrowseSongCollectionView: View {
                         Button {
                             play(song)
                         } label: {
-                            SongRow(song: song, size: .regular, showsArtwork: showsArtwork)
+                            SongRow(song: song, size: .regular, showsArtwork: true)
                                 .padding(.horizontal, rowHorizontalPadding)
                                 .padding(.vertical, 6)
                                 .contentShape(Rectangle())
@@ -168,7 +164,7 @@ struct BrowseSongCollectionView: View {
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
                         .accessibilityHint("Starts playback.")
                         .accessibilityIdentifier("BrowseSongCollection.song.\(song.id)")
-                        Divider().padding(.leading, rowHorizontalPadding + (showsArtwork ? 60 : 12))
+                        Divider().padding(.leading, rowHorizontalPadding + 60)
                     }
                 }
             }

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -171,11 +171,10 @@ struct ArtistDetailView: View {
                     }
                     .padding(.horizontal)
                     if !songs.isEmpty {
-                        let showsRowArtwork = songs.count <= 200
                         actionButtons
                         LazyVStack(spacing: 0) {
                             ForEach(songs) { song in
-                                ArtistSongRow(song: song, showsArtwork: showsRowArtwork) {
+                                ArtistSongRow(song: song, showsArtwork: true) {
                                     play(song)
                                 }
                                 .padding(.horizontal)

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -93,7 +93,7 @@ struct LibraryView: View {
                 recentSongsViewModel.loadIfNeeded()
             }
             .onChange(of: favorites.favoriteIDs) { _, _ in
-                viewModel.fetchFavoriteSongs()
+                viewModel.fetchFavoriteSongs(force: true)
             }
             .animation(
                 reduceMotion ? nil : AppMotion.spring(response: 0.34, dampingFraction: 0.84),
@@ -233,8 +233,8 @@ struct LibraryView: View {
     private func refreshLibrary() {
         AppHaptic.selection.play()
         favorites.loadIfNeeded()
-        viewModel.fetchPlaylists()
-        viewModel.fetchFavoriteSongs()
+        viewModel.fetchPlaylists(force: true)
+        viewModel.fetchFavoriteSongs(force: true)
         recentSongsViewModel.refresh()
     }
 }
@@ -374,7 +374,6 @@ struct LibrarySongsView: View {
         let songs = viewModel.displayedSongs
         let isSearching = !viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-        let showsRowArtwork = songs.count <= 200
         List {
             if viewModel.isLoading, songs.isEmpty {
                 skeletonRows
@@ -395,7 +394,7 @@ struct LibrarySongsView: View {
                         Button {
                             play(song, context: songs)
                         } label: {
-                            SongRow(song: song, size: .regular, showsArtwork: showsRowArtwork)
+                            SongRow(song: song, size: .regular, showsArtwork: true)
                                 .padding(.vertical, 6)
                                 .contentShape(Rectangle())
                                 .songRowAccessibility(song: song) {
@@ -674,7 +673,7 @@ struct PlaylistsGridScreen: View {
         }
         .task { userManager.loadIfNeeded() }
         .onChange(of: favorites.favoriteIDs) { _, _ in
-            viewModel.fetchFavoriteSongs()
+            viewModel.fetchFavoriteSongs(force: true)
         }
         .animation(
             reduceMotion ? nil : AppMotion.spring(response: 0.34, dampingFraction: 0.84),

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -203,7 +203,6 @@ struct PlaylistDetailView: View {
         rowHorizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) -> some View {
         if !songs.isEmpty {
-            let showsRowArtwork = songs.count <= 200
             VStack(spacing: 0) {
                 if !isWideOverview {
                     actionButtons(songs: songs)
@@ -213,7 +212,7 @@ struct PlaylistDetailView: View {
                         Button {
                             play(song, context: songs)
                         } label: {
-                            PlaylistRow(song: song, showsArtwork: showsRowArtwork, horizontalPadding: rowHorizontalPadding)
+                            PlaylistRow(song: song, showsArtwork: true, horizontalPadding: rowHorizontalPadding)
                                 .contentShape(Rectangle())
                                 .songRowAccessibility(song: song) {
                                     play(song, context: songs)
@@ -368,4 +367,3 @@ private struct ScrollOffsetKey: PreferenceKey {
 private func quantizedScrollOffset(_ offset: CGFloat) -> CGFloat {
     (offset / 8).rounded() * 8
 }
-

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -174,7 +174,7 @@ struct RandomSongsView: View {
                         } label: {
                             PlaylistRow(
                                 song: song,
-                                showsArtwork: songs.count <= 200,
+                                showsArtwork: true,
                                 horizontalPadding: rowHorizontalPadding
                             )
                             .contentShape(Rectangle())

--- a/Twinskaraoke/Models/Library/ArtistsViewModel.swift
+++ b/Twinskaraoke/Models/Library/ArtistsViewModel.swift
@@ -9,7 +9,7 @@ final class ArtistsViewModel: ObservableObject {
     private var page = 0
     private let pageSize = 25
     func fetchInitial() {
-        guard artists.isEmpty else { return }
+        guard artists.isEmpty, !isLoading else { return }
         page = 0
         canLoadMore = true
         load(reset: true)
@@ -29,6 +29,7 @@ final class ArtistsViewModel: ObservableObject {
     }
 
     private func load(reset: Bool) {
+        guard !isLoading else { return }
         let startIndex = page * pageSize
         let urlString =
             "\(StorageHost.api)/api/artists?startIndex=\(startIndex)&pageSize=\(pageSize)&search=&sortBy=Name&sortDescending=False"
@@ -80,13 +81,14 @@ final class ArtistDetailViewModel: ObservableObject {
         var request = URLRequest(url: url)
         GuestIdentity.applyIfNeeded(to: &request)
         URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
-            Task { @MainActor [weak self, data] in
-                self?.applyArtistDetailResponse(data)
+            Task { @MainActor [weak self, data, id] in
+                self?.applyArtistDetailResponse(data, id: id)
             }
         }.resume()
     }
 
-    private func applyArtistDetailResponse(_ data: Data?) {
+    private func applyArtistDetailResponse(_ data: Data?, id: String) {
+        guard loadedID == id else { return }
         defer { isLoading = false }
 
         guard let data else {

--- a/Twinskaraoke/Models/Library/GalleryModels.swift
+++ b/Twinskaraoke/Models/Library/GalleryModels.swift
@@ -39,12 +39,16 @@ struct GalleryArt: Codable, Identifiable, Equatable {
     }
 }
 
-class ArtGalleryViewModel: ObservableObject {
+@MainActor
+final class ArtGalleryViewModel: ObservableObject {
     @Published var artists: [GalleryArtist] = []
     @Published var isLoading = false
     @Published var loadFailed = false
+    private var hasLoaded = false
+
     func fetch(force: Bool = false) {
-        guard force || artists.isEmpty else { return }
+        guard !isLoading else { return }
+        guard force || !hasLoaded else { return }
         guard let url = URL(string: "\(StorageHost.api)/api/media/artists?loadArts=true")
         else { return }
         loadFailed = false
@@ -52,20 +56,24 @@ class ArtGalleryViewModel: ObservableObject {
         var request = URLRequest(url: url)
         GuestIdentity.applyIfNeeded(to: &request)
         URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
-            guard let self else { return }
-            if let data, let decoded = try? JSONDecoder().decode([GalleryArtist].self, from: data) {
-                let filtered = decoded.filter { ($0.arts?.count ?? 0) > 0 }
+            let filtered = data.flatMap { data -> [GalleryArtist]? in
+                guard let decoded = try? JSONDecoder().decode([GalleryArtist].self, from: data) else {
+                    return nil
+                }
+                return decoded
+                    .filter { ($0.arts?.count ?? 0) > 0 }
                     .sorted { ($0.arts?.count ?? 0) > ($1.arts?.count ?? 0) }
-                DispatchQueue.main.async {
-                    self.artists = filtered
-                    self.loadFailed = false
-                    self.isLoading = false
+            }
+            Task { @MainActor [weak self, filtered] in
+                guard let self else { return }
+                if let filtered {
+                    artists = filtered
+                    hasLoaded = true
+                    loadFailed = false
+                } else {
+                    loadFailed = artists.isEmpty
                 }
-            } else {
-                DispatchQueue.main.async {
-                    self.loadFailed = self.artists.isEmpty
-                    self.isLoading = false
-                }
+                isLoading = false
             }
         }.resume()
     }

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -6,15 +6,20 @@ final class LibrarySongsViewModel: ObservableObject {
     @Published var songs: [Song] = []
     @Published var isLoading = false
     @Published var isLoadingMore = false
-    @Published var sort: LibrarySongSort = .recentlyAdded
-    @Published var searchText = ""
+    @Published var sort: LibrarySongSort = .recentlyAdded {
+        didSet { rebuildDisplayedSongs() }
+    }
+    @Published var searchText = "" {
+        didSet { rebuildDisplayedSongs() }
+    }
+    @Published private(set) var displayedSongs: [Song] = []
     private var hasLoaded = false
     private var canLoadMore = true
     private var page = 1
     private var requestToken = 0
     private let pageSize = 40
 
-    var displayedSongs: [Song] {
+    private func rebuildDisplayedSongs() {
         let sorted: [Song] = switch sort {
         case .recentlyAdded:
             songs
@@ -29,8 +34,11 @@ final class LibrarySongsViewModel: ObservableObject {
         }
 
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return sorted }
-        return sorted.filter { song in
+        guard !query.isEmpty else {
+            displayedSongs = sorted
+            return
+        }
+        displayedSongs = sorted.filter { song in
             song.title.localizedCaseInsensitiveContains(query)
                 || song.displayArtist.localizedCaseInsensitiveContains(query)
                 || song.displayTitle.localizedCaseInsensitiveContains(query)
@@ -142,6 +150,7 @@ final class LibrarySongsViewModel: ObservableObject {
             let existing = Set(songs.map(\.id))
             songs += pageSongs.filter { !existing.contains($0.id) }
         }
+        rebuildDisplayedSongs()
 
         canLoadMore = pageSongs.count == pageSize
         if !pageSongs.isEmpty || replace {

--- a/Twinskaraoke/Models/Library/PlaylistsViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistsViewModel.swift
@@ -6,6 +6,9 @@ final class PlaylistsViewModel: ObservableObject {
     @Published var playlists: [Playlist] = []
     @Published var favoriteSongs: [Song] = []
     @Published var isLoading = false
+    @Published var isLoadingFavorites = false
+    private var hasLoadedPlaylists = false
+    private var hasLoadedFavoriteSongs = false
 
     var favoritesPlaylist: Playlist {
         let favoriteCount = max(favoriteSongs.count, FavoritesManager.shared.favoriteIDs.count)
@@ -34,7 +37,9 @@ final class PlaylistsViewModel: ObservableObject {
         return [favoritesPlaylist] + combined
     }
 
-    func fetchPlaylists() {
+    func fetchPlaylists(force: Bool = false) {
+        guard !isLoading else { return }
+        guard force || !hasLoadedPlaylists else { return }
         isLoading = true
         Task { [weak self] in
             guard let self else { return }
@@ -47,20 +52,30 @@ final class PlaylistsViewModel: ObservableObject {
                     sortDescending: false
                 )
                 playlists = loaded
+                hasLoadedPlaylists = true
                 RecentlyAddedTracker.shared.registerIfNew(loaded.map(\.id))
             } catch {
-                playlists = []
+                if force || playlists.isEmpty {
+                    playlists = []
+                }
             }
         }
     }
 
-    func fetchFavoriteSongs() {
+    func fetchFavoriteSongs(force: Bool = false) {
+        guard !isLoadingFavorites else { return }
+        guard force || !hasLoadedFavoriteSongs else { return }
+        isLoadingFavorites = true
         Task { [weak self] in
             guard let self else { return }
+            defer { isLoadingFavorites = false }
             do {
                 favoriteSongs = try await KaraokeAPIClient.favoriteSongs()
+                hasLoadedFavoriteSongs = true
             } catch {
-                favoriteSongs = []
+                if force || favoriteSongs.isEmpty {
+                    favoriteSongs = []
+                }
             }
         }
     }

--- a/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
+++ b/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
@@ -9,6 +9,8 @@ final class VideoGalleryViewModel: ObservableObject {
     @Published var canLoadMore = true
     private var page = 1
     private let pageSize = 25
+    private var loadGeneration = 0
+    private var activeTask: URLSessionDataTask?
 
     func fetchInitial() {
         guard videos.isEmpty, !isLoading else { return }
@@ -18,6 +20,9 @@ final class VideoGalleryViewModel: ObservableObject {
     }
 
     func refresh() {
+        activeTask?.cancel()
+        activeTask = nil
+        isLoading = false
         page = 1
         canLoadMore = true
         load(reset: true)
@@ -40,22 +45,37 @@ final class VideoGalleryViewModel: ObservableObject {
         }
         isLoading = true
         if reset { errorMessage = nil }
+        loadGeneration += 1
+        let generation = loadGeneration
         var request = URLRequest(url: url)
         GuestIdentity.applyIfNeeded(to: &request)
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
-            Task { @MainActor [weak self, data, response, error, reset] in
-                self?.applyVideosResponse(data, response: response, error: error, reset: reset)
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            Task { @MainActor [weak self, data, response, error, reset, generation] in
+                self?.applyVideosResponse(
+                    data,
+                    response: response,
+                    error: error,
+                    reset: reset,
+                    generation: generation
+                )
             }
-        }.resume()
+        }
+        activeTask = task
+        task.resume()
     }
 
     private func applyVideosResponse(
         _ data: Data?,
         response: URLResponse?,
         error: Error?,
-        reset: Bool
+        reset: Bool,
+        generation: Int
     ) {
-        defer { isLoading = false }
+        guard generation == loadGeneration else { return }
+        defer {
+            isLoading = false
+            activeTask = nil
+        }
 
         if let error {
             errorMessage = error.localizedDescription

--- a/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
+++ b/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
@@ -11,7 +11,7 @@ final class VideoGalleryViewModel: ObservableObject {
     private let pageSize = 25
 
     func fetchInitial() {
-        guard videos.isEmpty else { return }
+        guard videos.isEmpty, !isLoading else { return }
         page = 1
         canLoadMore = true
         load(reset: true)
@@ -31,6 +31,7 @@ final class VideoGalleryViewModel: ObservableObject {
     }
 
     private func load(reset: Bool) {
+        guard !isLoading else { return }
         let urlString =
             "\(StorageHost.api)/api/videos?page=\(page)&pageSize=\(pageSize)&sortBy=UploadedAt&sortDescending=True"
         guard let url = URL(string: urlString) else {
@@ -86,7 +87,7 @@ final class SimilarVideosViewModel: ObservableObject {
     @Published var isLoading = false
 
     func fetch(excluding currentID: String) {
-        guard videos.isEmpty else { return }
+        guard videos.isEmpty, !isLoading else { return }
         let urlString =
             "\(StorageHost.api)/api/videos?startIndex=0&pageSize=20&sortBy=CreatedAt&sortDescending=true"
         guard let url = URL(string: urlString) else { return }

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -176,8 +176,10 @@ final class GenresViewModel: ObservableObject {
     @Published var canLoadMore = true
     private var page = 0
     private let pageSize = 50
+    private var hasLoaded = false
     private var genreDetailOrder: [String] = []
     private let maxCachedGenreDetails = 30
+    private var detailRequestsInFlight = Set<String>()
     private var genresNeedingFallback = Set<String>()
     private var fallbackCancellable: AnyCancellable?
 
@@ -206,6 +208,7 @@ final class GenresViewModel: ObservableObject {
     }
 
     func loadIfNeeded() {
+        guard !hasLoaded, !isLoading else { return }
         fetchPage(0, replace: true)
     }
 
@@ -223,6 +226,8 @@ final class GenresViewModel: ObservableObject {
     }
 
     private func fetchPage(_ page: Int, replace: Bool) {
+        guard replace || (!isLoadingMore && canLoadMore) else { return }
+        guard !isLoading else { return }
         guard
             let url = URL(
                 string:
@@ -231,6 +236,7 @@ final class GenresViewModel: ObservableObject {
         else { return }
         if replace {
             isLoading = true
+            detailRequestsInFlight.removeAll()
         } else {
             isLoadingMore = true
         }
@@ -257,6 +263,7 @@ final class GenresViewModel: ObservableObject {
         let filtered = list.filter { $0.songCount > 0 }
         if replace {
             genres = filtered
+            hasLoaded = true
         } else {
             let existing = Set(genres.map(\.id))
             genres += filtered.filter { !existing.contains($0.id) }
@@ -270,7 +277,9 @@ final class GenresViewModel: ObservableObject {
 
     private func fetchDetail(for genre: GenreSummary) {
         if allSongs[genre.id] != nil { return }
+        guard detailRequestsInFlight.insert(genre.id).inserted else { return }
         guard let url = URL(string: "\(StorageHost.api)/api/genres/\(genre.id)") else {
+            detailRequestsInFlight.remove(genre.id)
             return
         }
         var request = URLRequest(url: url)
@@ -283,6 +292,7 @@ final class GenresViewModel: ObservableObject {
     }
 
     private func applyGenreDetailResponse(_ data: Data?, for genre: GenreSummary) {
+        defer { detailRequestsInFlight.remove(genre.id) }
         guard let data,
               let detail = try? JSONDecoder().decode(GenreDetail.self, from: data),
               let songs = detail.songs
@@ -325,7 +335,7 @@ final class SearchCategorySongsViewModel: ObservableObject {
     }
 
     func loadIfNeeded() {
-        guard !hasLoaded else { return }
+        guard !hasLoaded, !isLoading else { return }
         hasLoaded = true
         fetch()
     }

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -11,11 +11,11 @@ final class ArtworkPrefetcher {
     private let reuseWindow: TimeInterval = 45
 
     private init() {
-        prefetcher.maxConcurrentPrefetchCount = 2
+        prefetcher.maxConcurrentPrefetchCount = 1
     }
 
     func prefetchSongs(_ songs: [Song], limit: Int = 18, reason: String) {
-        prefetch(urls: songs.compactMap(\.imageURL), limit: limit, reason: reason)
+        prefetch(urls: songs.compactMap(\.imageURL), limit: min(limit, 8), reason: reason)
     }
 
     func prefetchPlaylists(_ playlists: [Playlist], limit: Int = 12, reason: String) {
@@ -27,11 +27,11 @@ final class ArtworkPrefetcher {
             values.append(contentsOf: playlist.initialMosaicArtworkURLs)
             return values
         }
-        prefetch(urls: urls, limit: limit, reason: reason)
+        prefetch(urls: urls, limit: min(limit, 6), reason: reason)
     }
 
     func prefetch(urls: [URL], limit: Int = 18, reason: String) {
-        let selected = freshUniqueURLs(from: urls, limit: limit)
+        let selected = freshUniqueURLs(from: urls, limit: adjustedLimit(limit, reason: reason))
         guard !selected.isEmpty else { return }
 
         let context: [SDWebImageContextOption: Any] = [
@@ -48,7 +48,7 @@ final class ArtworkPrefetcher {
 
         prefetcher.prefetchURLs(
             selected,
-            options: [.lowPriority, .retryFailed, .scaleDownLargeImages],
+            options: [.lowPriority, .scaleDownLargeImages],
             context: context,
             progress: nil
         ) { finished, skipped in
@@ -57,6 +57,17 @@ final class ArtworkPrefetcher {
                 category: .cache
             )
         }
+    }
+
+    private func adjustedLimit(_ limit: Int, reason: String) -> Int {
+        guard limit > 0 else { return 0 }
+        if DownloadManager.shared.hasActiveQueue {
+            return min(limit, reason == "radio metadata" ? 3 : 2)
+        }
+        if AudioPlayerManager.shared.isPlaying {
+            return min(limit, reason == "radio metadata" ? 5 : 4)
+        }
+        return limit
     }
 
     private func freshUniqueURLs(from urls: [URL], limit: Int) -> [URL] {
@@ -70,6 +81,7 @@ final class ArtworkPrefetcher {
             let key = url.absoluteString
             guard seen.insert(key).inserted else { continue }
             guard recentlyRequested[key] == nil else { continue }
+            guard !ArtworkFailureBackoff.shared.isBlocked(url) else { continue }
             recentlyRequested[key] = now
             result.append(url)
             if result.count == limit { break }

--- a/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
+++ b/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
@@ -6,20 +6,27 @@ import SDWebImage
 
 enum ImageCacheConfig {
     private static var didApply = false
+    private static let thumbnailDiskCacheResetKey = "image-cache.thumbnail-disk-store-reset.v2"
+
     static func applyLimits() {
         guard !didApply else { return }
         didApply = true
         let cfg = SDImageCache.shared.config
-        cfg.maxMemoryCost = 64 * 1024 * 1024
-        cfg.maxMemoryCount = 96
-        cfg.maxDiskSize = 256 * 1024 * 1024
+        cfg.maxMemoryCost = 32 * 1024 * 1024
+        cfg.maxMemoryCount = 64
+        cfg.maxDiskSize = 128 * 1024 * 1024
         cfg.shouldCacheImagesInMemory = true
         cfg.shouldUseWeakMemoryCache = true
         cfg.maxDiskAge = 30 * 24 * 60 * 60
         SDImageCache.shared.clearMemory()
+        if !UserDefaults.standard.bool(forKey: thumbnailDiskCacheResetKey) {
+            SDImageCache.shared.clearDisk {
+                UserDefaults.standard.set(true, forKey: thumbnailDiskCacheResetKey)
+            }
+        }
         let dl = SDWebImageDownloader.shared
 
-        dl.config.maxConcurrentDownloads = 4
+        dl.config.maxConcurrentDownloads = 2
         dl.requestModifier = SDWebImageDownloaderRequestModifier { request in
             var r = request
             r.cachePolicy = .returnCacheDataElseLoad
@@ -39,7 +46,6 @@ enum ImageCacheConfig {
     static let thumbnailPixelSize = CGSize(width: 480, height: 480)
 
     static let defaultOptions: SDWebImageOptions = [
-        .retryFailed,
         .scaleDownLargeImages,
     ]
 }

--- a/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
+++ b/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
@@ -6,7 +6,6 @@ import SDWebImage
 
 enum ImageCacheConfig {
     private static var didApply = false
-    private static let thumbnailDiskCacheResetKey = "image-cache.thumbnail-disk-store-reset.v2"
 
     static func applyLimits() {
         guard !didApply else { return }
@@ -19,11 +18,6 @@ enum ImageCacheConfig {
         cfg.shouldUseWeakMemoryCache = true
         cfg.maxDiskAge = 30 * 24 * 60 * 60
         SDImageCache.shared.clearMemory()
-        if !UserDefaults.standard.bool(forKey: thumbnailDiskCacheResetKey) {
-            SDImageCache.shared.clearDisk {
-                UserDefaults.standard.set(true, forKey: thumbnailDiskCacheResetKey)
-            }
-        }
         let dl = SDWebImageDownloader.shared
 
         dl.config.maxConcurrentDownloads = 2

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -935,6 +935,12 @@ final class AVEnginePlayback {
         } else {
             mainPlayer.pause()
         }
+        // File playback uses AVAudioEngine rather than AVPlayer. Pausing only the
+        // AVAudioPlayerNode leaves the engine running, and iOS Control Center can
+        // keep treating the session as actively playing even when Now Playing rate
+        // is 0.0. Pausing the engine makes app, lock-screen, and Control Center
+        // play/pause state agree; resume() restarts it through startEngineIfNeeded().
+        engine.pause()
     }
 
     func resume() {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2330,6 +2330,12 @@ class AudioPlayerManager: ObservableObject {
             return performOnMain {
                 DebugLogger.log("Remote pause command received", category: .playback)
                 if !self.isPlaybackRequested {
+                    // Some iOS surfaces can send pauseCommand from a stale paused
+                    // visual state even when the user is pressing the center play
+                    // button. Treat that stale pause as resume; removing this
+                    // fallback made lock-screen/control state diverge in device
+                    // testing, so this intentionally preserves the working
+                    // system-integration behavior over strict command semantics.
                     return self.resumeCurrentPlayback(source: "remote.pauseAsPlay") ? .success : .commandFailed
                 }
                 return self.pauseCurrentPlayback(source: "remote.pause") ? .success : .commandFailed
@@ -2473,9 +2479,18 @@ class AudioPlayerManager: ObservableObject {
         // media type matches public Swift player integrations such as Expo's
         // MediaController:
         // https://github.com/expo/expo/blob/main/packages/expo-audio/ios/MediaController.swift
+        let originalArtists = song.originalArtists?
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+        let artist: String
+        if let originalArtists, !originalArtists.isEmpty {
+            artist = originalArtists
+        } else {
+            artist = song.artistName
+        }
         var info: [String: Any] = [
             MPMediaItemPropertyTitle: song.title,
-            MPMediaItemPropertyArtist: song.originalArtists?.joined(separator: ", ") ?? "",
+            MPMediaItemPropertyArtist: artist,
             MPMediaItemPropertyMediaType: MPMediaType.music.rawValue,
             MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.audio.rawValue,
             MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? 1.0 : 0.0,
@@ -2502,7 +2517,7 @@ class AudioPlayerManager: ObservableObject {
         artworkTask = nil
         #if canImport(UIKit)
             if let cached = AudioPlayerManager.artworkCache.object(forKey: url as NSURL) {
-                applyArtwork(cached, for: songID)
+                applyArtwork(cached, for: songID, artworkURL: url)
                 return
             }
             let pixelSize = NSValue(
@@ -2532,18 +2547,19 @@ class AudioPlayerManager: ObservableObject {
                         * squareImage.scale * 4
                 )
                 AudioPlayerManager.artworkCache.setObject(squareImage, forKey: url as NSURL, cost: cost)
-                applyArtwork(squareImage, for: songID)
+                applyArtwork(squareImage, for: songID, artworkURL: url)
             }
         #endif
     }
 
     #if canImport(UIKit)
-        private func applyArtwork(_ image: UIImage, for songID: String?) {
+        private func applyArtwork(_ image: UIImage, for songID: String?, artworkURL requestedURL: URL) {
             let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
             DispatchQueue.main.async { [weak self] in
                 guard let self,
                       let song = self.currentSong,
-                      song.id == songID
+                      song.id == songID,
+                      self.artworkURL == requestedURL
                 else { return }
                 var info = self.makeNowPlayingInfo(
                     for: song,

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2293,10 +2293,18 @@ class AudioPlayerManager: ObservableObject {
             if Thread.isMainThread {
                 return MainActor.assumeIsolated { action() }
             }
-            DispatchQueue.main.async {
-                _ = MainActor.assumeIsolated { action() }
+            // MediaPlayer can deliver remote-command callbacks off the main thread.
+            // Return only after the playback state and Now Playing info have changed;
+            // returning .success before the main actor update lets Control Center redraw
+            // from stale state and can leave the play/pause button out of sync.
+            // Apple documents the public integration path as MPRemoteCommandCenter
+            // handlers plus MPNowPlayingInfoCenter metadata/rate updates:
+            // https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/MediaPlaybackGuide/Contents/Resources/en.lproj/RefiningTheUserExperience/RefiningTheUserExperience.html
+            var status: MPRemoteCommandHandlerStatus = .commandFailed
+            DispatchQueue.main.sync {
+                status = MainActor.assumeIsolated { action() }
             }
-            return .success
+            return status
         }
 
         cc.playCommand.removeTarget(nil)
@@ -2458,10 +2466,18 @@ class AudioPlayerManager: ObservableObject {
         includeExistingArtwork: Bool
     ) -> [String: Any] {
         let currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
+        // Keep the system surfaces driven by the public Now Playing contract:
+        // metadata, elapsed time, duration, and playback rate. Do not use
+        // MPNowPlayingInfoCenter.playbackState here; on iOS it logs an ignored
+        // MediaRemote private-entitlement warning for third-party apps. The audio
+        // media type matches public Swift player integrations such as Expo's
+        // MediaController:
+        // https://github.com/expo/expo/blob/main/packages/expo-audio/ios/MediaController.swift
         var info: [String: Any] = [
             MPMediaItemPropertyTitle: song.title,
             MPMediaItemPropertyArtist: song.originalArtists?.joined(separator: ", ") ?? "",
             MPMediaItemPropertyMediaType: MPMediaType.music.rawValue,
+            MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.audio.rawValue,
             MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? 1.0 : 0.0,
             MPNowPlayingInfoPropertyDefaultPlaybackRate: 1.0,
         ]

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2321,6 +2321,9 @@ class AudioPlayerManager: ObservableObject {
             guard let self else { return .commandFailed }
             return performOnMain {
                 DebugLogger.log("Remote pause command received", category: .playback)
+                if !self.isPlaybackRequested {
+                    return self.resumeCurrentPlayback(source: "remote.pauseAsPlay") ? .success : .commandFailed
+                }
                 return self.pauseCurrentPlayback(source: "remote.pause") ? .success : .commandFailed
             }
         }
@@ -2390,24 +2393,14 @@ class AudioPlayerManager: ObservableObject {
             updateRemoteCommandAvailability()
             return
         }
-        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-        info[MPMediaItemPropertyTitle] = song.title
-        info[MPMediaItemPropertyArtist] = song.originalArtists?.joined(separator: ", ") ?? ""
-        info[MPMediaItemPropertyMediaType] = MPMediaType.music.rawValue
-        if isRadioMode {
-            info[MPNowPlayingInfoPropertyIsLiveStream] = true
-            info[MPMediaItemPropertyPlaybackDuration] = nil
-            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = nil
-        } else {
-            info[MPNowPlayingInfoPropertyIsLiveStream] = false
-            info[MPMediaItemPropertyPlaybackDuration] = playbackDuration
-            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = playbackTime
-        }
-        info[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
-        info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
         let targetArt = isRadioMode ? radioArtworkURL : song.imageURL
-        if reloadArtwork || artworkURL != targetArt {
-            info[MPMediaItemPropertyArtwork] = nil
+        let shouldReloadArtwork = reloadArtwork || artworkURL != targetArt
+        let info = makeNowPlayingInfo(
+            for: song,
+            elapsed: isRadioMode ? nil : playbackTime,
+            includeExistingArtwork: !shouldReloadArtwork
+        )
+        if shouldReloadArtwork {
             artworkURL = targetArt
             #if canImport(UIKit)
                 if reloadArtwork { nowPlayingArtwork = nil }
@@ -2416,8 +2409,8 @@ class AudioPlayerManager: ObservableObject {
                 loadArtworkAsync(from: targetArt)
             }
         }
-        updateRemoteCommandAvailability()
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        updateRemoteCommandAvailability()
         DebugLogger.log(
             "Now Playing updated: rate=\(isPlaying ? 1.0 : 0.0), playing=\(isPlaying), buffering=\(isBuffering)",
             category: .playback
@@ -2436,10 +2429,15 @@ class AudioPlayerManager: ObservableObject {
         let playbackRate = isPlaying ? 1.0 : 0.0
         guard roundedSecond != lastNowPlayingElapsedSecond
             || playbackRate != lastNowPlayingPlaybackRate else { return }
-        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed
-        info[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
-        info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
+        guard let song = currentSong else {
+            updateNowPlayingInfo(reloadArtwork: false)
+            return
+        }
+        let info = makeNowPlayingInfo(
+            for: song,
+            elapsed: isRadioMode ? nil : elapsed,
+            includeExistingArtwork: true
+        )
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
         if lastLoggedNowPlayingElapsedSecond == nil
             || roundedSecond - (lastLoggedNowPlayingElapsedSecond ?? 0) >= 15
@@ -2452,6 +2450,34 @@ class AudioPlayerManager: ObservableObject {
         }
         lastNowPlayingElapsedSecond = roundedSecond
         lastNowPlayingPlaybackRate = playbackRate
+    }
+
+    private func makeNowPlayingInfo(
+        for song: Song,
+        elapsed: TimeInterval?,
+        includeExistingArtwork: Bool
+    ) -> [String: Any] {
+        let currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
+        var info: [String: Any] = [
+            MPMediaItemPropertyTitle: song.title,
+            MPMediaItemPropertyArtist: song.originalArtists?.joined(separator: ", ") ?? "",
+            MPMediaItemPropertyMediaType: MPMediaType.music.rawValue,
+            MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? 1.0 : 0.0,
+            MPNowPlayingInfoPropertyDefaultPlaybackRate: 1.0,
+        ]
+        if includeExistingArtwork,
+           let artwork = currentInfo?[MPMediaItemPropertyArtwork]
+        {
+            info[MPMediaItemPropertyArtwork] = artwork
+        }
+        if isRadioMode {
+            info[MPNowPlayingInfoPropertyIsLiveStream] = true
+        } else {
+            info[MPNowPlayingInfoPropertyIsLiveStream] = false
+            info[MPMediaItemPropertyPlaybackDuration] = playbackDuration
+            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed ?? playbackTime
+        }
+        return info
     }
 
     private func loadArtworkAsync(from url: URL) {
@@ -2499,11 +2525,18 @@ class AudioPlayerManager: ObservableObject {
         private func applyArtwork(_ image: UIImage, for songID: String?) {
             let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
             DispatchQueue.main.async { [weak self] in
-                guard let self, currentSong?.id == songID else { return }
-                var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+                guard let self,
+                      let song = self.currentSong,
+                      song.id == songID
+                else { return }
+                var info = self.makeNowPlayingInfo(
+                    for: song,
+                    elapsed: self.isRadioMode ? nil : self.playbackTime,
+                    includeExistingArtwork: false
+                )
                 info[MPMediaItemPropertyArtwork] = artwork
                 MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-                nowPlayingArtwork = image
+                self.nowPlayingArtwork = image
             }
         }
     #endif

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -31,280 +31,6 @@ enum RepeatMode {
     }
 }
 
-private final class AudioDownloadSession: NSObject, URLSessionDataDelegate {
-    private let songID: String
-    private let partialURL: URL
-    private let finalURL: URL
-    private let minimumPlayableBytes = 512 * 1024
-    private var remoteURL: URL?
-    private var fileHandle: FileHandle?
-    private var task: URLSessionDataTask?
-    private var session: URLSession?
-    private var hasReportedPlayableFallback = false
-    private var expectedContentLength: Int64 = NSURLSessionTransferSizeUnknown
-    private let stateLock = NSLock()
-    private var isCancelled = false
-    private var retryCount = 0
-    private let maxRetries = 3
-    private var retryTimer: Timer?
-    var onCompletion: ((URL?) -> Void)?
-    var onPlayableFallbackReady: ((URL) -> Void)?
-
-    private var partialFileSize: Int {
-        (try? partialURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-    }
-
-    init(songID: String) {
-        self.songID = songID
-        let songFiles = AudioCacheStore.files(for: songID)
-        finalURL = songFiles.main
-        partialURL = songFiles.mainPartial
-        super.init()
-    }
-
-    func start(from remoteURL: URL) {
-        self.remoteURL = remoteURL
-        try? FileManager.default.removeItem(at: partialURL)
-        FileManager.default.createFile(atPath: partialURL.path, contents: nil)
-        fileHandle = try? FileHandle(forWritingTo: partialURL)
-        guard fileHandle != nil else {
-            try? FileManager.default.removeItem(at: partialURL)
-            AudioCacheStore.writeMainSourceURL(nil, for: songID)
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
-            return
-        }
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-        configuration.urlCache = nil
-        configuration.waitsForConnectivity = false
-        configuration.timeoutIntervalForRequest = 30
-        configuration.timeoutIntervalForResource = 300
-        session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-        task = session?.dataTask(with: remoteURL)
-        task?.resume()
-    }
-
-    func cancel() {
-        stateLock.lock()
-        isCancelled = true
-        task?.cancel()
-        session?.invalidateAndCancel()
-        fileHandle?.closeFile()
-        fileHandle = nil
-        retryTimer?.invalidate()
-        retryTimer = nil
-        stateLock.unlock()
-        try? FileManager.default.removeItem(at: partialURL)
-        AudioCacheStore.writeMainSourceURL(nil, for: songID)
-    }
-
-    private func reportPlayableFallbackIfPossible() {
-        guard !hasReportedPlayableFallback else { return }
-        guard
-            let fileSize = try? partialURL.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-            fileSize >= minimumPlayableBytes
-        else { return }
-        guard AVEnginePlayback.hasValidAudioHeader(at: partialURL) else { return }
-        hasReportedPlayableFallback = true
-        let fallbackURL = partialURL
-        DispatchQueue.main.async { [weak self] in
-            self?.onPlayableFallbackReady?(fallbackURL)
-        }
-    }
-
-    func urlSession(
-        _: URLSession, dataTask _: URLSessionDataTask,
-        didReceive response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
-    ) {
-        guard AudioCacheStore.acceptsAudioResponse(response) else {
-            DebugLogger.log(
-                "Audio cache download rejected for \(songID): \(response.mimeType ?? "unknown MIME")",
-                category: .cache
-            )
-            completionHandler(.cancel)
-            return
-        }
-        if let http = response as? HTTPURLResponse {
-            expectedContentLength = response.expectedContentLength
-            DebugLogger.log(
-                "Audio cache download response for \(songID): HTTP \(http.statusCode), expectedBytes=\(response.expectedContentLength)",
-                category: .cache
-            )
-        }
-        completionHandler(.allow)
-    }
-
-    func urlSession(_: URLSession, dataTask _: URLSessionDataTask, didReceive data: Data) {
-        stateLock.lock()
-        let cancelled = isCancelled
-        if !cancelled {
-            fileHandle?.write(data)
-        }
-        stateLock.unlock()
-        guard !cancelled else { return }
-        reportPlayableFallbackIfPossible()
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        stateLock.lock()
-        let cancelled = isCancelled
-        fileHandle?.closeFile()
-        fileHandle = nil
-        stateLock.unlock()
-        session.invalidateAndCancel()
-        guard !cancelled else { return }
-        if let error {
-            if shouldRetry(error: error) {
-                scheduleRetry()
-                return
-            }
-            DebugLogger.log(
-                "Audio cache download failed for \(songID): bytes=\(partialFileSize), error=\(error.localizedDescription), retries=\(retryCount)",
-                category: .cache
-            )
-            try? FileManager.default.removeItem(at: partialURL)
-            AudioCacheStore.writeMainSourceURL(nil, for: songID)
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
-            return
-        }
-        if let http = task.response as? HTTPURLResponse, !(200 ... 299).contains(http.statusCode) {
-            if shouldRetryHTTPStatus(http.statusCode) {
-                scheduleRetry()
-                return
-            }
-            DebugLogger.log(
-                "Audio cache download failed for \(songID): HTTP \(http.statusCode), bytes=\(partialFileSize)",
-                category: .cache
-            )
-            try? FileManager.default.removeItem(at: partialURL)
-            AudioCacheStore.writeMainSourceURL(nil, for: songID)
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
-            return
-        }
-        guard let validRemoteURL = remoteURL else {
-            DebugLogger.log(
-                "Audio cache download failed for \(songID): missing remote URL, bytes=\(partialFileSize)",
-                category: .cache
-            )
-            try? FileManager.default.removeItem(at: partialURL)
-            AudioCacheStore.writeMainSourceURL(nil, for: songID)
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
-            return
-        }
-        guard AudioCacheStore.isPlayableAudioFile(at: partialURL) else {
-            DebugLogger.log(
-                "Audio cache download produced unplayable file for \(songID): bytes=\(partialFileSize)",
-                category: .cache
-            )
-            try? FileManager.default.removeItem(at: partialURL)
-            AudioCacheStore.writeMainSourceURL(nil, for: songID)
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
-            return
-        }
-        try? FileManager.default.removeItem(at: finalURL)
-        let completedBytes = partialFileSize
-        if expectedContentLength > 0, Int64(completedBytes) < expectedContentLength {
-            DebugLogger.log(
-                "Audio cache download incomplete for \(songID): bytes=\(completedBytes), expectedBytes=\(expectedContentLength)",
-                category: .cache
-            )
-            try? FileManager.default.removeItem(at: partialURL)
-            AudioCacheStore.writeMainSourceURL(nil, for: songID)
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
-            return
-        }
-        do {
-            try FileManager.default.moveItem(at: partialURL, to: finalURL)
-            AudioCacheStore.writeMainSourceURL(validRemoteURL, for: songID)
-            DebugLogger.log(
-                "Audio cache download completed for \(songID): bytes=\(completedBytes)",
-                category: .cache
-            )
-            let final = finalURL
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(final) }
-        } catch {
-            DebugLogger.log(
-                "Audio cache download move failed for \(songID): \(error.localizedDescription)",
-                category: .cache
-            )
-            try? FileManager.default.removeItem(at: partialURL)
-            AudioCacheStore.writeMainSourceURL(nil, for: songID)
-            DispatchQueue.main.async { [weak self] in self?.onCompletion?(nil) }
-        }
-    }
-
-    private func shouldRetry(error: Error) -> Bool {
-        guard retryCount < maxRetries else { return false }
-        let nsError = error as NSError
-        if nsError.domain == NSURLErrorDomain {
-            switch nsError.code {
-            case NSURLErrorTimedOut,
-                 NSURLErrorCannotConnectToHost,
-                 NSURLErrorNetworkConnectionLost,
-                 NSURLErrorDNSLookupFailed,
-                 NSURLErrorNotConnectedToInternet:
-                return true
-            default:
-                return false
-            }
-        }
-        return false
-    }
-
-    private func shouldRetryHTTPStatus(_ statusCode: Int) -> Bool {
-        guard retryCount < maxRetries else { return false }
-        switch statusCode {
-        case 408, 429, 500, 502, 503, 504:
-            return true
-        default:
-            return false
-        }
-    }
-
-    private func scheduleRetry() {
-        retryCount += 1
-        let delay = min(pow(2.0, Double(retryCount)), 8.0)
-        DebugLogger.log(
-            "Scheduling retry \(retryCount)/\(maxRetries) for \(songID) after \(delay)s",
-            category: .cache
-        )
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            retryTimer?.invalidate()
-            retryTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
-                guard let self else { return }
-                guard !isCancelled, let remoteURL else { return }
-                DebugLogger.log(
-                    "Retrying download for \(songID) (attempt \(retryCount))",
-                    category: .cache
-                )
-                retryTimer = nil
-                hasReportedPlayableFallback = false
-                expectedContentLength = NSURLSessionTransferSizeUnknown
-                try? FileManager.default.removeItem(at: partialURL)
-                FileManager.default.createFile(atPath: partialURL.path, contents: nil)
-                fileHandle = try? FileHandle(forWritingTo: partialURL)
-                guard fileHandle != nil else {
-                    try? FileManager.default.removeItem(at: partialURL)
-                    AudioCacheStore.writeMainSourceURL(nil, for: songID)
-                    onCompletion?(nil)
-                    return
-                }
-                let configuration = URLSessionConfiguration.ephemeral
-                configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-                configuration.urlCache = nil
-                configuration.waitsForConnectivity = false
-                configuration.timeoutIntervalForRequest = 30
-                configuration.timeoutIntervalForResource = 300
-                session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-                task = session?.dataTask(with: remoteURL)
-                task?.resume()
-            }
-        }
-    }
-}
-
 private enum AudioEffect {
     case karaoke, bassEnhance, vocalEnhance, instrumentalEnhance
 }
@@ -589,6 +315,7 @@ class AudioPlayerManager: ObservableObject {
     #endif
     private var lastNowPlayingElapsedSecond: Int?
     private var lastNowPlayingPlaybackRate: Double?
+    private var lastLoggedNowPlayingElapsedSecond: Int?
     private static func loadCrossfadeSeconds() -> Double {
         let raw = UserDefaults.standard.object(forKey: "nk.crossfadeSeconds") as? Double ?? 6.0
         return min(15, max(1, raw))
@@ -621,7 +348,6 @@ class AudioPlayerManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var artworkURL: URL?
     private var artworkTask: (any SDWebImageOperation)?
-    private var downloadSession: AudioDownloadSession?
     private var currentPlaybackURL: URL?
     private var instrumentalTask: Task<Void, Never>?
     private var backgroundAnalysisRetryTask: Task<Void, Never>?
@@ -637,7 +363,6 @@ class AudioPlayerManager: ObservableObject {
     private var handlingAudioSessionInterruption = false
 
     #if canImport(UIKit)
-        private var bgTaskID: UIBackgroundTaskIdentifier = .invalid
         private var trackTransitionTaskID: UIBackgroundTaskIdentifier = .invalid
     #endif
 
@@ -838,9 +563,6 @@ class AudioPlayerManager: ObservableObject {
             .sink { [weak self] _ in self?.handleMediaServicesReset() }
             .store(in: &cancellables)
         #if canImport(UIKit)
-            NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
-                .sink { [weak self] _ in self?.handleBackgroundTransition() }
-                .store(in: &cancellables)
             NotificationCenter.default.publisher(for: UIApplication.didReceiveMemoryWarningNotification)
                 .sink { [weak self] _ in self?.handleMemoryWarning() }
                 .store(in: &cancellables)
@@ -857,22 +579,14 @@ class AudioPlayerManager: ObservableObject {
             existing.player.removeTimeObserver(existing.token)
         }
         artworkTask?.cancel()
-        downloadSession?.cancel()
         cacheCompressionTask?.cancel()
         radioPlayer?.pause()
         #if canImport(UIKit)
-            let backgroundTaskID = bgTaskID
             let transitionTaskID = trackTransitionTaskID
-            bgTaskID = .invalid
             trackTransitionTaskID = .invalid
-            if backgroundTaskID != .invalid || transitionTaskID != .invalid {
+            if transitionTaskID != .invalid {
                 Task { @MainActor in
-                    if backgroundTaskID != .invalid {
-                        UIApplication.shared.endBackgroundTask(backgroundTaskID)
-                    }
-                    if transitionTaskID != .invalid {
-                        UIApplication.shared.endBackgroundTask(transitionTaskID)
-                    }
+                    UIApplication.shared.endBackgroundTask(transitionTaskID)
                 }
             }
         #endif
@@ -881,23 +595,6 @@ class AudioPlayerManager: ObservableObject {
     private func cancelBackgroundAnalysisRetry() {
         backgroundAnalysisRetryTask?.cancel()
         backgroundAnalysisRetryTask = nil
-    }
-
-    private func cancelDownloadSession() {
-        downloadSession?.cancel()
-        downloadSession = nil
-        #if canImport(UIKit)
-            endAudioCacheBackgroundTask()
-        #endif
-    }
-
-    private func completeDownloadSession(_ session: AudioDownloadSession?) -> Bool {
-        guard let session, downloadSession === session else { return false }
-        downloadSession = nil
-        #if canImport(UIKit)
-            endAudioCacheBackgroundTask()
-        #endif
-        return true
     }
 
     private func localPlaybackFileURL(for song: Song) -> URL? {
@@ -1275,7 +972,6 @@ class AudioPlayerManager: ObservableObject {
             category: .playback
         )
         cancelPendingTransitionWork()
-        cancelDownloadSession()
         instrumentalTask?.cancel()
         instrumentalTask = nil
         cancelBackgroundAnalysisRetry()
@@ -1477,7 +1173,6 @@ class AudioPlayerManager: ObservableObject {
                 originalQueue = []
             }
         }
-        cancelDownloadSession()
         let fileURL = localPlaybackFileURL(for: song)
         if let fileURL, let stems = stemsForCachedAIMode(song: song) {
             instrumentalTask?.cancel()
@@ -1528,50 +1223,6 @@ class AudioPlayerManager: ObservableObject {
                 triggerBackgroundAnalysis(for: song)
             }
         }
-        let songID = song.id
-        let session = AudioDownloadSession(songID: songID)
-        downloadSession = session
-        session.onPlayableFallbackReady = { [weak self, weak session] fallbackURL in
-            guard let self else { return }
-            guard downloadSession === session else { return }
-            guard let currentSong, currentSong.id == songID else { return }
-            switchSilentStreamToLocalFallback(fallbackURL, for: currentSong)
-        }
-        session.onCompletion = { [weak self, weak session] url in
-            guard let self else { return }
-            guard completeDownloadSession(session) else { return }
-            guard let url else { return }
-            CacheManager.shared.recordAccess(for: url)
-            let protectedIDs = activeSongIDs()
-            CacheManager.shared.enforceMusicCacheLimits(excluding: protectedIDs)
-            guard let currentSong, currentSong.id == songID else { return }
-            let expectedDuration = currentSong.duration > 0 ? TimeInterval(currentSong.duration) : nil
-            guard
-                let playableURL = AudioCacheStore.playableMainURL(
-                    for: songID,
-                    expectedRemoteURL: currentSong.audioURL,
-                    expectedDuration: expectedDuration
-                )
-            else { return }
-            if isStreamMode, currentPlaybackURL?.path != playableURL.path {
-                let resumeAt = max(0, activePlaybackTime(for: currentSong))
-                let shouldAutoplay = streamPlaybackRequested || isPlaying
-                startStreamPlayback(
-                    url: playableURL,
-                    songID: songID,
-                    startAt: resumeAt,
-                    autoplay: shouldAutoplay
-                )
-            }
-            currentPlaybackURL = playableURL
-            prepareBackgroundStemPlaybackIfPossible(for: currentSong)
-            if anyAIEffectActive {
-                applyMLSeparationIfNeeded()
-            } else if aiEnabled, aiAutoAnalyze {
-                triggerBackgroundAnalysis(for: currentSong)
-            }
-        }
-        session.start(from: remoteURL)
     }
 
     func playNext(song: Song) {
@@ -2126,7 +1777,6 @@ class AudioPlayerManager: ObservableObject {
         deferredAIEffect = nil
         VocalSeparator.shared.cancel()
         VocalSeparator.shared.cancelBackgroundAnalysis()
-        cancelDownloadSession()
         scheduleIdleCacheCompression(excluding: Set<String>())
         isRadioMode = true
         radioArtworkURL = artworkURL
@@ -2152,11 +1802,15 @@ class AudioPlayerManager: ObservableObject {
         player.volume = 1.0
         radioPlayer = player
         radioPlaybackRequested = true
-        setPlaybackState(playing: false, buffering: true, reason: "startRadio")
+        setPlaybackState(
+            playing: false,
+            buffering: true,
+            reloadArtwork: true,
+            reason: "startRadio"
+        )
         observeManagedPlayer(player, item: item, kind: .radio)
         NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
         player.play()
-        updateNowPlayingInfo(reloadArtwork: true)
     }
 
     private func stopRadioPlayer() {
@@ -2197,7 +1851,12 @@ class AudioPlayerManager: ObservableObject {
         streamPlayer = player
         streamStartedAt = Date()
         streamPlaybackRequested = autoplay
-        setPlaybackState(playing: false, buffering: autoplay, reason: "startStreamPlayback")
+        setPlaybackState(
+            playing: false,
+            buffering: autoplay,
+            reloadArtwork: true,
+            reason: "startStreamPlayback"
+        )
         observeManagedPlayer(player, item: item, kind: .stream)
         if startAt > 0 {
             setPreferredStreamResumeTime(startAt, for: songID)
@@ -2239,24 +1898,6 @@ class AudioPlayerManager: ObservableObject {
         } else if autoplay {
             player.play()
         }
-        updateNowPlayingInfo(reloadArtwork: true)
-    }
-
-    private func switchSilentStreamToLocalFallback(_ fallbackURL: URL, for song: Song) {
-        guard isStreamMode, !isRadioMode else { return }
-        guard streamPlaybackRequested else { return }
-        guard currentSong?.id == song.id else { return }
-        guard let startedAt = streamStartedAt, Date().timeIntervalSince(startedAt) >= 3 else { return }
-        let streamTime = streamPlayer?.currentTime().seconds ?? .nan
-        let hasRemoteProgress = streamTime.isFinite && streamTime > 0.25
-
-        guard !hasRemoteProgress else { return }
-        DebugLogger.log(
-            "Switching startup-stalled stream to local fallback for \(song.id)",
-            category: .playback
-        )
-        let resumeAt = max(0, activePlaybackTime(for: song))
-        startStreamPlayback(url: fallbackURL, songID: song.id, startAt: resumeAt)
     }
 
     private func stopStreamPlayer() {
@@ -2314,7 +1955,6 @@ class AudioPlayerManager: ObservableObject {
         DebugLogger.log("Clearing all cache", category: .cache)
         cancelPendingTransitionWork()
         cacheCompressionTask?.cancel()
-        cancelDownloadSession()
         instrumentalTask?.cancel()
         instrumentalTask = nil
         preparedStemSongID = nil
@@ -2746,6 +2386,7 @@ class AudioPlayerManager: ObservableObject {
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
             lastNowPlayingElapsedSecond = nil
             lastNowPlayingPlaybackRate = nil
+            lastLoggedNowPlayingElapsedSecond = nil
             updateRemoteCommandAvailability()
             return
         }
@@ -2783,6 +2424,7 @@ class AudioPlayerManager: ObservableObject {
         )
         lastNowPlayingElapsedSecond = isRadioMode ? nil : Int(playbackTime.rounded(.down))
         lastNowPlayingPlaybackRate = isPlaying ? 1.0 : 0.0
+        lastLoggedNowPlayingElapsedSecond = nil
     }
 
     private func updateNowPlayingElapsed(_ elapsed: Double) {
@@ -2799,10 +2441,15 @@ class AudioPlayerManager: ObservableObject {
         info[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
         info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-        DebugLogger.log(
-            "Now Playing elapsed update: elapsed=\(elapsed), rate=\(playbackRate)",
-            category: .playback
-        )
+        if lastLoggedNowPlayingElapsedSecond == nil
+            || roundedSecond - (lastLoggedNowPlayingElapsedSecond ?? 0) >= 15
+        {
+            DebugLogger.log(
+                "Now Playing elapsed update: elapsed=\(elapsed), rate=\(playbackRate)",
+                category: .playback
+            )
+            lastLoggedNowPlayingElapsedSecond = roundedSecond
+        }
         lastNowPlayingElapsedSecond = roundedSecond
         lastNowPlayingPlaybackRate = playbackRate
     }
@@ -2824,8 +2471,13 @@ class AudioPlayerManager: ObservableObject {
             )
             artworkTask = SDWebImageManager.shared.loadImage(
                 with: url,
-                options: [.retryFailed, .scaleDownLargeImages],
-                context: [.imageThumbnailPixelSize: pixelSize],
+                options: [.scaleDownLargeImages],
+                context: [
+                    .imageThumbnailPixelSize: pixelSize,
+                    .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
+                    .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+                    .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
+                ],
                 progress: nil
             ) { [weak self] image, _, _, _, _, _ in
                 guard let self, currentSong?.id == songID else { return }
@@ -2857,21 +2509,6 @@ class AudioPlayerManager: ObservableObject {
     #endif
 
     #if canImport(UIKit)
-        private func handleBackgroundTransition() {
-            endAudioCacheBackgroundTask()
-
-            guard downloadSession != nil else { return }
-            bgTaskID = UIApplication.shared.beginBackgroundTask(withName: "AudioCache") { [weak self] in
-                self?.endAudioCacheBackgroundTask()
-            }
-        }
-
-        private func endAudioCacheBackgroundTask() {
-            guard bgTaskID != .invalid else { return }
-            UIApplication.shared.endBackgroundTask(bgTaskID)
-            bgTaskID = .invalid
-        }
-
         private func beginTrackTransitionBackgroundTask() {
             endTrackTransitionBackgroundTask()
             trackTransitionTaskID = UIApplication.shared.beginBackgroundTask(
@@ -3083,7 +2720,6 @@ class AudioPlayerManager: ObservableObject {
         }
         stopStreamPlayer()
         clearPreferredStreamResumeTime()
-        cancelDownloadSession()
         let song = plan.nextSong
         currentPlaybackURL = plan.nextFileURL
         CacheManager.shared.recordAccess(for: plan.nextFileURL)

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -146,18 +146,11 @@ final class TransitionCoordinator {
             let nextURL = audioFileURL(for: nextSong)
 
             if nextURL == nil, let remoteURL = nextSong.audioURL {
-                if DownloadManager.shared.hasActiveQueue {
-                    DebugLogger.log(
-                        "Skipping transition predownload for \(nextSong.id) while download queue is active",
-                        category: .playback
-                    )
-                } else {
-                    DebugLogger.log(
-                        "Predownloading next transition track \(nextSong.id) from \(remoteURL.lastPathComponent)",
-                        category: .playback
-                    )
-                    await predownload(song: nextSong, from: remoteURL)
-                }
+                DebugLogger.log(
+                    "Predownloading next transition track \(nextSong.id) from \(remoteURL.lastPathComponent)",
+                    category: .playback
+                )
+                await predownload(song: nextSong, from: remoteURL)
             }
 
             let nextFileURL = audioFileURL(for: nextSong)

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -146,11 +146,18 @@ final class TransitionCoordinator {
             let nextURL = audioFileURL(for: nextSong)
 
             if nextURL == nil, let remoteURL = nextSong.audioURL {
-                DebugLogger.log(
-                    "Predownloading next transition track \(nextSong.id) from \(remoteURL.lastPathComponent)",
-                    category: .playback
-                )
-                await predownload(song: nextSong, from: remoteURL)
+                if DownloadManager.shared.hasActiveQueue {
+                    DebugLogger.log(
+                        "Skipping transition predownload for \(nextSong.id) while download queue is active",
+                        category: .playback
+                    )
+                } else {
+                    DebugLogger.log(
+                        "Predownloading next transition track \(nextSong.id) from \(remoteURL.lastPathComponent)",
+                        category: .playback
+                    )
+                    await predownload(song: nextSong, from: remoteURL)
+                }
             }
 
             let nextFileURL = audioFileURL(for: nextSong)

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -3,6 +3,36 @@ import Foundation
 import Network
 import SwiftUI
 
+private final class DownloadTaskRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var activeTokens: [String: UUID] = [:]
+
+    func register(songID: String, token: UUID) {
+        lock.lock()
+        activeTokens[songID] = token
+        lock.unlock()
+    }
+
+    func cancel(songID: String) {
+        lock.lock()
+        activeTokens.removeValue(forKey: songID)
+        lock.unlock()
+    }
+
+    func clear() {
+        lock.lock()
+        activeTokens.removeAll()
+        lock.unlock()
+    }
+
+    func performIfActive<T>(songID: String, token: UUID, _ body: () throws -> T) rethrows -> T? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard activeTokens[songID] == token else { return nil }
+        return try body()
+    }
+}
+
 @MainActor
 final class DownloadManager: ObservableObject {
     private struct SongFiles {
@@ -32,6 +62,7 @@ final class DownloadManager: ObservableObject {
     private var pendingWiFiRepairs: [String: Song] = [:]
     private var validDownloadCache: [String: ValidDownloadCacheEntry] = [:]
     private var isWiFiAvailable = false
+    private let taskRegistry = DownloadTaskRegistry()
     private let networkMonitor = NWPathMonitor()
     private let networkMonitorQueue = DispatchQueue(label: "DownloadManager.NetworkMonitor")
     private let maxConcurrentDownloads = 6
@@ -163,6 +194,9 @@ final class DownloadManager: ObservableObject {
         }
         let songID = song.id
         let songFiles = files(for: songID)
+        let token = UUID()
+        let taskRegistry = taskRegistry
+        taskRegistry.register(songID: songID, token: token)
         ensureSongDirectory(for: songID)
         let task = URLSession.shared.downloadTask(with: remote) { [weak self] tempURL, response, error in
             var moved = false
@@ -175,18 +209,23 @@ final class DownloadManager: ObservableObject {
                Self.isValidDownloadedAudio(at: tempURL, expectedDuration: expectedDuration)
             {
                 do {
-                    try FileManager.default.createDirectory(
-                        at: songFiles.directory,
-                        withIntermediateDirectories: true
-                    )
-                    try? FileManager.default.removeItem(at: songFiles.audio)
-                    try FileManager.default.moveItem(at: tempURL, to: songFiles.audio)
-                    try? FileManager.default.removeItem(at: songFiles.source)
-                    FileManager.default.createFile(
-                        atPath: songFiles.source.path,
-                        contents: remote.absoluteString.data(using: .utf8)
-                    )
-                    moved = true
+                    moved = try taskRegistry.performIfActive(songID: songID, token: token) {
+                        try FileManager.default.createDirectory(
+                            at: songFiles.directory,
+                            withIntermediateDirectories: true
+                        )
+                        try? FileManager.default.removeItem(at: songFiles.audio)
+                        try FileManager.default.moveItem(at: tempURL, to: songFiles.audio)
+                        try? FileManager.default.removeItem(at: songFiles.source)
+                        FileManager.default.createFile(
+                            atPath: songFiles.source.path,
+                            contents: remote.absoluteString.data(using: .utf8)
+                        )
+                        return true
+                    } ?? false
+                    if !moved {
+                        try? FileManager.default.removeItem(at: tempURL)
+                    }
                 } catch {
                     DebugLogger.log("Download move failed for \(songID): \(error)", category: .network)
                 }
@@ -201,15 +240,29 @@ final class DownloadManager: ObservableObject {
                     )
                 }
             }
-            Task { @MainActor [weak self, moved, song, songID] in
-                self?.finishDownload(songID: songID, song: song, moved: moved)
+            Task { @MainActor [weak self, moved, song, songID, token] in
+                self?.finishDownload(songID: songID, song: song, moved: moved, token: token)
             }
         }
         tasks[song.id] = task
         task.resume()
     }
 
-    private func finishDownload(songID: String, song: Song, moved: Bool) {
+    private func finishDownload(songID: String, song: Song, moved: Bool, token: UUID? = nil) {
+        if let token {
+            let isCurrentTask = taskRegistry.performIfActive(songID: songID, token: token) { true } ?? false
+            guard isCurrentTask else {
+                if moved {
+                    let songFiles = files(for: songID)
+                    try? FileManager.default.removeItem(at: songFiles.audio)
+                    try? FileManager.default.removeItem(at: songFiles.source)
+                }
+                startQueuedDownloadsIfPossible()
+                logDownloadQueueCompletionIfNeeded()
+                return
+            }
+            taskRegistry.cancel(songID: songID)
+        }
         tasks.removeValue(forKey: songID)
         let wasInProgress = inProgress.remove(songID) != nil
         progress.removeValue(forKey: songID)
@@ -236,6 +289,7 @@ final class DownloadManager: ObservableObject {
     }
 
     func cancel(songID: String) {
+        taskRegistry.cancel(songID: songID)
         tasks[songID]?.cancel()
         tasks.removeValue(forKey: songID)
         queuedDownloads.removeValue(forKey: songID)
@@ -263,6 +317,7 @@ final class DownloadManager: ObservableObject {
         for task in tasks.values {
             task.cancel()
         }
+        taskRegistry.clear()
         tasks.removeAll()
         queuedDownloads.removeAll()
         queuedDownloadOrder.removeAll()

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -12,16 +12,29 @@ final class DownloadManager: ObservableObject {
         let metadata: URL
     }
 
+    private struct ValidDownloadCacheEntry {
+        let source: String?
+        let expectedDuration: TimeInterval?
+        let modifiedAt: Date?
+    }
+
     static let shared = DownloadManager()
     @Published private(set) var downloadedIDs: Set<String> = []
     @Published private(set) var inProgress: Set<String> = []
     @Published private(set) var progress: [String: Double] = [:]
     private let cacheDir: URL
     private var tasks: [String: URLSessionDownloadTask] = [:]
+    private var queuedDownloads: [String: Song] = [:]
+    private var queuedDownloadOrder: [String] = []
+    private var isLoggingDownloadQueue = false
+    private var completedInCurrentQueue = 0
+    private var failedInCurrentQueue = 0
     private var pendingWiFiRepairs: [String: Song] = [:]
+    private var validDownloadCache: [String: ValidDownloadCacheEntry] = [:]
     private var isWiFiAvailable = false
     private let networkMonitor = NWPathMonitor()
     private let networkMonitorQueue = DispatchQueue(label: "DownloadManager.NetworkMonitor")
+    private let maxConcurrentDownloads = 6
 
     private init() {
         cacheDir = FileManager.default
@@ -96,6 +109,10 @@ final class DownloadManager: ObservableObject {
         (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
     }
 
+    private nonisolated static func modificationDate(at url: URL) -> Date? {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+    }
+
     func isDownloaded(_ songID: String) -> Bool {
         downloadedIDs.contains(songID)
     }
@@ -104,14 +121,46 @@ final class DownloadManager: ObservableObject {
         inProgress.contains(songID)
     }
 
+    var hasActiveQueue: Bool {
+        !tasks.isEmpty || !queuedDownloadOrder.isEmpty
+    }
+
     func download(song: Song) {
-        guard let remote = song.audioURL else { return }
+        guard song.audioURL != nil else { return }
         if isDownloaded(song.id), playableURL(for: song) != nil { return }
         guard !isDownloading(song.id) else { return }
+        if !isLoggingDownloadQueue {
+            isLoggingDownloadQueue = true
+            completedInCurrentQueue = 0
+            failedInCurrentQueue = 0
+            DebugLogger.log("Download queue started", category: .network)
+        }
         pendingWiFiRepairs.removeValue(forKey: song.id)
-        DebugLogger.log("Starting download: \(song.id)", category: .network)
         inProgress.insert(song.id)
         progress[song.id] = 0
+        queuedDownloads[song.id] = song
+        queuedDownloadOrder.append(song.id)
+        startQueuedDownloadsIfPossible()
+    }
+
+    private func startQueuedDownloadsIfPossible() {
+        while tasks.count < maxConcurrentDownloads, !queuedDownloadOrder.isEmpty {
+            let songID = queuedDownloadOrder.removeFirst()
+            guard let song = queuedDownloads.removeValue(forKey: songID) else { continue }
+            guard inProgress.contains(songID), !downloadedIDs.contains(songID) else {
+                inProgress.remove(songID)
+                progress.removeValue(forKey: songID)
+                continue
+            }
+            startDownloadTask(song: song)
+        }
+    }
+
+    private func startDownloadTask(song: Song) {
+        guard let remote = song.audioURL else {
+            finishDownload(songID: song.id, song: song, moved: false)
+            return
+        }
         let songID = song.id
         let songFiles = files(for: songID)
         ensureSongDirectory(for: songID)
@@ -162,27 +211,45 @@ final class DownloadManager: ObservableObject {
 
     private func finishDownload(songID: String, song: Song, moved: Bool) {
         tasks.removeValue(forKey: songID)
-        inProgress.remove(songID)
+        let wasInProgress = inProgress.remove(songID) != nil
         progress.removeValue(forKey: songID)
+        guard wasInProgress else {
+            startQueuedDownloadsIfPossible()
+            logDownloadQueueCompletionIfNeeded()
+            return
+        }
         if moved {
             writeMetadata(for: song)
             downloadedIDs.insert(songID)
-            DebugLogger.log("Download completed: \(songID)", category: .network)
+            validDownloadCache[songID] = ValidDownloadCacheEntry(
+                source: song.audioURL?.absoluteString,
+                expectedDuration: song.duration > 0 ? TimeInterval(song.duration) : nil,
+                modifiedAt: Self.modificationDate(at: files(for: songID).audio)
+            )
+            completedInCurrentQueue += 1
         } else {
+            failedInCurrentQueue += 1
             DebugLogger.log("Download failed: \(songID)", category: .network)
         }
+        startQueuedDownloadsIfPossible()
+        logDownloadQueueCompletionIfNeeded()
     }
 
     func cancel(songID: String) {
         tasks[songID]?.cancel()
         tasks.removeValue(forKey: songID)
+        queuedDownloads.removeValue(forKey: songID)
+        queuedDownloadOrder.removeAll { $0 == songID }
         inProgress.remove(songID)
         progress.removeValue(forKey: songID)
+        startQueuedDownloadsIfPossible()
+        logDownloadQueueCompletionIfNeeded()
     }
 
     func remove(songID: String) {
         cancel(songID: songID)
         pendingWiFiRepairs.removeValue(forKey: songID)
+        validDownloadCache.removeValue(forKey: songID)
         let songFiles = files(for: songID)
         try? FileManager.default.removeItem(at: songFiles.directory)
         try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(songID).mp3"))
@@ -197,9 +264,15 @@ final class DownloadManager: ObservableObject {
             task.cancel()
         }
         tasks.removeAll()
+        queuedDownloads.removeAll()
+        queuedDownloadOrder.removeAll()
+        isLoggingDownloadQueue = false
+        completedInCurrentQueue = 0
+        failedInCurrentQueue = 0
         inProgress.removeAll()
         progress.removeAll()
         pendingWiFiRepairs.removeAll()
+        validDownloadCache.removeAll()
 
         let fm = FileManager.default
         if let files = try? fm.contentsOfDirectory(at: cacheDir, includingPropertiesForKeys: nil) {
@@ -209,6 +282,17 @@ final class DownloadManager: ObservableObject {
         }
         downloadedIDs = []
         DebugLogger.log("All downloads removed", category: .network)
+    }
+
+    private func logDownloadQueueCompletionIfNeeded() {
+        guard isLoggingDownloadQueue, tasks.isEmpty, queuedDownloadOrder.isEmpty else { return }
+        DebugLogger.log(
+            "Download queue complete: completed=\(completedInCurrentQueue), failed=\(failedInCurrentQueue)",
+            category: .network
+        )
+        isLoggingDownloadQueue = false
+        completedInCurrentQueue = 0
+        failedInCurrentQueue = 0
     }
 
     private func refreshExistingDownloads() {
@@ -248,15 +332,30 @@ final class DownloadManager: ObservableObject {
         let songFiles = files(for: song.id)
         guard FileManager.default.fileExists(atPath: songFiles.audio.path) else {
             downloadedIDs.remove(song.id)
+            validDownloadCache.removeValue(forKey: song.id)
             return nil
         }
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
-        guard Self.isValidDownloadedAudio(at: songFiles.audio, expectedDuration: expectedDuration) else {
-            DebugLogger.log("Discarding invalid downloaded audio for \(song.id)", category: .cache)
-            discardBrokenDownloadAndScheduleRepair(for: song, reason: "file validation failed")
+        let expectedSource = song.audioURL?.absoluteString
+        let cachedSource = readSourceURL(for: song.id)
+        if let cachedSource, let expectedSource, cachedSource != expectedSource {
+            DebugLogger.log(
+                "Discarding downloaded audio for \(song.id) due to source mismatch",
+                category: .cache
+            )
+            discardBrokenDownloadAndScheduleRepair(for: song, reason: "source URL changed")
             return nil
         }
-        guard let cached = readSourceURL(for: song.id) else {
+        let resolvedSource = cachedSource ?? expectedSource
+        if hasCachedValidation(
+            for: song.id,
+            audioURL: songFiles.audio,
+            source: resolvedSource,
+            expectedDuration: expectedDuration
+        ) {
+            return songFiles.audio
+        }
+        guard let cachedSource else {
             if let expected = song.audioURL {
                 writeSourceURL(expected, for: song.id)
                 writeMetadata(for: song)
@@ -266,20 +365,56 @@ final class DownloadManager: ObservableObject {
                     category: .cache
                 )
             }
-            return songFiles.audio
-        }
-        guard let expected = song.audioURL?.absoluteString else {
-            return songFiles.audio
-        }
-        guard cached == expected else {
-            DebugLogger.log(
-                "Discarding downloaded audio for \(song.id) due to source mismatch",
-                category: .cache
+            guard Self.isValidDownloadedAudio(at: songFiles.audio, expectedDuration: expectedDuration) else {
+                DebugLogger.log("Discarding invalid downloaded audio for \(song.id)", category: .cache)
+                discardBrokenDownloadAndScheduleRepair(for: song, reason: "file validation failed")
+                return nil
+            }
+            cacheValidDownload(
+                songID: song.id,
+                audioURL: songFiles.audio,
+                source: expectedSource,
+                expectedDuration: expectedDuration
             )
-            discardBrokenDownloadAndScheduleRepair(for: song, reason: "source URL changed")
+            return songFiles.audio
+        }
+        guard Self.isValidDownloadedAudio(at: songFiles.audio, expectedDuration: expectedDuration) else {
+            DebugLogger.log("Discarding invalid downloaded audio for \(song.id)", category: .cache)
+            discardBrokenDownloadAndScheduleRepair(for: song, reason: "file validation failed")
             return nil
         }
+        cacheValidDownload(
+            songID: song.id,
+            audioURL: songFiles.audio,
+            source: cachedSource,
+            expectedDuration: expectedDuration
+        )
         return songFiles.audio
+    }
+
+    private func hasCachedValidation(
+        for songID: String,
+        audioURL: URL,
+        source: String?,
+        expectedDuration: TimeInterval?
+    ) -> Bool {
+        guard let cached = validDownloadCache[songID] else { return false }
+        return cached.source == source
+            && cached.expectedDuration == expectedDuration
+            && cached.modifiedAt == Self.modificationDate(at: audioURL)
+    }
+
+    private func cacheValidDownload(
+        songID: String,
+        audioURL: URL,
+        source: String?,
+        expectedDuration: TimeInterval?
+    ) {
+        validDownloadCache[songID] = ValidDownloadCacheEntry(
+            source: source,
+            expectedDuration: expectedDuration,
+            modifiedAt: Self.modificationDate(at: audioURL)
+        )
     }
 
     /// Returns true only when the on-disk download is conclusively invalid and was removed.
@@ -380,6 +515,7 @@ final class DownloadManager: ObservableObject {
             "Removing confirmed broken download for \(song.id): \(reason)",
             category: .cache
         )
+        validDownloadCache.removeValue(forKey: song.id)
         removeBrokenAudioFiles(for: song)
         guard let repairSong else { return }
         pendingWiFiRepairs[song.id] = repairSong
@@ -389,6 +525,7 @@ final class DownloadManager: ObservableObject {
     private func removeBrokenAudioFiles(for song: Song) {
         cancel(songID: song.id)
         let songFiles = files(for: song.id)
+        validDownloadCache.removeValue(forKey: song.id)
         try? FileManager.default.removeItem(at: songFiles.audio)
         try? FileManager.default.removeItem(at: songFiles.source)
         try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(song.id).mp3"))

--- a/Twinskaraoke/Services/User/FavoritesManager.swift
+++ b/Twinskaraoke/Services/User/FavoritesManager.swift
@@ -8,22 +8,31 @@ final class FavoritesManager: ObservableObject {
     @Published private(set) var favoriteIDs: Set<String> = []
     private var inFlight: Set<String> = []
     private var loaded = false
+    private var isLoading = false
+    private var lastLoadFailure: Date?
+    private let loadFailureRetryDelay: TimeInterval = 30
 
     func isFavorite(_ songID: String) -> Bool {
         favoriteIDs.contains(songID)
     }
 
     func loadIfNeeded() {
-        reload()
+        guard !loaded, !isLoading else { return }
+        if let lastLoadFailure, Date().timeIntervalSince(lastLoadFailure) < loadFailureRetryDelay {
+            return
+        }
+        Task { await load() }
     }
 
     func reload() {
+        guard !isLoading else { return }
         Task { await load() }
     }
 
     func clear() {
         favoriteIDs = []
         loaded = false
+        lastLoadFailure = nil
     }
 
     func toggle(songID: String) {
@@ -52,11 +61,18 @@ final class FavoritesManager: ObservableObject {
 
     private func load() async {
         guard UserDefaults.standard.string(forKey: "nk.token") != nil else { return }
+        isLoading = true
+        defer { isLoading = false }
         guard let req = try? KaraokeAPIClient.request(path: "/api/user/favorites"),
               let data = try? await KaraokeAPIClient.data(for: req)
-        else { return }
+        else {
+            lastLoadFailure = Date()
+            return
+        }
         let ids = Self.parseIDs(from: data)
-        await MainActor.run { self.favoriteIDs = Set(ids) }
+        favoriteIDs = Set(ids)
+        loaded = true
+        lastLoadFailure = nil
     }
 
     private func send(songID: String) async -> Bool {

--- a/Twinskaraoke/Services/User/FavoritesManager.swift
+++ b/Twinskaraoke/Services/User/FavoritesManager.swift
@@ -21,12 +21,12 @@ final class FavoritesManager: ObservableObject {
         if let lastLoadFailure, Date().timeIntervalSince(lastLoadFailure) < loadFailureRetryDelay {
             return
         }
-        Task { await load() }
+        Task { @MainActor in await load() }
     }
 
     func reload() {
         guard !isLoading else { return }
-        Task { await load() }
+        Task { @MainActor in await load() }
     }
 
     func clear() {

--- a/Twinskaraoke/Services/User/UserPlaylistsManager.swift
+++ b/Twinskaraoke/Services/User/UserPlaylistsManager.swift
@@ -11,12 +11,15 @@ final class UserPlaylistsManager: ObservableObject {
     private var loaded = false
 
     func loadIfNeeded() {
-        fetchPlaylists()
+        fetchPlaylists(force: false)
     }
 
-    func fetchPlaylists() {
+    func fetchPlaylists(force: Bool = true) {
+        guard !isLoading else { return }
+        guard force || !loaded else { return }
         guard UserDefaults.standard.string(forKey: "nk.token") != nil else {
             playlists = []
+            loaded = false
             return
         }
 
@@ -31,6 +34,7 @@ final class UserPlaylistsManager: ObservableObject {
 
             await MainActor.run {
                 self.playlists = decoded
+                self.loaded = true
                 RecentlyAddedTracker.shared.registerIfNew(decoded.map(\.id))
             }
         }

--- a/TwinskaraokeWatchApp/Models/Library/PlaylistDetailViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/PlaylistDetailViewModel.swift
@@ -12,6 +12,7 @@ final class PlaylistDetailViewModel: ObservableObject {
     }
 
     func fetchSongs() {
+        guard !isLoading, songs.isEmpty else { return }
         isLoading = true
         Task { [weak self] in
             guard let self else { return }

--- a/TwinskaraokeWatchApp/Models/Library/PlaylistsViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/PlaylistsViewModel.swift
@@ -7,6 +7,7 @@ final class PlaylistsViewModel: ObservableObject {
     @Published var isLoading = false
 
     func fetchMusic() {
+        guard !isLoading, playlists.isEmpty else { return }
         isLoading = true
         Task { [weak self] in
             guard let self else { return }

--- a/TwinskaraokeWatchApp/Models/Library/SongsViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/SongsViewModel.swift
@@ -7,6 +7,7 @@ final class SongsViewModel: ObservableObject {
     @Published var isLoading = false
 
     func fetchSongs() {
+        guard !isLoading, songs.isEmpty else { return }
         isLoading = true
         Task { [weak self] in
             guard let self else { return }


### PR DESCRIPTION
## Summary
- reduce artwork decode/cache pressure with bounded prefetching, memory-only transformed thumbnails, failure backoff, and safer Now Playing artwork updates
- queue playlist downloads with six concurrent tasks, queue-level logging, cancellation guards, and less network contention during playback transitions
- remove opportunistic stream-side audio caching and reduce repeated Now Playing/popup update work
- add lightweight caching/throttling across library, search, playlist, gallery, favorites, and watch data paths
- fix iOS lock screen and Control Center play/pause sync for AVAudioEngine-backed playback by synchronizing remote command handling, publishing complete Now Playing audio metadata, and pausing the underlying engine when file playback pauses

## Root Cause
- Artwork and data views could trigger repeated decode/network work and overlapping fetches while navigating quickly.
- Playlist downloads previously started too many concurrent tasks and could race with cancellation/removal paths.
- iOS media controls were receiving Now Playing updates, but file playback only paused the `AVAudioPlayerNode`; the `AVAudioEngine` stayed running, so system surfaces could keep treating playback as active.
- Remote command callbacks can arrive off the main thread, so returning success before the main-actor state update allowed Control Center to redraw from stale state.

## Validation
- `git diff --check`
- tested on real iOS hardware across app controls, lock screen, Control Center, previous/next, seek, downloaded playback, streaming playback, radio, and playlist download flow

## Notes
- The `remote.pauseAsPlay` fallback is intentionally preserved. Although strict `pauseCommand` semantics would no-op while paused, device testing showed some iOS surfaces can send `pauseCommand` from stale paused UI state when the user is effectively pressing the center play control. Removing that fallback caused lock screen and Control Center state to diverge again.