### PR TITLE
Smooth crossfade handoff playback

### DIFF
--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -209,6 +209,7 @@ final class AVEnginePlayback {
     private(set) var isCrossfading = false
 
     private var crossfadeTimer: Timer?
+    private var handoffBlendTimer: Timer?
     private var singleLoadTask: Task<LoadedMedia, Error>?
     private var stemsLoadTask: Task<LoadedStemTriple, Error>?
     private var switchToStemsLoadTask: Task<LoadedStemPair, Error>?
@@ -605,6 +606,14 @@ final class AVEnginePlayback {
     }
 
     private func safePlay(_ player: SimpleAudioPlayer, from position: TimeInterval) {
+        safePlay(player, from: position, at: nil)
+    }
+
+    private func safePlay(
+        _ player: SimpleAudioPlayer,
+        from position: TimeInterval,
+        at startTime: AVAudioTime?
+    ) {
         player.stop()
         player.playerNode.reset()
         let dur = player.duration
@@ -618,9 +627,13 @@ final class AVEnginePlayback {
         }
         let clamped = min(position, max(0, dur - 0.25))
         if clamped < 0.05 {
-            player.play()
+            if let startTime {
+                player.play(from: 0, at: startTime)
+            } else {
+                player.play()
+            }
         } else {
-            player.play(from: clamped)
+            player.play(from: clamped, at: startTime)
         }
     }
 
@@ -649,6 +662,8 @@ final class AVEnginePlayback {
         cancelCrossfadeLoadTasks()
         crossfadeTimer?.invalidate()
         crossfadeTimer = nil
+        handoffBlendTimer?.invalidate()
+        handoffBlendTimer = nil
         pendingCrossfadeURL = nil
         preloadedCrossfadeURL = nil
         isCrossfading = false
@@ -1188,6 +1203,8 @@ final class AVEnginePlayback {
         cancelCrossfadeLoadTasks()
         crossfadeTimer?.invalidate()
         crossfadeTimer = nil
+        handoffBlendTimer?.invalidate()
+        handoffBlendTimer = nil
         preloadedCrossfadeURL = nil
         pendingCrossfadeURL = nil
         guard isCrossfading else {
@@ -1210,6 +1227,8 @@ final class AVEnginePlayback {
     private func finalizeCrossfade() {
         crossfadeTimer?.invalidate()
         crossfadeTimer = nil
+        handoffBlendTimer?.invalidate()
+        handoffBlendTimer = nil
         isCrossfading = false
 
         suppressionToken &+= 1
@@ -1402,7 +1421,7 @@ final class AVEnginePlayback {
         mode = .single
         aiStartOffset = 0
         stopAllStems(releasingMedia: true)
-        mainPlayer.volume = 1.0
+        mainPlayer.volume = 0
         resetInstrumentalEQ()
         startEngineIfNeeded()
         let loadedDuration = mainPlayer.duration
@@ -1416,18 +1435,55 @@ final class AVEnginePlayback {
                 ]
             )
         }
+        let handoffLeadTime: TimeInterval = 0.08
+        let handoffStartTime = synchronizedStartTime(leadTime: handoffLeadTime)
         let freshTime = crossfadePlayer.currentTime
         let actualResume = crossfadePlayer.isPlaying && freshTime > resumeTime
             ? freshTime : resumeTime
-        safePlay(mainPlayer, from: actualResume)
+        let scheduledResume = actualResume + handoffLeadTime
+        safePlay(mainPlayer, from: scheduledResume, at: handoffStartTime)
         currentURL = url
         DebugLogger.log(
-            "Crossfade handoff complete url=\(url.lastPathComponent), media=\(Self.describeMedia(media)), resumeTime=\(actualResume), mainTime=\(mainPlayer.currentTime), mainDuration=\(mainPlayer.duration)",
+            "Crossfade handoff complete url=\(url.lastPathComponent), media=\(Self.describeMedia(media)), resumeTime=\(scheduledResume), mainTime=\(mainPlayer.currentTime), mainDuration=\(mainPlayer.duration)",
             category: .playback
         )
-        releasePlayerMedia(crossfadePlayer)
+        beginCrossfadeHandoffBlend(after: handoffLeadTime) { [weak self] in
+            self?.onCrossfadeCompleted?()
+        }
         pendingCrossfadeURL = nil
-        onCrossfadeCompleted?()
+    }
+
+    private func beginCrossfadeHandoffBlend(after delay: TimeInterval, completion: @escaping () -> Void) {
+        handoffBlendTimer?.invalidate()
+        let duration: TimeInterval = 0.35
+        let startTime = Date()
+        let timer = Timer(timeInterval: 0.02, repeats: true) { [weak self] timer in
+            guard self != nil else {
+                timer.invalidate()
+                return
+            }
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let elapsed = Date().timeIntervalSince(startTime) - delay
+                guard elapsed >= 0 else {
+                    self.mainPlayer.volume = 0
+                    self.crossfadePlayer.volume = 1.0
+                    return
+                }
+                let t = Float(min(1.0, max(0.0, elapsed / duration)))
+                self.mainPlayer.volume = t
+                self.crossfadePlayer.volume = 1.0 - t
+                if t >= 1.0 {
+                    timer.invalidate()
+                    self.handoffBlendTimer = nil
+                    self.mainPlayer.volume = 1.0
+                    self.releasePlayerMedia(self.crossfadePlayer)
+                    completion()
+                }
+            }
+        }
+        handoffBlendTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     private static func handoffMedia(


### PR DESCRIPTION
## Summary
- smooth the final AVAudioEngine handoff after a crossfade by keeping the crossfade player audible while the main player is scheduled and blended in
- delay the transition-complete callback until the internal handoff blend has finished
- ensure scheduled playback is respected even when the handoff starts near the beginning of a track

## Root Cause
During a crossfade, the next track was first played through the temporary crossfade player. At the end of the fade, playback was immediately handed back to the main player by reloading/scheduling that same media, stopping the old player, and notifying the app that the transition was complete. That meant the app could start song-state, artwork, cache, and Now Playing update work while the audio graph was still swapping active players. On device this showed up as a short hiccup roughly within the first second of the new song, after the crossfade itself had already sounded correct.

The issue affected both streamed and file-backed transitions because both paths eventually use the same AVAudioEngine crossfade-to-main-player handoff.

## Fix
- schedule the main player slightly ahead using an AVAudioTime instead of starting it immediately
- keep the crossfade player at full volume until that scheduled start point
- blend from the crossfade player to the main player over a short internal handoff window
- release the temporary crossfade player only after that blend completes
- call the transition completion handler after the handoff blend, so app/UI/cache work starts after the audio handoff is stable

This does not change automix or crossfade selection behavior; it only smooths the internal player handoff after the crossfade.

## Validation
- git diff --check
- tested on device with natural song transitions for both streaming and downloaded/file-backed playback

## Summary by Sourcery

Smooth the AVAudioEngine crossfade handoff by scheduling main player startup and blending volumes before completing the transition.

Bug Fixes:
- Eliminate audible playback hiccups at the beginning of tracks after crossfade transitions.
- Ensure scheduled playback positions are respected even when the handoff starts near the beginning of a track.

Enhancements:
- Introduce a timed handoff blend between the crossfade player and main player using coordinated volume transitions.
- Delay the crossfade-completed callback until the internal handoff blend has finished, so UI and app work start after audio is stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved seamless playback transitions with a smoother handoff between tracks.

* **Bug Fixes**
  * Reduced the chance of volume jumps or lingering fades after a crossfade is interrupted.
  * Made playback timing more precise when resuming near a scheduled start, helping tracks stay better aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->