### PR TITLE
Improve artwork loading, playback startup, and main-thread performance

### DIFF
--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -776,7 +776,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -818,7 +818,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -847,7 +847,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -875,7 +875,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -902,7 +902,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -928,7 +928,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Twinskaraoke/App/TwinskaraokeApp.swift
+++ b/Twinskaraoke/App/TwinskaraokeApp.swift
@@ -28,6 +28,12 @@ struct TwinskaraokeApp: App {
                 .environment(\.locale, Locale(identifier: resolvedLanguage.localeIdentifier))
                 .injectReduceMotion()
                 .tint(.appAccent)
+                .onAppear {
+                    DebugLogger.log(
+                        "Display refresh rate: \(DisplayRefreshRate.maximumFramesPerSecond) fps max",
+                        category: .ui
+                    )
+                }
         }
     }
 

--- a/Twinskaraoke/Components/Account/AboutComponents.swift
+++ b/Twinskaraoke/Components/Account/AboutComponents.swift
@@ -146,25 +146,29 @@ struct AboutBulletList: View {
 struct LinkifiedText: View {
     let text: String
     var body: some View {
-        let parts = LinkifiedText.split(text)
-        parts.reduce(Text("")) { acc, part in
+        Text(LinkifiedText.attributedString(from: text))
+    }
+
+    private static func attributedString(from text: String) -> AttributedString {
+        var result = AttributedString()
+        for part in split(text) {
             switch part {
             case let .text(s):
-                acc + Text(s)
+                result.append(AttributedString(s))
             case let .url(s, url):
-                acc
-                    + Text(
-                        AttributedString(
-                            s,
-                            attributes: AttributeContainer([
-                                .link: url,
-                                .foregroundColor: UIColor.systemBlue,
-                                .underlineStyle: NSUnderlineStyle.single.rawValue,
-                            ])
-                        )
+                result.append(
+                    AttributedString(
+                        s,
+                        attributes: AttributeContainer([
+                            .link: url,
+                            .foregroundColor: UIColor.systemBlue,
+                            .underlineStyle: NSUnderlineStyle.single.rawValue,
+                        ])
                     )
+                )
             }
         }
+        return result
     }
 
     private enum Part {

--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -148,7 +148,11 @@ struct LatestSingleSection: View {
                 play()
             } label: {
                 HStack(spacing: AM.Spacing.m) {
-                    RemoteArtworkImage(url: song.imageURL, cornerRadius: AM.Radius.card)
+                    RemoteArtworkImage(
+                        url: song.thumbnailURL ?? song.imageURL,
+                        cornerRadius: AM.Radius.card,
+                        lowResURL: song.rowImageURL
+                    )
                         .frame(width: 92, height: 92)
                         .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
                         .amShadow(AM.Shadow.card)

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -179,7 +179,7 @@ private struct AddToPlaylistSongPreview: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            RemoteArtworkImage(url: song.imageURL, cornerRadius: 10)
+            RemoteArtworkImage(url: song.thumbnailURL ?? song.imageURL, cornerRadius: 10)
                 .frame(width: 74, height: 74)
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 .shadow(color: Color.appShadow, radius: 10, y: 6)

--- a/Twinskaraoke/Components/Media/FavoritesArtworkTile.swift
+++ b/Twinskaraoke/Components/Media/FavoritesArtworkTile.swift
@@ -115,7 +115,14 @@ struct PlaylistMosaicArtwork: View {
             ) {
                 ForEach(0 ..< 4, id: \.self) { index in
                     if let url = artworkURL(at: index) {
-                        RemoteArtworkImage(url: url, cornerRadius: 0, showsLoading: showsLoading)
+                        let variant: ArtworkImageVariant = cell <= 80 ? .row : .thumbnail
+                        let optimizedURL = ArtworkURLBuilder.variantURL(from: url, variant: variant) ?? url
+                        RemoteArtworkImage(
+                            url: optimizedURL,
+                            cornerRadius: 0,
+                            showsLoading: showsLoading,
+                            fixedDisplaySize: CGSize(width: cell, height: cell)
+                        )
                             .frame(width: cell, height: cell)
                     } else {
                         PlaylistPlaceholderArtwork(seed: "\(index)-\(urls.count)")
@@ -148,19 +155,16 @@ struct PlaylistPlaceholderArtwork: View {
 
 extension Playlist {
     var explicitCoverURL: URL? {
-        if let cfId = media?.cloudflareId, !cfId.isEmpty {
-            return URL(string: "\(StorageHost.images)/\(cfId)/width=480,quality=85,format=auto")
-        }
-        if let path = media?.absolutePath, !path.isEmpty {
-            return Playlist.mediaURL(from: path)
-        }
-        return nil
+        imageURL(variant: .card)
+    }
+
+    var explicitCoverThumbnailURL: URL? {
+        imageURL(variant: .thumbnail)
     }
 
     var initialMosaicArtworkURLs: [URL] {
         let mosaicURLs = mosaicMedia?.compactMap { media -> URL? in
-            guard let path = media.absolutePath, !path.isEmpty else { return nil }
-            return Playlist.mediaURL(from: path)
+            Playlist.mediaURL(from: media, variant: .card)
         } ?? []
         if !mosaicURLs.isEmpty {
             return Playlist.uniqueURLs(mosaicURLs, limit: 4)
@@ -169,8 +173,19 @@ extension Playlist {
     }
 
     static func mediaURL(from path: String) -> URL? {
-        let normalized = path.hasPrefix("/") ? path : "/\(path)"
-        return URL(string: "\(StorageHost.images)\(normalized)/width=480,quality=85,format=auto")
+        ArtworkURLBuilder.imageURL(cloudflareID: nil, path: path, variant: .card)
+    }
+
+    static func mediaURL(from path: String, variant: ArtworkImageVariant) -> URL? {
+        ArtworkURLBuilder.imageURL(cloudflareID: nil, path: path, variant: variant)
+    }
+
+    static func mediaURL(from media: Media, variant: ArtworkImageVariant) -> URL? {
+        ArtworkURLBuilder.imageURL(
+            cloudflareID: media.cloudflareId,
+            path: media.absolutePath,
+            variant: variant
+        )
     }
 
     static func uniqueURLs(_ urls: [URL], limit: Int) -> [URL] {

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -37,17 +37,7 @@ struct RemoteArtworkImage: View {
     @ViewBuilder
     private func imageContent(size: CGSize) -> some View {
         let displaySize = sanitizedDisplaySize(size)
-        let pixelSize = NSValue(cgSize: thumbnailPixelSize(for: displaySize))
-        let context: [SDWebImageContextOption: Any] =
-            fullResolution
-                ? [:] : [
-                    .imageThumbnailPixelSize: pixelSize,
-                    .imageDecodeOptions: [SDImageCoderOption.decodeScaleFactor: 1.0],
-
-                    .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
-                    .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                    .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                ]
+        let context = fullResolution ? ImageCacheConfig.memoryAndDiskCacheContext : ImageCacheConfig.visibleImageContext
         ZStack {
             if !transparentBackground {
                 MusicArtworkPlaceholder(cornerRadius: cornerRadius)
@@ -55,11 +45,8 @@ struct RemoteArtworkImage: View {
             if let lowResURL, !fullLoaded {
                 WebImage(
                     url: lowResURL,
-                    options: [.scaleDownLargeImages, .fromCacheOnly],
-                    context: [
-                        .imageThumbnailPixelSize: NSValue(cgSize: CGSize(width: 120, height: 120)),
-                        .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
-                    ]
+                    options: [.fromCacheOnly],
+                    context: context
                 ) { image in
                     image
                         .resizable()
@@ -155,17 +142,6 @@ struct RemoteArtworkImage: View {
         return CGSize(width: width, height: height)
     }
 
-    private func thumbnailPixelSize(for displaySize: CGSize) -> CGSize {
-        #if canImport(UIKit)
-            let scale = UIScreen.main.scale
-        #else
-            let scale: CGFloat = 2
-        #endif
-        let w = max(displaySize.width, 1) * scale
-        let h = max(displaySize.height, 1) * scale
-        let cap = ImageCacheConfig.thumbnailPixelSize
-        return CGSize(width: min(w, cap.width), height: min(h, cap.height))
-    }
 }
 
 final class ArtworkFailureBackoff {

--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -158,9 +158,12 @@ struct PlayerAmbientBackground: View {
                 progress: nil
             ) { image, _, _, _, _, _ in
                 guard let image else { return }
-                let extracted = ArtworkPalette(image: image)
-                DispatchQueue.main.async {
-                    palette = extracted
+                // Pixel sampling is too heavy for the main-queue completion.
+                Task.detached(priority: .utility) {
+                    let extracted = ArtworkPalette(image: image)
+                    await MainActor.run {
+                        palette = extracted
+                    }
                 }
             }
         #endif

--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -62,16 +62,10 @@ struct PlayerAmbientBackground: View {
     private var blurredArtworkLayer: some View {
         if let artworkURL {
             GeometryReader { geo in
-                let pixelSize = NSValue(cgSize: backgroundPixelSize(for: geo.size))
                 WebImage(
                     url: artworkURL,
                     options: ImageCacheConfig.defaultOptions,
-                    context: [
-                        .imageThumbnailPixelSize: pixelSize,
-                        .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
-                        .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                        .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                    ]
+                    context: ImageCacheConfig.visibleImageContext
                 ) { image in
                     image
                         .resizable()
@@ -151,33 +145,16 @@ struct PlayerAmbientBackground: View {
         )
     }
 
-    private func backgroundPixelSize(for displaySize: CGSize) -> CGSize {
-        #if canImport(UIKit)
-            let scale = UIScreen.main.scale
-        #else
-            let scale: CGFloat = 2
-        #endif
-        let width = max(displaySize.width, 1) * scale
-        let height = max(displaySize.height, 1) * scale
-        return CGSize(width: min(width, 900), height: min(height, 900))
-    }
-
     private func loadPalette() {
         guard let url = artworkURL else {
             palette = .placeholder
             return
         }
         #if canImport(UIKit)
-            let pixelSize = NSValue(cgSize: CGSize(width: 96, height: 96))
             SDWebImageManager.shared.loadImage(
                 with: url,
-                options: [.scaleDownLargeImages],
-                context: [
-                    .imageThumbnailPixelSize: pixelSize,
-                    .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
-                    .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                    .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                ],
+                options: [],
+                context: ImageCacheConfig.visibleImageContext,
                 progress: nil
             ) { image, _, _, _, _, _ in
                 guard let image else { return }

--- a/Twinskaraoke/Components/Player/PlayerArtworkView.swift
+++ b/Twinskaraoke/Components/Player/PlayerArtworkView.swift
@@ -32,8 +32,10 @@ struct PlayerArtworkView: View {
     private var artwork: some View {
         ZStack {
             RemoteArtworkImage(
-                url: audioManager.displayImageURL(for: song), cornerRadius: AM.Radius.hero,
-                contentMode: .fill
+                url: audioManager.displayImageURL(for: song, variant: .card),
+                cornerRadius: AM.Radius.hero,
+                contentMode: .fill,
+                lowResURL: audioManager.displayImageURL(for: song, variant: .thumbnail)
             )
             .frame(width: size, height: size)
             .clipShape(RoundedRectangle(cornerRadius: AM.Radius.hero, style: .continuous))

--- a/Twinskaraoke/Components/Player/QueueComponents.swift
+++ b/Twinskaraoke/Components/Player/QueueComponents.swift
@@ -14,7 +14,11 @@ struct QueueRow: View {
             Button(action: onPlay) {
                 HStack(spacing: 12) {
                     ZStack(alignment: .topLeading) {
-                        RemoteArtworkImage(url: audioManager.displayImageURL(for: song), cornerRadius: 7)
+                        RemoteArtworkImage(
+                            url: audioManager.displayImageURL(for: song, variant: .row),
+                            cornerRadius: 7,
+                            lowResURL: song.thumbnailURL
+                        )
                             .frame(width: 50, height: 50)
                             .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
                         if isPlayingNext {

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -24,7 +24,7 @@ enum AppearanceMode: String, CaseIterable {
     }
 }
 
-extension Color {
+nonisolated extension Color {
     #if canImport(UIKit)
         private static func adaptive(light: UIColor, dark: UIColor) -> Color {
             Color(

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -54,8 +54,9 @@ struct SongRow: View {
             ZStack {
                 if showsArtwork {
                     RemoteArtworkImage(
-                        url: playback.displayImageURL(for: song),
+                        url: playback.displayImageURL(for: song, variant: .row),
                         cornerRadius: size.cornerRadius,
+                        lowResURL: song.thumbnailURL,
                         fixedDisplaySize: CGSize(width: size.artSize, height: size.artSize)
                     )
                     .frame(width: size.artSize, height: size.artSize)
@@ -258,10 +259,11 @@ struct MusicGridCard: View {
 
     @ViewBuilder
     private var artworkContent: some View {
-        if let imageURL = playback.displayImageURL(for: song) {
+        if let imageURL = playback.displayImageURL(for: song, variant: .card) {
             RemoteArtworkImage(
                 url: imageURL,
                 cornerRadius: AM.Radius.card,
+                lowResURL: playback.displayImageURL(for: song, variant: .thumbnail),
                 fixedDisplaySize: width.map { CGSize(width: $0, height: $0) }
             )
         } else {
@@ -364,6 +366,7 @@ struct SongContextPreview: View {
             RemoteArtworkImage(
                 url: song.imageURL,
                 cornerRadius: 10,
+                lowResURL: song.thumbnailURL,
                 fixedDisplaySize: CGSize(width: 220, height: 220)
             )
             .aspectRatio(1, contentMode: .fill)

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -864,7 +864,7 @@ private final class QRCameraController: UIViewController, AVCaptureMetadataOutpu
 
     private func observeRuntimeErrors() {
         runtimeErrorObserver = NotificationCenter.default.addObserver(
-            forName: .AVCaptureSessionRuntimeError,
+            forName: AVCaptureSession.runtimeErrorNotification,
             object: session,
             queue: .main
         ) { [weak self] _ in

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -134,8 +134,9 @@ struct BrowseSongCollectionView: View {
 
     @ViewBuilder
     private var heroArtwork: some View {
-        let artURL = songs.first(where: { $0.hasOwnArtwork })?.imageURL ?? FallbackArtProvider.shared.randomURL
-        RemoteArtworkImage(url: artURL, cornerRadius: 0, contentMode: .fill)
+        let heroSong = songs.first(where: { $0.hasOwnArtwork })
+        let artURL = heroSong?.imageURL ?? FallbackArtProvider.shared.randomURL
+        RemoteArtworkImage(url: artURL, cornerRadius: 0, contentMode: .fill, lowResURL: heroSong?.thumbnailURL)
     }
 
     @ViewBuilder

--- a/Twinskaraoke/Features/Home/HomeWideHero.swift
+++ b/Twinskaraoke/Features/Home/HomeWideHero.swift
@@ -175,7 +175,12 @@ private struct WideSongHeroCard: View {
     @ViewBuilder
     private var heroArtwork: some View {
         if let song {
-            RemoteArtworkImage(url: song.fullHDImageURL ?? song.imageURL, cornerRadius: 0, contentMode: .fill)
+            RemoteArtworkImage(
+                url: song.imageURL,
+                cornerRadius: 0,
+                contentMode: .fill,
+                lowResURL: song.thumbnailURL
+            )
                 .allowsHitTesting(false)
         } else if let playlist {
             PlaylistArtwork(playlist: playlist, cornerRadius: 0)

--- a/Twinskaraoke/Features/Home/NewSections.swift
+++ b/Twinskaraoke/Features/Home/NewSections.swift
@@ -74,7 +74,12 @@ private struct NewFeatureCard: View {
                         .lineLimit(1)
                 }
                 ZStack(alignment: .bottomLeading) {
-                    RemoteArtworkImage(url: song.imageURL, cornerRadius: AM.Radius.card, contentMode: .fill)
+                    RemoteArtworkImage(
+                        url: song.imageURL,
+                        cornerRadius: AM.Radius.card,
+                        contentMode: .fill,
+                        lowResURL: song.thumbnailURL
+                    )
                     LinearGradient(
                         colors: [.clear, .black.opacity(0.38)],
                         startPoint: .center,

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -91,8 +91,8 @@ struct PlaylistListView: View {
         ArtworkPrefetcher.shared.prefetchPlaylists(
             Array(displayedPlaylists.prefix(12)),
             limit: 12,
-            reason: "playlist list"
+            reason: "playlist list",
+            variant: .thumbnail
         )
     }
 }
-

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailHero.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailHero.swift
@@ -77,7 +77,7 @@ struct ArtworkDetailHero: View {
 
     @ViewBuilder
     private var heroArtwork: some View {
-        if let url = fullResURL {
+        if let url = art.heroImageURL ?? fullResURL ?? art.imageURL {
             RemoteArtworkImage(
                 url: url,
                 cornerRadius: 20,

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
@@ -6,7 +6,7 @@ struct ArtistCircleCard: View {
     var body: some View {
         VStack(spacing: 8) {
             ZStack {
-                if let art = artist.arts?.first, let url = art.imageURL {
+                if let art = artist.arts?.first, let url = art.imageURL(variant: .thumbnail) {
                     RemoteArtworkImage(
                         url: url, cornerRadius: 100, showsLoading: false, lowResURL: art.blurPreviewURL,
                         transparentBackground: true

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistListRow.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistListRow.swift
@@ -6,7 +6,7 @@ struct ArtistListRow: View {
     var body: some View {
         HStack(spacing: 14) {
             Group {
-                if let art = artist.arts?.first, let url = art.imageURL {
+                if let art = artist.arts?.first, let url = art.imageURL(variant: .thumbnail) {
                     RemoteArtworkImage(
                         url: url, cornerRadius: 100, showsLoading: false, lowResURL: art.blurPreviewURL,
                         transparentBackground: true

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -83,7 +83,7 @@ private struct ArtistRow: View {
     let artist: Artist
     var body: some View {
         HStack(spacing: 12) {
-            ArtistAvatar(url: artist.imageURL)
+            ArtistAvatar(url: artist.rowImageURL)
                 .frame(width: 52, height: 52)
                 .clipShape(Circle())
             VStack(alignment: .leading, spacing: 2) {

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -194,7 +194,8 @@ struct DownloadedSongsView: View {
         ArtworkPrefetcher.shared.prefetchSongs(
             Array(songs.prefix(18)),
             limit: 18,
-            reason: "downloaded songs"
+            reason: "downloaded songs",
+            variant: .row
         )
         if reduceMotion {
             localSongs = songs

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -451,7 +451,8 @@ struct LibrarySongsView: View {
             ArtworkPrefetcher.shared.prefetchSongs(
                 Array(songs.prefix(18)),
                 limit: 18,
-                reason: "library visible songs"
+                reason: "library visible songs",
+                variant: .row
             )
         }
         .animation(listAnimation, value: songs.map(\.id))

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -81,11 +81,17 @@ struct PlaylistDetailView: View {
     }
 
     private func prefetchArtwork(songs: [Song]) {
-        ArtworkPrefetcher.shared.prefetchPlaylists([playlist], limit: 6, reason: "playlist cover")
+        ArtworkPrefetcher.shared.prefetchPlaylists(
+            [playlist],
+            limit: 6,
+            reason: "playlist cover",
+            variant: .thumbnail
+        )
         ArtworkPrefetcher.shared.prefetchSongs(
             Array(songs.prefix(18)),
             limit: 18,
-            reason: "playlist songs"
+            reason: "playlist songs",
+            variant: .row
         )
     }
 

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -204,8 +204,8 @@ struct FullScreenPlayerView: View {
         .fullScreenCover(isPresented: $showCoverArt) {
             if let song {
                 let isEasterEgg = easterEggImageURL != nil
-                let hdURL = easterEggImageURL ?? song.fullHDImageURL ?? audioManager.displayImageURL(for: song)
-                let thumbURL = isEasterEgg ? nil : audioManager.displayImageURL(for: song)
+                let hdURL = easterEggImageURL ?? audioManager.displayImageURL(for: song, variant: .fullHD) ?? song.fullHDImageURL
+                let thumbURL = isEasterEgg ? nil : audioManager.displayImageURL(for: song, variant: .thumbnail)
                 ZoomableImageViewer(
                     url: hdURL,
                     lowResURL: thumbURL,
@@ -528,7 +528,10 @@ struct FullScreenPlayerView: View {
             } label: {
                 HStack(spacing: 12) {
                     RemoteArtworkImage(
-                        url: audioManager.displayImageURL(for: song), cornerRadius: 8, contentMode: .fill
+                        url: audioManager.displayImageURL(for: song, variant: .thumbnail),
+                        cornerRadius: 8,
+                        contentMode: .fill,
+                        lowResURL: song.thumbnailURL
                     )
                     .frame(width: metrics.lyricsArtworkSize, height: metrics.lyricsArtworkSize)
                     .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
@@ -860,7 +863,7 @@ struct FullScreenPlayerView: View {
 
     private func backgroundView(song: Song) -> some View {
         PlayerAmbientBackground(
-            artworkURL: audioManager.displayImageURL(for: song),
+            artworkURL: audioManager.displayImageURL(for: song, variant: .card),
             isPlaying: audioManager.isPlaying
         )
         .id(song.id)
@@ -1034,11 +1037,12 @@ struct FullScreenPlayerView: View {
             DispatchQueue.main.async {
                 guard let data,
                       let item = try? JSONDecoder().decode(RandomYuriArtItem.self, from: data),
-                      let imageURL = URL(string: "\(item.url)/quality=95")
+                      let baseURL = URL(string: item.url)
                 else {
                     showCoverArt = true
                     return
                 }
+                let imageURL = ArtworkURLBuilder.variantURL(from: baseURL, variant: .hero) ?? baseURL
                 easterEggImageURL = imageURL
                 easterEggArtistName = item.artistCredit
                 easterEggArtistLink = nil

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -211,7 +211,11 @@ struct QueueView: View {
             dismiss()
         } label: {
             HStack(spacing: 12) {
-                RemoteArtworkImage(url: audioManager.displayImageURL(for: current), cornerRadius: 6)
+                RemoteArtworkImage(
+                    url: audioManager.displayImageURL(for: current, variant: .row),
+                    cornerRadius: 6,
+                    lowResURL: current.thumbnailURL
+                )
                     .frame(width: 48, height: 48)
                     .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
                 VStack(alignment: .leading, spacing: 3) {

--- a/Twinskaraoke/Features/Radio/RadioQueueArtwork.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueArtwork.swift
@@ -7,7 +7,10 @@ struct RadioQueueArtwork: View {
     var body: some View {
         Group {
             if let url = song.artworkURL {
-                RemoteArtworkImage(url: url, cornerRadius: cornerRadius)
+                RemoteArtworkImage(
+                    url: ArtworkURLBuilder.variantURL(from: url, variant: .thumbnail) ?? url,
+                    cornerRadius: cornerRadius
+                )
             } else {
                 LinearGradient(
                     colors: [Color.appAccent.opacity(0.85), Color.purple.opacity(0.85)],

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -271,7 +271,7 @@ struct RadioView: View {
                     HStack(spacing: 12) {
                         if let art = next.art, let url = URL(string: art) {
                             RemoteArtworkImage(
-                                url: url,
+                                url: ArtworkURLBuilder.variantURL(from: url, variant: .row) ?? url,
                                 cornerRadius: 6,
                                 fixedDisplaySize: CGSize(width: 48, height: 48)
                             )
@@ -339,9 +339,10 @@ struct RadioView: View {
             Group {
                 if let art = song?.art, let url = URL(string: art) {
                     RemoteArtworkImage(
-                        url: url,
+                        url: ArtworkURLBuilder.variantURL(from: url, variant: .card) ?? url,
                         cornerRadius: AM.Radius.hero,
-                        contentMode: .fill
+                        contentMode: .fill,
+                        lowResURL: ArtworkURLBuilder.variantURL(from: url, variant: .thumbnail)
                     )
                 } else {
                     artPlaceholder
@@ -620,7 +621,11 @@ private struct RadioStationContextPreview: View {
         ContextPreviewCard {
             Group {
                 if let artworkURL {
-                    RemoteArtworkImage(url: artworkURL, cornerRadius: 10)
+                    RemoteArtworkImage(
+                        url: ArtworkURLBuilder.variantURL(from: artworkURL, variant: .card) ?? artworkURL,
+                        cornerRadius: 10,
+                        lowResURL: ArtworkURLBuilder.variantURL(from: artworkURL, variant: .thumbnail)
+                    )
                 } else {
                     MusicArtworkPlaceholder(cornerRadius: 10)
                 }
@@ -664,7 +669,7 @@ private struct RadioHistoryRow: View {
         HStack(spacing: 12) {
             if let art = song.art, let url = URL(string: art) {
                 RemoteArtworkImage(
-                    url: url,
+                    url: ArtworkURLBuilder.variantURL(from: url, variant: .row) ?? url,
                     cornerRadius: 6,
                     fixedDisplaySize: CGSize(width: 48, height: 48)
                 )

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -115,7 +115,8 @@ struct SearchView: View {
                 ArtworkPrefetcher.shared.prefetchSongs(
                     Array(viewModel.results.prefix(18)),
                     limit: 18,
-                    reason: "search results"
+                    reason: "search results",
+                    variant: .row
                 )
             }
             .onDisappear {
@@ -882,6 +883,11 @@ private struct SearchFeaturedShortcutTile: View {
         horizontalSizeClass == .compact
     }
 
+    private var optimizedArtworkURL: URL? {
+        guard let artworkURL else { return nil }
+        return ArtworkURLBuilder.variantURL(from: artworkURL, variant: .card) ?? artworkURL
+    }
+
     var body: some View {
         ZStack(alignment: .bottomLeading) {
             background
@@ -917,7 +923,7 @@ private struct SearchFeaturedShortcutTile: View {
 
     @ViewBuilder
     private var background: some View {
-        if let artworkURL {
+        if let artworkURL = optimizedArtworkURL {
             RemoteArtworkImage(url: artworkURL, cornerRadius: 0, contentMode: .fill)
                 .allowsHitTesting(false)
             LinearGradient(
@@ -943,9 +949,14 @@ private struct CategoryTile: View {
         horizontalSizeClass == .compact
     }
 
+    private var optimizedArtworkURL: URL? {
+        guard let artworkURL else { return nil }
+        return ArtworkURLBuilder.variantURL(from: artworkURL, variant: .thumbnail) ?? artworkURL
+    }
+
     var body: some View {
         ZStack(alignment: .bottomLeading) {
-            if let artworkURL {
+            if let artworkURL = optimizedArtworkURL {
                 RemoteArtworkImage(url: artworkURL, cornerRadius: 0, contentMode: .fill)
                     .allowsHitTesting(false)
                 LinearGradient(

--- a/Twinskaraoke/Models/Account/ProfileModels.swift
+++ b/Twinskaraoke/Models/Account/ProfileModels.swift
@@ -28,8 +28,11 @@ struct Badge: Decodable, Identifiable {
     let conditionValue: Int
     let media: BadgeMedia?
     var iconURL: URL? {
-        guard let cf = media?.cloudflareId, !cf.isEmpty else { return nil }
-        return URL(string: "\(StorageHost.images)/\(cf)/public")
+        ArtworkURLBuilder.imageURL(
+            cloudflareID: media?.cloudflareId,
+            path: nil,
+            variant: .thumbnail
+        )
     }
 }
 

--- a/Twinskaraoke/Models/Library/Artist.swift
+++ b/Twinskaraoke/Models/Library/Artist.swift
@@ -8,9 +8,17 @@ nonisolated struct Artist: Codable, Identifiable, Equatable {
     let songCount: Int?
     let songListDTOs: [Song]?
     var imageURL: URL? {
+        artistImageURL(variant: .thumbnail)
+    }
+
+    var rowImageURL: URL? {
+        artistImageURL(variant: .row)
+    }
+
+    private func artistImageURL(variant: ArtworkImageVariant) -> URL? {
         guard let path = imagePath, !path.isEmpty else { return nil }
-        let cleanPath = path.hasPrefix("/") ? path : "/" + path
-        return URL(string: StorageHost.base + cleanPath)
+        return ArtworkURLBuilder.storageResizedURL(path: path, variant: variant)
+            ?? URL(string: StorageHost.base + ArtworkURLBuilder.normalizedPath(path))
     }
 
     static func == (lhs: Artist, rhs: Artist) -> Bool {

--- a/Twinskaraoke/Models/Library/GalleryModels.swift
+++ b/Twinskaraoke/Models/Library/GalleryModels.swift
@@ -18,24 +18,27 @@ struct GalleryArt: Codable, Identifiable, Equatable {
     let absolutePath: String?
     let upvotes: Int?
     var imageURL: URL? {
-        if let identifier = cloudflareId {
-            return URL(string: "\(StorageHost.images)/\(identifier)/public")
-        }
-        guard let path = absolutePath else { return nil }
-        return URL(string: StorageHost.images + path + "/quality=95")
+        imageURL(variant: .card)
     }
 
     var fullHDImageURL: URL? {
-        if let identifier = cloudflareId {
-            return URL(string: "\(StorageHost.images)/\(identifier)/quality=95")
-        }
-        guard let path = absolutePath else { return imageURL }
-        return URL(string: StorageHost.images + path + "/quality=95")
+        imageURL(variant: .fullHD) ?? imageURL
+    }
+
+    var heroImageURL: URL? {
+        imageURL(variant: .hero)
     }
 
     var blurPreviewURL: URL? {
-        guard let path = absolutePath else { return nil }
-        return URL(string: StorageHost.images + path + "/width=20,quality=30,blur=30")
+        imageURL(variant: .blur)
+    }
+
+    func imageURL(variant: ArtworkImageVariant) -> URL? {
+        ArtworkURLBuilder.imageURL(
+            cloudflareID: cloudflareId,
+            path: absolutePath,
+            variant: variant
+        )
     }
 }
 

--- a/Twinskaraoke/Models/Library/GalleryVideo.swift
+++ b/Twinskaraoke/Models/Library/GalleryVideo.swift
@@ -9,7 +9,13 @@ nonisolated struct GalleryVideo: Codable, Identifiable, Equatable {
     let createdBy: String?
     let createdDate: String?
     var thumbnailURL: URL? {
-        thumbnailUrl.flatMap(URL.init(string:))
+        guard let raw = thumbnailUrl, let baseURL = URL(string: raw) else { return nil }
+        return ArtworkURLBuilder.variantURL(from: baseURL, variant: .card) ?? baseURL
+    }
+
+    var rowThumbnailURL: URL? {
+        guard let raw = thumbnailUrl, let baseURL = URL(string: raw) else { return nil }
+        return ArtworkURLBuilder.variantURL(from: baseURL, variant: .thumbnail) ?? thumbnailURL
     }
 
     var embedURL: URL? {

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -159,7 +159,8 @@ final class LibrarySongsViewModel: ObservableObject {
         ArtworkPrefetcher.shared.prefetchSongs(
             Array(pageSongs.prefix(18)),
             limit: 18,
-            reason: replace ? "library songs initial" : "library songs page"
+            reason: replace ? "library songs initial" : "library songs page",
+            variant: .row
         )
     }
 

--- a/Twinskaraoke/Models/Library/UserPlaylist.swift
+++ b/Twinskaraoke/Models/Library/UserPlaylist.swift
@@ -34,9 +34,7 @@ struct UserPlaylist: Codable, Identifiable, Hashable {
     func asPlaylist() -> Playlist {
         var mediaArray: [Media]? = mosaicMedia
         if mediaArray == nil || mediaArray?.isEmpty == true {
-            if let cfId = media?.cloudflareId, !cfId.isEmpty {
-                mediaArray = [Media(absolutePath: "/\(cfId)")]
-            } else if let path = media?.absolutePath, !path.isEmpty {
+            if let path = media?.absolutePath, !path.isEmpty {
                 mediaArray = [Media(absolutePath: path)]
             }
         }

--- a/Twinskaraoke/Services/Artwork/ArtworkPalette.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPalette.swift
@@ -4,7 +4,7 @@ import SwiftUI
     import UIKit
 #endif
 
-struct ArtworkPalette: Equatable {
+nonisolated struct ArtworkPalette: Equatable {
     var primary: Color
     var secondary: Color
     var tertiary: Color
@@ -101,7 +101,7 @@ struct ArtworkPalette: Equatable {
 
 #if canImport(UIKit)
 
-    fileprivate extension UIColor {
+    nonisolated fileprivate extension UIColor {
         func distance(to other: UIColor) -> CGFloat {
             var r1: CGFloat = 0
             var g1: CGFloat = 0

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -11,35 +11,62 @@ final class ArtworkPrefetcher {
     private let reuseWindow: TimeInterval = 45
 
     private init() {
-        prefetcher.maxConcurrentPrefetchCount = 1
+        prefetcher.maxConcurrentPrefetchCount = 3
     }
 
-    func prefetchSongs(_ songs: [Song], limit: Int = 18, reason: String) {
-        prefetch(urls: songs.compactMap(\.imageURL), limit: min(limit, 8), reason: reason)
+    func prefetchSongs(
+        _ songs: [Song],
+        limit: Int = 18,
+        reason: String,
+        variant: ArtworkImageVariant = .card
+    ) {
+        let urls = songs.compactMap { song -> URL? in
+            switch variant {
+            case .row:
+                song.rowImageURL
+            case .thumbnail:
+                song.thumbnailURL
+            case .hero:
+                song.heroImageURL
+            case .fullHD:
+                song.fullHDImageURL
+            default:
+                song.imageURL
+            }
+        }
+        prefetch(urls: urls, limit: limit, reason: reason, variant: variant)
     }
 
-    func prefetchPlaylists(_ playlists: [Playlist], limit: Int = 12, reason: String) {
+    func prefetchPlaylists(
+        _ playlists: [Playlist],
+        limit: Int = 12,
+        reason: String,
+        variant: ArtworkImageVariant = .card
+    ) {
         let urls = playlists.flatMap { playlist -> [URL] in
             var values: [URL] = []
-            if let imageURL = playlist.imageURL {
+            if let imageURL = playlist.imageURL(variant: variant) {
                 values.append(imageURL)
             }
-            values.append(contentsOf: playlist.initialMosaicArtworkURLs)
+            values.append(contentsOf: playlist.initialMosaicArtworkURLs.compactMap {
+                ArtworkURLBuilder.variantURL(from: $0, variant: variant)
+            })
             return values
         }
-        prefetch(urls: urls, limit: min(limit, 6), reason: reason)
+        prefetch(urls: urls, limit: limit, reason: reason, variant: variant)
     }
 
-    func prefetch(urls: [URL], limit: Int = 18, reason: String) {
-        let selected = freshUniqueURLs(from: urls, limit: adjustedLimit(limit, reason: reason))
+    func prefetch(
+        urls: [URL],
+        limit: Int = 18,
+        reason: String,
+        variant: ArtworkImageVariant = .card
+    ) {
+        let variantURLs = urls.map { url in
+            ArtworkURLBuilder.variantURL(from: url, variant: variant) ?? url
+        }
+        let selected = freshUniqueURLs(from: variantURLs, limit: adjustedLimit(limit, reason: reason))
         guard !selected.isEmpty else { return }
-
-        let context: [SDWebImageContextOption: Any] = [
-            .imageThumbnailPixelSize: NSValue(cgSize: ImageCacheConfig.thumbnailPixelSize),
-            .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
-            .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-            .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-        ]
 
         DebugLogger.log(
             "Prefetching \(selected.count) artwork images for \(reason)",
@@ -48,8 +75,8 @@ final class ArtworkPrefetcher {
 
         prefetcher.prefetchURLs(
             selected,
-            options: [.lowPriority, .scaleDownLargeImages],
-            context: context,
+            options: [.avoidDecodeImage],
+            context: ImageCacheConfig.memoryAndDiskCacheContext,
             progress: nil
         ) { finished, skipped in
             DebugLogger.log(
@@ -65,9 +92,9 @@ final class ArtworkPrefetcher {
             return min(limit, reason == "radio metadata" ? 3 : 2)
         }
         if AudioPlayerManager.shared.isPlaying {
-            return min(limit, reason == "radio metadata" ? 5 : 4)
+            return min(limit, reason == "radio metadata" ? 4 : 4)
         }
-        return limit
+        return min(limit, reason == "radio metadata" ? 6 : 8)
     }
 
     private func freshUniqueURLs(from urls: [URL], limit: Int) -> [URL] {

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -75,8 +75,8 @@ final class ArtworkPrefetcher {
 
         prefetcher.prefetchURLs(
             selected,
-            options: [.avoidDecodeImage],
-            context: ImageCacheConfig.memoryAndDiskCacheContext,
+            options: [],
+            context: ImageCacheConfig.prefetchContext,
             progress: nil
         ) { finished, skipped in
             DebugLogger.log(

--- a/Twinskaraoke/Services/Artwork/FallbackArtProvider.swift
+++ b/Twinskaraoke/Services/Artwork/FallbackArtProvider.swift
@@ -213,7 +213,10 @@ final nonisolated class FallbackArtProvider: ObservableObject, @unchecked Sendab
                       let baseURL = URL(string: item.url)
                 else { return }
 
-                let urlWithQuality = URL(string: "\(item.url)/width=480,quality=85,format=auto") ?? baseURL
+                let urlWithQuality =
+                    ArtworkURLBuilder.variantURL(from: baseURL, variant: .card)
+                    ?? URL(string: "\(item.url)/width=480,quality=85,format=webp")
+                    ?? baseURL
 
                 group.enter()
                 var headRequest = URLRequest(url: urlWithQuality)

--- a/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
+++ b/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
@@ -7,25 +7,50 @@ import SDWebImage
 enum ImageCacheConfig {
     private static var didApply = false
 
+    static let memoryAndDiskCacheContext: [SDWebImageContextOption: Any] = [
+        .queryCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
+        .storeCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
+    ]
+
+    static let visibleImageContext: [SDWebImageContextOption: Any] = [
+        .queryCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
+        .storeCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
+        .imageDecodeOptions: [SDImageCoderOption.decodeScaleFactor: 1.0],
+    ]
+
     static func applyLimits() {
         guard !didApply else { return }
         didApply = true
         let cfg = SDImageCache.shared.config
-        cfg.maxMemoryCost = 32 * 1024 * 1024
-        cfg.maxMemoryCount = 64
-        cfg.maxDiskSize = 128 * 1024 * 1024
+        cfg.maxMemoryCost = 128 * 1024 * 1024
+        cfg.maxMemoryCount = 240
+        cfg.maxDiskSize = 768 * 1024 * 1024
         cfg.shouldCacheImagesInMemory = true
         cfg.shouldUseWeakMemoryCache = true
-        cfg.maxDiskAge = 30 * 24 * 60 * 60
-        SDImageCache.shared.clearMemory()
+        cfg.maxDiskAge = 90 * 24 * 60 * 60
         let dl = SDWebImageDownloader.shared
 
-        dl.config.maxConcurrentDownloads = 2
+        dl.config.maxConcurrentDownloads = 6
         dl.requestModifier = SDWebImageDownloaderRequestModifier { request in
             var r = request
             r.cachePolicy = .returnCacheDataElseLoad
             r.timeoutInterval = 15
+            r.setValue("image/webp,image/*,*/*;q=0.8", forHTTPHeaderField: "Accept")
             return r
+        }
+        dl.responseModifier = SDWebImageDownloaderResponseModifier { response in
+            guard let httpResponse = response as? HTTPURLResponse,
+                  let url = httpResponse.url,
+                  shouldInspectArtworkResponse(url),
+                  let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
+                  !contentType.contains("webp")
+            else { return response }
+
+            DebugLogger.log(
+                "Artwork response content-type=\(contentType), status=\(httpResponse.statusCode), url=\(redactedURLString(url))",
+                category: .cache
+            )
+            return response
         }
         #if canImport(UIKit)
             NotificationCenter.default.addObserver(
@@ -37,9 +62,18 @@ enum ImageCacheConfig {
         #endif
     }
 
-    static let thumbnailPixelSize = CGSize(width: 480, height: 480)
+    static let defaultOptions: SDWebImageOptions = []
 
-    static let defaultOptions: SDWebImageOptions = [
-        .scaleDownLargeImages,
-    ]
+    private static func shouldInspectArtworkResponse(_ url: URL) -> Bool {
+        guard let host = url.host else { return false }
+        return host.contains("images.neurokaraoke.com")
+            || (host.contains("storage.neurokaraoke.com") && url.path.contains("/cdn-cgi/image/"))
+    }
+
+    private static func redactedURLString(_ url: URL) -> String {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.query = nil
+        components?.fragment = nil
+        return components?.string ?? url.lastPathComponent
+    }
 }

--- a/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
+++ b/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
@@ -18,6 +18,13 @@ enum ImageCacheConfig {
         .imageDecodeOptions: [SDImageCoderOption.decodeScaleFactor: 1.0],
     ]
 
+    // Prefetch warms cache without forcing decode; decoding happens on display.
+    static let prefetchContext: [SDWebImageContextOption: Any] = [
+        .queryCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
+        .storeCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
+        .imageForceDecodePolicy: NSNumber(value: SDImageForceDecodePolicy.never.rawValue),
+    ]
+
     static func applyLimits() {
         guard !didApply else { return }
         didApply = true

--- a/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
+++ b/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
@@ -60,8 +60,7 @@ final class PlaylistCoverLoader: ObservableObject {
 
     private static func extractMosaicURLs(from playlist: Playlist) -> [URL] {
         let mediaURLs = playlist.mosaicMedia?.compactMap { media -> URL? in
-            guard let path = media.absolutePath, !path.isEmpty else { return nil }
-            return Playlist.mediaURL(from: path)
+            Playlist.mediaURL(from: media, variant: .card)
         } ?? []
         if !mediaURLs.isEmpty { return Playlist.uniqueURLs(mediaURLs, limit: 4) }
         return extractArtworkURLs(fromSongs: playlist.songListDTOs ?? [])

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -339,6 +339,7 @@ class AudioPlayerManager: ObservableObject {
     private var radioPlaybackRequested = false
     private var streamPlaybackRequested = false
     private var remotePlaybackCacheTask: Task<Void, Never>?
+    private var remotePlaybackCacheToken: UUID?
     private var lastKnownPlaybackTime: TimeInterval = 0
     private var pollTimer: Timer?
     private var streamFadeTimer: Timer?
@@ -620,6 +621,22 @@ class AudioPlayerManager: ObservableObject {
         return AudioCacheStore.playableMainURL(for: song.id, expectedRemoteURL: song.audioURL, expectedDuration: expectedDuration)
     }
 
+    /// Local file lookup for the tap-to-play path: never decompresses on the
+    /// main thread. Compressed-only cache entries return nil here and are
+    /// recovered off-main by the remote playback cache task (which hits the
+    /// same cache and decompresses before playing, without re-downloading).
+    private func immediateLocalPlaybackFileURL(for song: Song) -> URL? {
+        if let downloaded = DownloadManager.shared.playableURL(for: song) {
+            return downloaded
+        }
+        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+        return AudioCacheStore.immediatelyPlayableMainURL(
+            for: song.id,
+            expectedRemoteURL: song.audioURL,
+            expectedDuration: expectedDuration
+        )
+    }
+
     private func cachedStems(for song: Song, sourceURL: URL? = nil) -> CachedStems? {
         let expectedDuration: TimeInterval?
         if song.duration > 0 {
@@ -699,6 +716,13 @@ class AudioPlayerManager: ObservableObject {
                 return progress * fallbackDuration
             }
             return 0
+        }
+        if isRemotePlaybackCaching, let preferredResume = preferredStreamResumeTime(for: song) {
+            let fallbackDuration = Double(song?.duration ?? currentSong?.duration ?? 0)
+            if fallbackDuration > 0 {
+                return min(max(0, preferredResume), fallbackDuration)
+            }
+            return max(0, preferredResume)
         }
         let currentTime = avEngine.currentTime
         if currentTime.isFinite, currentTime >= 0 {
@@ -1192,7 +1216,12 @@ class AudioPlayerManager: ObservableObject {
                 originalQueue = []
             }
         }
-        let fileURL = localPlaybackFileURL(for: song)
+        // Songs with a remote source use the non-decompressing lookup; a
+        // compressed-only cache falls through to startStreamPlayback, whose
+        // cache-hit path decompresses off the main thread.
+        let fileURL = song.audioURL != nil
+            ? immediateLocalPlaybackFileURL(for: song)
+            : localPlaybackFileURL(for: song)
         if let fileURL, let stems = stemsForCachedAIMode(song: song) {
             instrumentalTask?.cancel()
             instrumentalTask = nil
@@ -1405,6 +1434,9 @@ class AudioPlayerManager: ObservableObject {
         if isRemotePlaybackCaching {
             let wasActive = streamPlaybackRequested || isBuffering
             streamPlaybackRequested = false
+            if let preferredResume = preferredStreamResumeTime(for: currentSong) {
+                lastKnownPlaybackTime = preferredResume
+            }
             setPlaybackState(
                 playing: false,
                 buffering: false,
@@ -1535,7 +1567,9 @@ class AudioPlayerManager: ObservableObject {
         if !isPlaying, avEngine.currentURL == nil, let song = currentSong,
            let fileURL = localPlaybackFileURL(for: song)
         {
-            startPlayingFile(fileURL, startAt: lastKnownPlaybackTime)
+            let resumeAt = preferredStreamResumeTime(for: song) ?? lastKnownPlaybackTime
+            clearPreferredStreamResumeTime()
+            startPlayingFile(fileURL, startAt: resumeAt)
             return true
         }
         guard !isPlaying else {
@@ -1584,6 +1618,14 @@ class AudioPlayerManager: ObservableObject {
             if anyAIEffectActive {
                 applyMLSeparationIfNeeded()
             }
+            updateNowPlayingInfo(reloadArtwork: false)
+            return
+        }
+        if isRemotePlaybackCaching, let song = currentSong, song.duration > 0 {
+            let totalDur = Double(song.duration)
+            let targetSeconds = min(totalDur * fraction, totalDur - 1.5)
+            guard targetSeconds >= 0 else { return }
+            setPreferredStreamResumeTime(targetSeconds, for: song.id)
             updateNowPlayingInfo(reloadArtwork: false)
             return
         }
@@ -1953,6 +1995,10 @@ class AudioPlayerManager: ObservableObject {
         }
 
         remotePlaybackCacheTask?.cancel()
+        // Token guard: replaying the same URL cancels the old task, whose
+        // cancellation handler must not reset state owned by the new request.
+        let requestToken = UUID()
+        remotePlaybackCacheToken = requestToken
         remotePlaybackCacheTask = Task { [weak self] in
             do {
                 let cachedURL = try await Self.cacheRemoteAudio(
@@ -1961,11 +2007,13 @@ class AudioPlayerManager: ObservableObject {
                     expectedDuration: expectedDuration
                 )
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, remotePlaybackCacheToken == requestToken else { return }
                     guard currentSong?.id == songID, currentPlaybackURL == url else { return }
                     remotePlaybackCacheTask = nil
                     if streamPlaybackRequested {
-                        startPlayingFile(cachedURL, startAt: startAt)
+                        let resumeAt = preferredStreamResumeTime(for: currentSong) ?? startAt
+                        clearPreferredStreamResumeTime()
+                        startPlayingFile(cachedURL, startAt: resumeAt)
                     } else {
                         currentPlaybackURL = cachedURL
                         setPlaybackState(
@@ -1978,7 +2026,8 @@ class AudioPlayerManager: ObservableObject {
                 }
             } catch is CancellationError {
                 await MainActor.run { [weak self] in
-                    guard let self, currentSong?.id == songID else { return }
+                    guard let self, remotePlaybackCacheToken == requestToken else { return }
+                    guard currentSong?.id == songID else { return }
                     guard currentPlaybackURL == url else { return }
                     remotePlaybackCacheTask = nil
                     streamPlaybackRequested = false
@@ -1991,7 +2040,8 @@ class AudioPlayerManager: ObservableObject {
                 }
             } catch {
                 await MainActor.run { [weak self] in
-                    guard let self, currentSong?.id == songID else { return }
+                    guard let self, remotePlaybackCacheToken == requestToken else { return }
+                    guard currentSong?.id == songID else { return }
                     guard currentPlaybackURL == url else { return }
                     remotePlaybackCacheTask = nil
                     streamPlaybackRequested = false
@@ -2010,7 +2060,9 @@ class AudioPlayerManager: ObservableObject {
         }
     }
 
-    private static func cacheRemoteAudio(
+    // nonisolated: cache validation, file moves, and possible decompression
+    // are blocking file I/O that must stay off the main actor.
+    private nonisolated static func cacheRemoteAudio(
         from remoteURL: URL,
         songID: String,
         expectedDuration: TimeInterval?
@@ -2081,6 +2133,7 @@ class AudioPlayerManager: ObservableObject {
     private func stopStreamPlayer() {
         remotePlaybackCacheTask?.cancel()
         remotePlaybackCacheTask = nil
+        remotePlaybackCacheToken = nil
         streamPlayerCancellables.removeAll()
         streamPlaybackRequested = false
         if let observer = streamEndObserver {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -338,6 +338,7 @@ class AudioPlayerManager: ObservableObject {
     private var streamPlayerCancellables = Set<AnyCancellable>()
     private var radioPlaybackRequested = false
     private var streamPlaybackRequested = false
+    private var remotePlaybackCacheTask: Task<Void, Never>?
     private var lastKnownPlaybackTime: TimeInterval = 0
     private var pollTimer: Timer?
     private var streamFadeTimer: Timer?
@@ -396,10 +397,19 @@ class AudioPlayerManager: ObservableObject {
         return !isKaraokePreparedForCurrentSong
     }
 
+    private var isRemotePlaybackCaching: Bool {
+        remotePlaybackCacheTask != nil
+    }
+
     private var isPlaybackRequested: Bool {
         if isRadioMode { return radioPlaybackRequested }
+        if isRemotePlaybackCaching { return streamPlaybackRequested }
         if isStreamMode { return streamPlaybackRequested }
         return isPlaying
+    }
+
+    private var nowPlayingPlaybackRate: Double {
+        isPlaybackRequested ? 1.0 : 0.0
     }
 
     var isBackgroundKaraokeLocked: Bool {
@@ -577,6 +587,7 @@ class AudioPlayerManager: ObservableObject {
         streamFadeTimer?.invalidate()
         instrumentalTask?.cancel()
         backgroundAnalysisRetryTask?.cancel()
+        remotePlaybackCacheTask?.cancel()
         if let existing = radioTimeObserver {
             existing.player.removeTimeObserver(existing.token)
         }
@@ -807,9 +818,11 @@ class AudioPlayerManager: ObservableObject {
 
         if let remoteURL = song.audioURL {
             avEngine.stop()
+            let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
             startStreamPlayback(
                 url: remoteURL,
                 songID: song.id,
+                expectedDuration: expectedDuration,
                 startAt: max(0, elapsed),
                 autoplay: isPlaybackRequested
             )
@@ -1221,7 +1234,8 @@ class AudioPlayerManager: ObservableObject {
             #endif
             return
         }
-        startStreamPlayback(url: remoteURL, songID: song.id)
+        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+        startStreamPlayback(url: remoteURL, songID: song.id, expectedDuration: expectedDuration)
         if aiEnabled {
             if anyAIEffectActive {
                 applyMLSeparationIfNeeded()
@@ -1351,7 +1365,8 @@ class AudioPlayerManager: ObservableObject {
             )
             return
         }
-        startStreamPlayback(url: remoteURL, songID: song.id, startAt: resumeAt)
+        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+        startStreamPlayback(url: remoteURL, songID: song.id, expectedDuration: expectedDuration, startAt: resumeAt)
     }
 
     /// Returns true when a pause request matched an active or resumable playback path.
@@ -1386,6 +1401,17 @@ class AudioPlayerManager: ObservableObject {
             player.pause()
             setPlaybackState(playing: false, buffering: false, reason: "pause.radio.\(source)")
             return true
+        }
+        if isRemotePlaybackCaching {
+            let wasActive = streamPlaybackRequested || isBuffering
+            streamPlaybackRequested = false
+            setPlaybackState(
+                playing: false,
+                buffering: false,
+                forceNowPlayingUpdate: true,
+                reason: "pause.cachedRemote.\(source)"
+            )
+            return wasActive
         }
         if isStreamMode {
             let wasActive = streamPlaybackRequested || isPlaying || isBuffering
@@ -1455,8 +1481,30 @@ class AudioPlayerManager: ObservableObject {
             NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
             radioPlaybackRequested = true
             setPlaybackState(playing: false, buffering: true, reason: "resume.radio.buffering.\(source)")
-            player.play()
+            player.playImmediately(atRate: 1.0)
             refreshManagedPlayerState(player, kind: .radio)
+            return true
+        }
+        if isRemotePlaybackCaching {
+            guard !streamPlaybackRequested || !isBuffering else {
+                setPlaybackState(
+                    playing: false,
+                    buffering: true,
+                    forceNowPlayingUpdate: true,
+                    reason: "resume.cachedRemote.alreadyPreparing.\(source)"
+                )
+                return true
+            }
+            configureAudioSessionCategory()
+            activateAudioSession()
+            NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
+            streamPlaybackRequested = true
+            setPlaybackState(
+                playing: false,
+                buffering: true,
+                forceNowPlayingUpdate: true,
+                reason: "resume.cachedRemote.buffering.\(source)"
+            )
             return true
         }
         if isStreamMode {
@@ -1479,11 +1527,17 @@ class AudioPlayerManager: ObservableObject {
             NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
             streamPlaybackRequested = true
             setPlaybackState(playing: false, buffering: true, reason: "resume.stream.buffering.\(source)")
-            player.play()
+            player.playImmediately(atRate: 1.0)
             refreshManagedPlayerState(player, kind: .stream)
             return true
         }
         guard currentSong != nil else { return false }
+        if !isPlaying, avEngine.currentURL == nil, let song = currentSong,
+           let fileURL = localPlaybackFileURL(for: song)
+        {
+            startPlayingFile(fileURL, startAt: lastKnownPlaybackTime)
+            return true
+        }
         guard !isPlaying else {
             setPlaybackState(
                 playing: true,
@@ -1849,7 +1903,7 @@ class AudioPlayerManager: ObservableObject {
         )
         observeManagedPlayer(player, item: item, kind: .radio)
         NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
-        player.play()
+        player.playImmediately(atRate: 1.0)
     }
 
     private func stopRadioPlayer() {
@@ -1867,6 +1921,7 @@ class AudioPlayerManager: ObservableObject {
     private func startStreamPlayback(
         url: URL,
         songID: String,
+        expectedDuration: TimeInterval? = nil,
         startAt: TimeInterval = 0,
         autoplay: Bool = true
     ) {
@@ -1875,19 +1930,11 @@ class AudioPlayerManager: ObservableObject {
         avEngine.stop()
         currentPlaybackURL = url
         DebugLogger.log(
-            "Starting stream playback for \(songID): source=\(playbackSourceDescription(url)), startAt=\(startAt), autoplay=\(autoplay)",
+            "Starting cached remote playback for \(songID): source=\(playbackSourceDescription(url)), startAt=\(startAt), autoplay=\(autoplay)",
             category: .playback
         )
         configureAudioSessionCategory()
         activateAudioSession()
-        let item = AVPlayerItem(url: url)
-        let player = AVPlayer(playerItem: item)
-        if #available(iOS 15.0, *) {
-            player.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
-        }
-        player.automaticallyWaitsToMinimizeStalling = true
-        player.volume = 1.0
-        streamPlayer = player
         streamStartedAt = Date()
         streamPlaybackRequested = autoplay
         setPlaybackState(
@@ -1896,50 +1943,144 @@ class AudioPlayerManager: ObservableObject {
             reloadArtwork: true,
             reason: "startStreamPlayback"
         )
-        observeManagedPlayer(player, item: item, kind: .stream)
         if startAt > 0 {
             setPreferredStreamResumeTime(startAt, for: songID)
         } else {
             clearPreferredStreamResumeTime()
         }
-        streamEndObserver = NotificationCenter.default.addObserver(
-            forName: .AVPlayerItemDidPlayToEndTime, object: item, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                guard let self, isStreamMode, !self.isRadioMode else { return }
-                guard isPlaying else { return }
-                guard !avEngine.isCrossfading, !avEngine.isCrossfadePending else { return }
-                guard quickCutTimer == nil else { return }
-                guard !suppressTransitionAfterSeek else { return }
-                guard !isPlaybackEndedCallbackSuppressed else { return }
-                if handlePrematurePlaybackEndIfNeeded(source: "Stream AVPlayer") { return }
-                playNextOrRandom()
-            }
-        }
         if autoplay {
             NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
         }
-        if startAt > 0 {
-            let target = CMTime(seconds: startAt, preferredTimescale: 600)
-            player.pause()
-            player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero) {
-                [weak self, weak player] _ in
-                Task { @MainActor [weak self, weak player] in
-                    guard let self, let player, streamPlayer === player else { return }
-                    guard streamPlaybackRequested else {
-                        refreshManagedPlayerState(player, kind: .stream)
-                        return
+
+        remotePlaybackCacheTask?.cancel()
+        remotePlaybackCacheTask = Task { [weak self] in
+            do {
+                let cachedURL = try await Self.cacheRemoteAudio(
+                    from: url,
+                    songID: songID,
+                    expectedDuration: expectedDuration
+                )
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    guard currentSong?.id == songID, currentPlaybackURL == url else { return }
+                    remotePlaybackCacheTask = nil
+                    if streamPlaybackRequested {
+                        startPlayingFile(cachedURL, startAt: startAt)
+                    } else {
+                        currentPlaybackURL = cachedURL
+                        setPlaybackState(
+                            playing: false,
+                            buffering: false,
+                            forceNowPlayingUpdate: true,
+                            reason: "startStreamPlayback.cachedPaused"
+                        )
                     }
-                    player.play()
-                    refreshManagedPlayerState(player, kind: .stream)
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    guard let self, currentSong?.id == songID else { return }
+                    guard currentPlaybackURL == url else { return }
+                    remotePlaybackCacheTask = nil
+                    streamPlaybackRequested = false
+                    setPlaybackState(
+                        playing: false,
+                        buffering: false,
+                        forceNowPlayingUpdate: true,
+                        reason: "startStreamPlayback.cancelled"
+                    )
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self, currentSong?.id == songID else { return }
+                    guard currentPlaybackURL == url else { return }
+                    remotePlaybackCacheTask = nil
+                    streamPlaybackRequested = false
+                    DebugLogger.log(
+                        "Remote playback cache failed for \(songID): \(error.localizedDescription)",
+                        category: .playback
+                    )
+                    setPlaybackState(
+                        playing: false,
+                        buffering: false,
+                        forceNowPlayingUpdate: true,
+                        reason: "startStreamPlayback.cacheFailed"
+                    )
                 }
             }
-        } else if autoplay {
-            player.play()
+        }
+    }
+
+    private static func cacheRemoteAudio(
+        from remoteURL: URL,
+        songID: String,
+        expectedDuration: TimeInterval?
+    ) async throws -> URL {
+        if let cachedURL = AudioCacheStore.playableMainURL(
+            for: songID,
+            expectedRemoteURL: remoteURL,
+            expectedDuration: expectedDuration
+        ) {
+            DebugLogger.log("Remote playback cache hit for \(songID)", category: .cache)
+            return cachedURL
+        }
+
+        let songFiles = AudioCacheStore.files(for: songID)
+        DebugLogger.log("Remote playback cache start for \(songID)", category: .cache)
+        try? FileManager.default.removeItem(at: songFiles.mainPartial)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.waitsForConnectivity = true
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 180
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        let (temporaryURL, response) = try await session.download(from: remoteURL)
+        try Task.checkCancellation()
+        guard AudioCacheStore.acceptsAudioResponse(response) else {
+            throw RemotePlaybackCacheError.invalidResponse
+        }
+
+        try? FileManager.default.removeItem(at: songFiles.mainPartial)
+        do {
+            try FileManager.default.moveItem(at: temporaryURL, to: songFiles.mainPartial)
+        } catch {
+            try FileManager.default.copyItem(at: temporaryURL, to: songFiles.mainPartial)
+            try? FileManager.default.removeItem(at: temporaryURL)
+        }
+        try Task.checkCancellation()
+
+        guard AudioCacheStore.isPlayableAudioFile(at: songFiles.mainPartial) else {
+            try? FileManager.default.removeItem(at: songFiles.mainPartial)
+            throw RemotePlaybackCacheError.invalidAudio
+        }
+
+        try? FileManager.default.removeItem(at: songFiles.main)
+        try FileManager.default.moveItem(at: songFiles.mainPartial, to: songFiles.main)
+        AudioCacheStore.writeMainSourceURL(remoteURL, for: songID)
+        DebugLogger.log("Remote playback cache complete for \(songID)", category: .cache)
+        return songFiles.main
+    }
+
+    private enum RemotePlaybackCacheError: LocalizedError {
+        case invalidResponse
+        case invalidAudio
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidResponse:
+                "Remote audio response was not playable"
+            case .invalidAudio:
+                "Downloaded remote audio was not playable"
+            }
         }
     }
 
     private func stopStreamPlayer() {
+        remotePlaybackCacheTask?.cancel()
+        remotePlaybackCacheTask = nil
         streamPlayerCancellables.removeAll()
         streamPlaybackRequested = false
         if let observer = streamEndObserver {
@@ -2007,6 +2148,7 @@ class AudioPlayerManager: ObservableObject {
         cancelPlayerArtworkWarmups()
         warmedPlayerArtworkAt.removeAll()
         cacheCompressionTask?.cancel()
+        remotePlaybackCacheTask?.cancel()
         instrumentalTask?.cancel()
         instrumentalTask = nil
         preparedStemSongID = nil
@@ -2476,15 +2618,24 @@ class AudioPlayerManager: ObservableObject {
                 loadArtworkAsync(from: targetArt)
             }
         }
+        if shouldResetNowPlayingIdentity {
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        }
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
         updateRemoteCommandAvailability()
         DebugLogger.log(
-            "Now Playing updated: rate=\(isPlaying ? 1.0 : 0.0), playing=\(isPlaying), buffering=\(isBuffering)",
+            "Now Playing updated: rate=\(nowPlayingPlaybackRate), playing=\(isPlaying), buffering=\(isBuffering)",
             category: .playback
         )
         lastNowPlayingElapsedSecond = isRadioMode ? nil : Int(playbackTime.rounded(.down))
-        lastNowPlayingPlaybackRate = isPlaying ? 1.0 : 0.0
+        lastNowPlayingPlaybackRate = nowPlayingPlaybackRate
         lastLoggedNowPlayingElapsedSecond = nil
+    }
+
+    private var shouldResetNowPlayingIdentity: Bool {
+        guard isStreamMode || isRadioMode else { return false }
+        guard let lastNowPlayingPlaybackRate else { return false }
+        return lastNowPlayingPlaybackRate != nowPlayingPlaybackRate
     }
 
     private func updateNowPlayingElapsed(_ elapsed: Double) {
@@ -2493,7 +2644,7 @@ class AudioPlayerManager: ObservableObject {
             return
         }
         let roundedSecond = Int(elapsed.rounded(.down))
-        let playbackRate = isPlaying ? 1.0 : 0.0
+        let playbackRate = nowPlayingPlaybackRate
         guard roundedSecond != lastNowPlayingElapsedSecond
             || playbackRate != lastNowPlayingPlaybackRate else { return }
         guard let song = currentSong else {
@@ -2525,13 +2676,8 @@ class AudioPlayerManager: ObservableObject {
         includeExistingArtwork: Bool
     ) -> [String: Any] {
         let currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
-        // Keep the system surfaces driven by the public Now Playing contract:
-        // metadata, elapsed time, duration, and playback rate. Do not use
-        // MPNowPlayingInfoCenter.playbackState here; on iOS it logs an ignored
-        // MediaRemote private-entitlement warning for third-party apps. The audio
-        // media type matches public Swift player integrations such as Expo's
-        // MediaController:
-        // https://github.com/expo/expo/blob/main/packages/expo-audio/ios/MediaController.swift
+        // Keep system surfaces driven by the public Now Playing contract:
+        // metadata, elapsed time, duration, and playback rate.
         let originalArtists = song.originalArtists?
             .filter { !$0.isEmpty }
             .joined(separator: ", ")
@@ -2546,7 +2692,7 @@ class AudioPlayerManager: ObservableObject {
             MPMediaItemPropertyArtist: artist,
             MPMediaItemPropertyMediaType: MPMediaType.music.rawValue,
             MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.audio.rawValue,
-            MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? 1.0 : 0.0,
+            MPNowPlayingInfoPropertyPlaybackRate: nowPlayingPlaybackRate,
             MPNowPlayingInfoPropertyDefaultPlaybackRate: 1.0,
         ]
         if includeExistingArtwork,
@@ -2610,6 +2756,14 @@ class AudioPlayerManager: ObservableObject {
                 )
                 info[MPMediaItemPropertyArtwork] = artwork
                 MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+                self.updateRemoteCommandAvailability()
+                if self.isRadioMode {
+                    self.lastNowPlayingElapsedSecond = nil
+                } else {
+                    self.lastNowPlayingElapsedSecond = Int(self.playbackTime.rounded(.down))
+                }
+                self.lastNowPlayingPlaybackRate = self.nowPlayingPlaybackRate
+                self.lastLoggedNowPlayingElapsedSecond = nil
                 self.nowPlayingArtwork = image
             }
         }

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -348,6 +348,8 @@ class AudioPlayerManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var artworkURL: URL?
     private var artworkTask: (any SDWebImageOperation)?
+    private var playerArtworkWarmupTasks: [String: any SDWebImageOperation] = [:]
+    private var warmedPlayerArtworkAt: [String: Date] = [:]
     private var currentPlaybackURL: URL?
     private var instrumentalTask: Task<Void, Never>?
     private var backgroundAnalysisRetryTask: Task<Void, Never>?
@@ -579,6 +581,8 @@ class AudioPlayerManager: ObservableObject {
             existing.player.removeTimeObserver(existing.token)
         }
         artworkTask?.cancel()
+        playerArtworkWarmupTasks.values.forEach { $0.cancel() }
+        playerArtworkWarmupTasks.removeAll()
         cacheCompressionTask?.cancel()
         radioPlayer?.pause()
         #if canImport(UIKit)
@@ -972,6 +976,7 @@ class AudioPlayerManager: ObservableObject {
             category: .playback
         )
         cancelPendingTransitionWork()
+        cancelPlayerArtworkWarmups()
         instrumentalTask?.cancel()
         instrumentalTask = nil
         cancelBackgroundAnalysisRetry()
@@ -1162,6 +1167,7 @@ class AudioPlayerManager: ObservableObject {
         } else {
             currentSong = song
         }
+        warmPlayerArtwork(for: song)
         if !context.isEmpty {
             queue = context
             if isShuffled {
@@ -1285,6 +1291,39 @@ class AudioPlayerManager: ObservableObject {
             triggerBackgroundAnalysis(for: song)
             prepareBackgroundStemPlaybackIfPossible(for: song)
         }
+    }
+
+    private func warmPlayerArtwork(for song: Song) {
+        let urls = [
+            displayImageURL(for: song, variant: .thumbnail),
+            displayImageURL(for: song, variant: .card),
+        ].compactMap { $0 }
+        warmPlayerArtworkURLs(urls)
+    }
+
+    private func warmPlayerArtworkURLs(_ urls: [URL]) {
+        let now = Date()
+        warmedPlayerArtworkAt = warmedPlayerArtworkAt.filter { now.timeIntervalSince($0.value) < 60 }
+        for url in urls {
+            let key = url.absoluteString
+            guard warmedPlayerArtworkAt[key] == nil, playerArtworkWarmupTasks[key] == nil else { continue }
+            warmedPlayerArtworkAt[key] = now
+            playerArtworkWarmupTasks[key] = SDWebImageManager.shared.loadImage(
+                with: url,
+                options: [.highPriority],
+                context: ImageCacheConfig.visibleImageContext,
+                progress: nil
+            ) { [weak self] _, _, _, _, _, _ in
+                Task { @MainActor in
+                    self?.playerArtworkWarmupTasks.removeValue(forKey: key)
+                }
+            }
+        }
+    }
+
+    private func cancelPlayerArtworkWarmups() {
+        playerArtworkWarmupTasks.values.forEach { $0.cancel() }
+        playerArtworkWarmupTasks.removeAll()
     }
 
     private func fallBackToMainPlayback(for song: Song, startAt: TimeInterval) {
@@ -1944,16 +1983,29 @@ class AudioPlayerManager: ObservableObject {
         updateNowPlayingInfo(reloadArtwork: true)
     }
 
-    func displayImageURL(for song: Song) -> URL? {
+    func displayImageURL(for song: Song, variant: ArtworkImageVariant = .card) -> URL? {
         if isRadioMode, currentSong?.id == song.id, let art = radioArtworkURL {
-            return art
+            return ArtworkURLBuilder.variantURL(from: art, variant: variant) ?? art
         }
-        return song.imageURL
+        switch variant {
+        case .row:
+            return song.rowImageURL
+        case .thumbnail:
+            return song.thumbnailURL
+        case .hero:
+            return song.heroImageURL
+        case .fullHD:
+            return song.fullHDImageURL
+        default:
+            return song.imageURL
+        }
     }
 
     func clearCache() {
         DebugLogger.log("Clearing all cache", category: .cache)
         cancelPendingTransitionWork()
+        cancelPlayerArtworkWarmups()
+        warmedPlayerArtworkAt.removeAll()
         cacheCompressionTask?.cancel()
         instrumentalTask?.cancel()
         instrumentalTask = nil
@@ -2419,6 +2471,7 @@ class AudioPlayerManager: ObservableObject {
             #if canImport(UIKit)
                 if reloadArtwork { nowPlayingArtwork = nil }
             #endif
+            warmPlayerArtwork(for: song)
             if let targetArt {
                 loadArtworkAsync(from: targetArt)
             }
@@ -2520,21 +2573,10 @@ class AudioPlayerManager: ObservableObject {
                 applyArtwork(cached, for: songID, artworkURL: url)
                 return
             }
-            let pixelSize = NSValue(
-                cgSize: CGSize(
-                    width: AudioPlayerManager.artworkMaxPixel,
-                    height: AudioPlayerManager.artworkMaxPixel
-                )
-            )
             artworkTask = SDWebImageManager.shared.loadImage(
                 with: url,
-                options: [.scaleDownLargeImages],
-                context: [
-                    .imageThumbnailPixelSize: pixelSize,
-                    .storeCacheType: NSNumber(value: SDImageCacheType.memory.rawValue),
-                    .originalStoreCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                    .originalQueryCacheType: NSNumber(value: SDImageCacheType.disk.rawValue),
-                ],
+                options: [],
+                context: ImageCacheConfig.memoryAndDiskCacheContext,
                 progress: nil
             ) { [weak self] image, _, _, _, _, _ in
                 guard let self, currentSong?.id == songID else { return }

--- a/Twinskaraoke/Services/Debug/PlaybackRowState.swift
+++ b/Twinskaraoke/Services/Debug/PlaybackRowState.swift
@@ -36,10 +36,21 @@ final class PlaybackRowState: ObservableObject {
             .store(in: &cancellables)
     }
 
-    func displayImageURL(for song: Song) -> URL? {
+    func displayImageURL(for song: Song, variant: ArtworkImageVariant = .card) -> URL? {
         if isRadioMode, currentSongID == song.id, let radioArtworkURL {
-            return radioArtworkURL
+            return ArtworkURLBuilder.variantURL(from: radioArtworkURL, variant: variant) ?? radioArtworkURL
         }
-        return song.imageURL
+        switch variant {
+        case .row:
+            return song.rowImageURL
+        case .thumbnail:
+            return song.thumbnailURL
+        case .hero:
+            return song.heroImageURL
+        case .fullHD:
+            return song.fullHDImageURL
+        default:
+            return song.imageURL
+        }
     }
 }

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -49,6 +49,22 @@ nonisolated enum AudioCacheStore {
         return playableURL(for: files(for: songID).main)
     }
 
+    /// Like `playableMainURL`, but never decompresses: returns nil when only the
+    /// compressed cache exists, so callers on the main thread can defer that
+    /// work to a background path instead.
+    static func immediatelyPlayableMainURL(
+        for songID: String,
+        expectedRemoteURL: URL? = nil,
+        expectedDuration: TimeInterval? = nil
+    ) -> URL? {
+        guard fm.fileExists(atPath: files(for: songID).main.path) else { return nil }
+        return playableMainURL(
+            for: songID,
+            expectedRemoteURL: expectedRemoteURL,
+            expectedDuration: expectedDuration
+        )
+    }
+
     static func playableStems(
         for songID: String,
         startOffset: TimeInterval,

--- a/Twinskaraoke/Services/Storage/CacheManager.swift
+++ b/Twinskaraoke/Services/Storage/CacheManager.swift
@@ -6,10 +6,10 @@ import SDWebImageSwiftUI
 final class CacheManager: ObservableObject {
     static let shared = CacheManager()
 
-    static let imageCacheLimit: UInt64 = 2 * 1024 * 1024 * 1024
-    static let musicCacheLimit: UInt64 = 4 * 1024 * 1024 * 1024
-    static let lyricsCacheLimit: UInt64 = 2 * 1024 * 1024 * 1024
-    static let maxCacheAge: TimeInterval = 6 * 30 * 24 * 3600
+    nonisolated static let imageCacheLimit: UInt64 = 2 * 1024 * 1024 * 1024
+    nonisolated static let musicCacheLimit: UInt64 = 4 * 1024 * 1024 * 1024
+    nonisolated static let lyricsCacheLimit: UInt64 = 2 * 1024 * 1024 * 1024
+    nonisolated static let maxCacheAge: TimeInterval = 6 * 30 * 24 * 3600
 
     @Published private(set) var imageCacheSize: UInt64 = 0
     @Published private(set) var musicCacheSize: UInt64 = 0
@@ -17,73 +17,85 @@ final class CacheManager: ObservableObject {
 
     private let fm = FileManager.default
 
+    // Maintenance walks entire cache directories (music cache can hold
+    // gigabytes across hundreds of folders). That file I/O must stay off the
+    // main thread; the serial queue also keeps passes from overlapping.
+    private nonisolated static let maintenanceQueue = DispatchQueue(
+        label: "nk.cacheMaintenance", qos: .utility
+    )
+
     private init() {
-        refreshSizes()
-        pruneExpiredEntries()
-        enforceAllLimits()
-        DebugLogger.log("CacheManager initialized", category: .cache)
+        let directories = Self.directories
+        Self.maintenanceQueue.async { [weak self] in
+            guard let self else { return }
+            let pruned = pruneExpiredEntriesBlocking(directories: directories)
+            DebugLogger.log("Pruned \(pruned) expired cache entries", category: .cache)
+            _ = enforceImageCacheLimitsBlocking(imageDirectory: directories.image)
+            _ = enforceMusicCacheLimitsBlocking(musicDirectory: directories.music, excluding: [])
+            _ = enforceLyricsCacheLimitsBlocking(lyricsDirectory: directories.lyrics)
+            publishSizes(computeSizesBlocking(directories: directories))
+            DebugLogger.log("CacheManager initialized", category: .cache)
+        }
+    }
+
+    private static var directories: (image: URL, music: URL, lyrics: URL) {
+        (imageCacheDirectory, AudioPlayerManager.audioCacheDir, LyricsCacheStore.cacheDirectory)
     }
 
     func enforceAllLimits() {
-        enforceImageCacheLimits()
-        enforceMusicCacheLimits()
-        enforceLyricsCacheLimits()
+        let directories = Self.directories
+        Self.maintenanceQueue.async { [weak self] in
+            guard let self else { return }
+            let image = enforceImageCacheLimitsBlocking(imageDirectory: directories.image)
+            let music = enforceMusicCacheLimitsBlocking(musicDirectory: directories.music, excluding: [])
+            let lyrics = enforceLyricsCacheLimitsBlocking(lyricsDirectory: directories.lyrics)
+            publishSizes((image: image, music: music, lyrics: lyrics))
+        }
     }
 
     func refreshSizes() {
-        imageCacheSize = computeImageCacheSize()
-        musicCacheSize = computeMusicCacheSize()
-        lyricsCacheSize = computeLyricsCacheSize()
-        DebugLogger.log(
-            "Cache sizes — images: \(formatBytes(imageCacheSize)), music: \(formatBytes(musicCacheSize)), lyrics: \(formatBytes(lyricsCacheSize))",
-            category: .cache
-        )
+        let directories = Self.directories
+        Self.maintenanceQueue.async { [weak self] in
+            guard let self else { return }
+            publishSizes(computeSizesBlocking(directories: directories))
+        }
     }
 
     func enforceImageCacheLimits() {
-        let sdCache = SDImageCache.shared
-        let diskSize = UInt64(sdCache.totalDiskSize())
-
-        if diskSize > Self.imageCacheLimit {
-            DebugLogger.log(
-                "Image cache \(formatBytes(diskSize)) exceeds limit \(formatBytes(Self.imageCacheLimit)), clearing oldest",
-                category: .cache
-            )
-            sdCache.deleteOldFiles(completionBlock: nil)
+        let imageDirectory = Self.imageCacheDirectory
+        Self.maintenanceQueue.async { [weak self] in
+            guard let self else { return }
+            let size = enforceImageCacheLimitsBlocking(imageDirectory: imageDirectory)
+            publishSizes((image: size, music: nil, lyrics: nil))
         }
-
-        let imageCacheDir = Self.imageCacheDirectory
-        evictOldestFiles(in: imageCacheDir, limit: Self.imageCacheLimit, label: "image")
-
-        imageCacheSize = computeImageCacheSize()
     }
 
     func enforceMusicCacheLimits(excluding songIDs: Set<String> = []) {
-        let musicDir = AudioPlayerManager.audioCacheDir
-        evictOldestSongDirectories(in: musicDir, limit: Self.musicCacheLimit, excluding: songIDs)
-        musicCacheSize = computeMusicCacheSize()
+        let musicDirectory = AudioPlayerManager.audioCacheDir
+        Self.maintenanceQueue.async { [weak self] in
+            guard let self else { return }
+            let size = enforceMusicCacheLimitsBlocking(musicDirectory: musicDirectory, excluding: songIDs)
+            publishSizes((image: nil, music: size, lyrics: nil))
+        }
     }
 
     func enforceLyricsCacheLimits() {
-        evictOldestFiles(in: LyricsCacheStore.cacheDirectory, limit: Self.lyricsCacheLimit, label: "lyrics")
-        lyricsCacheSize = computeLyricsCacheSize()
+        let lyricsDirectory = LyricsCacheStore.cacheDirectory
+        Self.maintenanceQueue.async { [weak self] in
+            guard let self else { return }
+            let size = enforceLyricsCacheLimitsBlocking(lyricsDirectory: lyricsDirectory)
+            publishSizes((image: nil, music: nil, lyrics: size))
+        }
     }
 
     func pruneExpiredEntries() {
-        let cutoff = Date().addingTimeInterval(-Self.maxCacheAge)
-        DebugLogger.log("Pruning cache entries older than \(cutoff)", category: .cache)
-
-        var prunedCount = 0
-
-        let musicDir = AudioPlayerManager.audioCacheDir
-        prunedCount += pruneOldSongDirectories(in: musicDir, olderThan: cutoff)
-
-        prunedCount += pruneOldFiles(in: LyricsCacheStore.cacheDirectory, olderThan: cutoff)
-
-        SDImageCache.shared.deleteOldFiles(completionBlock: nil)
-
-        DebugLogger.log("Pruned \(prunedCount) expired cache entries", category: .cache)
-        refreshSizes()
+        let directories = Self.directories
+        Self.maintenanceQueue.async { [weak self] in
+            guard let self else { return }
+            let pruned = pruneExpiredEntriesBlocking(directories: directories)
+            DebugLogger.log("Pruned \(pruned) expired cache entries", category: .cache)
+            publishSizes(computeSizesBlocking(directories: directories))
+        }
     }
 
     func recordAccess(for url: URL) {
@@ -142,19 +154,81 @@ final class CacheManager: ObservableObject {
             .appendingPathComponent("com.hackemist.SDImageCache/default", isDirectory: true)
     }
 
-    private func computeImageCacheSize() -> UInt64 {
-        UInt64(SDImageCache.shared.totalDiskSize())
+    // MARK: - Maintenance cores (run on maintenanceQueue, never the main actor)
+
+    private nonisolated func publishSizes(
+        _ sizes: (image: UInt64?, music: UInt64?, lyrics: UInt64?)
+    ) {
+        if let image = sizes.image, let music = sizes.music, let lyrics = sizes.lyrics {
+            DebugLogger.log(
+                "Cache sizes — images: \(formatBytes(image)), music: \(formatBytes(music)), lyrics: \(formatBytes(lyrics))",
+                category: .cache
+            )
+        }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let image = sizes.image { imageCacheSize = image }
+            if let music = sizes.music { musicCacheSize = music }
+            if let lyrics = sizes.lyrics { lyricsCacheSize = lyrics }
+        }
     }
 
-    private func computeMusicCacheSize() -> UInt64 {
-        directorySize(at: AudioPlayerManager.audioCacheDir)
+    private nonisolated func computeSizesBlocking(
+        directories: (image: URL, music: URL, lyrics: URL)
+    ) -> (image: UInt64?, music: UInt64?, lyrics: UInt64?) {
+        (
+            image: UInt64(SDImageCache.shared.totalDiskSize()),
+            music: directorySize(at: directories.music),
+            lyrics: directorySize(at: directories.lyrics)
+        )
     }
 
-    private func computeLyricsCacheSize() -> UInt64 {
-        directorySize(at: LyricsCacheStore.cacheDirectory)
+    private nonisolated func enforceImageCacheLimitsBlocking(imageDirectory: URL) -> UInt64 {
+        let sdCache = SDImageCache.shared
+        let diskSize = UInt64(sdCache.totalDiskSize())
+
+        if diskSize > Self.imageCacheLimit {
+            DebugLogger.log(
+                "Image cache \(formatBytes(diskSize)) exceeds limit \(formatBytes(Self.imageCacheLimit)), clearing oldest",
+                category: .cache
+            )
+            sdCache.deleteOldFiles(completionBlock: nil)
+        }
+
+        evictOldestFiles(in: imageDirectory, limit: Self.imageCacheLimit, label: "image")
+        return UInt64(sdCache.totalDiskSize())
     }
 
-    private func directorySize(at url: URL) -> UInt64 {
+    private nonisolated func enforceMusicCacheLimitsBlocking(
+        musicDirectory: URL,
+        excluding protectedIDs: Set<String>
+    ) -> UInt64 {
+        evictOldestSongDirectories(in: musicDirectory, limit: Self.musicCacheLimit, excluding: protectedIDs)
+        return directorySize(at: musicDirectory)
+    }
+
+    private nonisolated func enforceLyricsCacheLimitsBlocking(lyricsDirectory: URL) -> UInt64 {
+        evictOldestFiles(in: lyricsDirectory, limit: Self.lyricsCacheLimit, label: "lyrics")
+        return directorySize(at: lyricsDirectory)
+    }
+
+    private nonisolated func pruneExpiredEntriesBlocking(
+        directories: (image: URL, music: URL, lyrics: URL)
+    ) -> Int {
+        let cutoff = Date().addingTimeInterval(-Self.maxCacheAge)
+        DebugLogger.log("Pruning cache entries older than \(cutoff)", category: .cache)
+
+        var prunedCount = 0
+        prunedCount += pruneOldSongDirectories(in: directories.music, olderThan: cutoff)
+        prunedCount += pruneOldFiles(in: directories.lyrics, olderThan: cutoff)
+        SDImageCache.shared.deleteOldFiles(completionBlock: nil)
+        return prunedCount
+    }
+
+    // MARK: - File helpers
+
+    private nonisolated func directorySize(at url: URL) -> UInt64 {
+        let fm = FileManager.default
         guard let enumerator = fm.enumerator(
             at: url,
             includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
@@ -173,7 +247,8 @@ final class CacheManager: ObservableObject {
         return total
     }
 
-    private func evictOldestFiles(in directory: URL, limit: UInt64, label: String) {
+    private nonisolated func evictOldestFiles(in directory: URL, limit: UInt64, label: String) {
+        let fm = FileManager.default
         guard fm.fileExists(atPath: directory.path) else { return }
 
         var currentSize = directorySize(at: directory)
@@ -202,7 +277,12 @@ final class CacheManager: ObservableObject {
         )
     }
 
-    private func evictOldestSongDirectories(in directory: URL, limit: UInt64, excluding protectedIDs: Set<String> = []) {
+    private nonisolated func evictOldestSongDirectories(
+        in directory: URL,
+        limit: UInt64,
+        excluding protectedIDs: Set<String> = []
+    ) {
+        let fm = FileManager.default
         guard fm.fileExists(atPath: directory.path) else { return }
 
         var currentSize = directorySize(at: directory)
@@ -223,7 +303,8 @@ final class CacheManager: ObservableObject {
         }
     }
 
-    private func pruneOldFiles(in directory: URL, olderThan cutoff: Date) -> Int {
+    private nonisolated func pruneOldFiles(in directory: URL, olderThan cutoff: Date) -> Int {
+        let fm = FileManager.default
         guard fm.fileExists(atPath: directory.path) else { return 0 }
         guard let enumerator = fm.enumerator(
             at: directory,
@@ -247,7 +328,12 @@ final class CacheManager: ObservableObject {
         return count
     }
 
-    private func pruneOldSongDirectories(in directory: URL, olderThan cutoff: Date, excluding protectedIDs: Set<String> = []) -> Int {
+    private nonisolated func pruneOldSongDirectories(
+        in directory: URL,
+        olderThan cutoff: Date,
+        excluding protectedIDs: Set<String> = []
+    ) -> Int {
+        let fm = FileManager.default
         guard fm.fileExists(atPath: directory.path) else { return 0 }
         guard
             let entries = try? fm.contentsOfDirectory(
@@ -275,7 +361,8 @@ final class CacheManager: ObservableObject {
         return count
     }
 
-    private func filesOrderedByDate(in directory: URL) -> [URL] {
+    private nonisolated func filesOrderedByDate(in directory: URL) -> [URL] {
+        let fm = FileManager.default
         guard let enumerator = fm.enumerator(
             at: directory,
             includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
@@ -296,14 +383,15 @@ final class CacheManager: ObservableObject {
         return files.sorted { $0.date < $1.date }.map(\.url)
     }
 
-    private func fileSize(at url: URL) -> UInt64 {
+    private nonisolated func fileSize(at url: URL) -> UInt64 {
         guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
               let size = values.fileSize
         else { return 0 }
         return UInt64(size)
     }
 
-    private func songDirectoriesOrderedByDate(in directory: URL) -> [URL] {
+    private nonisolated func songDirectoriesOrderedByDate(in directory: URL) -> [URL] {
+        let fm = FileManager.default
         guard
             let entries = try? fm.contentsOfDirectory(
                 at: directory,
@@ -336,14 +424,10 @@ final class CacheManager: ObservableObject {
         }
     }
 
-    private static let bytesFormatter: ByteCountFormatter = {
+    private nonisolated func formatBytes(_ bytes: UInt64) -> String {
         let formatter = ByteCountFormatter()
         formatter.allowedUnits = [.useMB, .useGB]
         formatter.countStyle = .binary
-        return formatter
-    }()
-
-    private func formatBytes(_ bytes: UInt64) -> String {
-        Self.bytesFormatter.string(fromByteCount: Int64(bytes))
+        return formatter.string(fromByteCount: Int64(bytes))
     }
 }

--- a/Twinskaraoke/Services/User/AuthManager.swift
+++ b/Twinskaraoke/Services/User/AuthManager.swift
@@ -304,10 +304,17 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
     }
 
     func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        UIApplication.shared.connectedScenes
+        let scenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .flatMap(\.windows)
-            .first { $0.isKeyWindow } ?? ASPresentationAnchor()
+        let windows = scenes.flatMap(\.windows)
+        if let window = windows.first(where: \.isKeyWindow) ?? windows.first {
+            return window
+        }
+        guard let scene = scenes.first else {
+            // Auth UI is only requested while a scene is connected.
+            preconditionFailure("presentationAnchor requested with no connected window scene")
+        }
+        return ASPresentationAnchor(windowScene: scene)
     }
 
     enum AuthError: Error {

--- a/TwinskaraokeShared/Components/AppMotion.swift
+++ b/TwinskaraokeShared/Components/AppMotion.swift
@@ -8,9 +8,12 @@ enum DisplayRefreshRate {
 
   static var maximumFramesPerSecond: Int {
     #if os(iOS)
-      max(UIScreen.main.maximumFramesPerSecond, 60)
+      let sceneMaximum = UIApplication.shared.connectedScenes
+        .compactMap { ($0 as? UIWindowScene)?.screen.maximumFramesPerSecond }
+        .max()
+      return max(sceneMaximum ?? 60, 60)
     #else
-      60
+      return 60
     #endif
   }
 

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -90,27 +90,40 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   var cloudflareId: String? { cloudflareID }
 
   var imageURL: URL? {
-    imageURL(width: 480, quality: 85)
+    imageURL(variant: .card)
   }
 
   var fullHDImageURL: URL? {
-    imageURL(width: 1920, quality: 90)
+    imageURL(variant: .fullHD)
   }
 
   var thumbnailURL: URL? {
-    imageURL(width: 240, quality: 80)
+    imageURL(variant: .thumbnail)
   }
 
-  private func imageURL(width: Int, quality: Int) -> URL? {
-    if let identifier = cloudflareID, !identifier.isEmpty {
-      let urlString = "\(StorageHost.images)/\(identifier)/width=\(width),quality=\(quality),format=auto"
-      guard let url = URL(string: urlString) else { return neuroFallbackImageURL }
-      return url
-    }
-    guard let path = coverArt?.absolutePath, !path.isEmpty else { return neuroFallbackImageURL }
-    let urlString = StorageHost.images + normalizedImagePath(path) + "/width=\(width),quality=\(quality),format=auto"
-    guard let url = URL(string: urlString) else { return neuroFallbackImageURL }
-    return url
+  var rowImageURL: URL? {
+    imageURL(variant: .row)
+  }
+
+  var heroImageURL: URL? {
+    imageURL(variant: .hero)
+  }
+
+  var downloadCoverImageURL: URL? {
+    guard hasOwnArtwork else { return nil }
+    return ArtworkURLBuilder.imageURL(
+      cloudflareID: cloudflareID,
+      path: coverArt?.absolutePath,
+      variant: .download
+    )
+  }
+
+  private func imageURL(variant: ArtworkImageVariant) -> URL? {
+    ArtworkURLBuilder.imageURL(
+      cloudflareID: cloudflareID,
+      path: coverArt?.absolutePath,
+      variant: variant
+    ) ?? neuroFallbackImageURL
   }
 
   var hasOwnArtwork: Bool {
@@ -192,9 +205,6 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
 
   static func == (lhs: Song, rhs: Song) -> Bool { lhs.id == rhs.id }
 
-  private func normalizedImagePath(_ rawPath: String) -> String {
-    rawPath.hasPrefix("/") ? rawPath : "/\(rawPath)"
-  }
 }
 
 nonisolated struct Playlist: Codable, Identifiable, Hashable, Sendable {
@@ -263,16 +273,47 @@ nonisolated struct Playlist: Codable, Identifiable, Hashable, Sendable {
   }
 
   var imageURL: URL? {
-    if let cfId = media?.cloudflareId, !cfId.isEmpty {
-      return URL(string: "\(StorageHost.images)/\(cfId)/width=480,quality=85,format=auto")
+    imageURL(variant: .card)
+  }
+
+  var thumbnailURL: URL? {
+    imageURL(variant: .thumbnail)
+  }
+
+  var rowImageURL: URL? {
+    imageURL(variant: .row)
+  }
+
+  func imageURL(variant: ArtworkImageVariant) -> URL? {
+    if let url = ArtworkURLBuilder.imageURL(
+      cloudflareID: media?.cloudflareId,
+      path: media?.absolutePath,
+      variant: variant
+    ) {
+      return url
     }
-    if let path = media?.absolutePath, !path.isEmpty {
-      return URL(string: StorageHost.images + normalizedImagePath(path) + "/width=480,quality=85,format=auto")
+    if let media = mosaicMedia?.first,
+      let url = ArtworkURLBuilder.imageURL(
+        cloudflareID: media.cloudflareId,
+        path: media.absolutePath,
+        variant: variant
+      )
+    {
+      return url
     }
-    if let path = mosaicMedia?.first?.absolutePath {
-      return URL(string: StorageHost.images + normalizedImagePath(path) + "/width=480,quality=85,format=auto")
+    guard let song = songListDTOs?.first else { return nil }
+    switch variant {
+    case .row:
+      return song.rowImageURL
+    case .thumbnail:
+      return song.thumbnailURL
+    case .hero:
+      return song.heroImageURL
+    case .fullHD:
+      return song.fullHDImageURL
+    default:
+      return song.imageURL
     }
-    return songListDTOs?.first?.imageURL
   }
 
   var isFavorites: Bool { id == Self.favoritesID }
@@ -285,10 +326,6 @@ nonisolated struct Playlist: Codable, Identifiable, Hashable, Sendable {
 
   func hash(into hasher: inout Hasher) {
     hasher.combine(id)
-  }
-
-  private func normalizedImagePath(_ rawPath: String) -> String {
-    rawPath.hasPrefix("/") ? rawPath : "/\(rawPath)"
   }
 
   private static func decodeSongs(
@@ -386,6 +423,32 @@ nonisolated struct PlaylistMedia: Codable, Sendable {
 
 nonisolated struct Media: Codable, Sendable {
   let absolutePath: String?
+  let cloudflareId: String?
+
+  private enum CodingKeys: String, CodingKey {
+    case absolutePath
+    case cloudflareId
+    case cloudflareID
+  }
+
+  init(absolutePath: String?, cloudflareId: String? = nil) {
+    self.absolutePath = absolutePath
+    self.cloudflareId = cloudflareId
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    absolutePath = try? container.decodeIfPresent(String.self, forKey: .absolutePath)
+    cloudflareId =
+      (try? container.decodeIfPresent(String.self, forKey: .cloudflareId))
+      ?? (try? container.decodeIfPresent(String.self, forKey: .cloudflareID))
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(absolutePath, forKey: .absolutePath)
+    try container.encodeIfPresent(cloudflareId, forKey: .cloudflareId)
+  }
 }
 
 typealias SongMedia = Media
@@ -411,11 +474,23 @@ nonisolated struct SearchSongItem: Codable, Identifiable, Sendable {
   let cloudflareId: String?
 
   var imageURL: URL? {
-    if let cfId = cloudflareId, !cfId.isEmpty {
-      return URL(string: "\(StorageHost.images)/\(cfId)/width=480,quality=85,format=auto")
-    }
-    guard let path = coverArt?.absolutePath else { return nil }
-    return URL(string: StorageHost.images + normalizedImagePath(path) + "/width=480,quality=85,format=auto")
+    imageURL(variant: .card)
+  }
+
+  var thumbnailURL: URL? {
+    imageURL(variant: .thumbnail)
+  }
+
+  var rowImageURL: URL? {
+    imageURL(variant: .row)
+  }
+
+  func imageURL(variant: ArtworkImageVariant) -> URL? {
+    ArtworkURLBuilder.imageURL(
+      cloudflareID: cloudflareId,
+      path: coverArt?.absolutePath,
+      variant: variant
+    )
   }
 
   var originalArtistDisplay: String {
@@ -437,9 +512,6 @@ nonisolated struct SearchSongItem: Codable, Identifiable, Sendable {
     )
   }
 
-  private func normalizedImagePath(_ rawPath: String) -> String {
-    rawPath.hasPrefix("/") ? rawPath : "/\(rawPath)"
-  }
 }
 
 nonisolated struct SearchMedia: Codable, Sendable {

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -35,9 +35,10 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   let originalArtists: [String]?
   let coverArtists: [String]?
   let userUploaded: Bool?
+  let oss: String?
 
   enum CodingKeys: String, CodingKey {
-    case id, title, duration, absolutePath, coverArt, originalArtists, coverArtists, userUploaded
+    case id, title, duration, absolutePath, coverArt, originalArtists, coverArtists, userUploaded, oss
     case cloudflareID = "cloudflareId"
   }
 
@@ -50,7 +51,8 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
     coverArt: Media?,
     originalArtists: [String]?,
     coverArtists: [String]?,
-    userUploaded: Bool?
+    userUploaded: Bool?,
+    oss: String? = nil
   ) {
     self.id = id
     self.title = title
@@ -61,6 +63,7 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
     self.originalArtists = originalArtists
     self.coverArtists = coverArtists
     self.userUploaded = userUploaded
+    self.oss = oss
   }
 
   init(
@@ -156,9 +159,16 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   }
 
   var audioURL: URL? {
-    guard let path = absolutePath else { return nil }
-    let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
-    return URL(string: "\(StorageHost.base)/\(cleanPath)")
+    if let path = absolutePath {
+      let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+      return URL(string: "\(StorageHost.base)/\(cleanPath)")
+    }
+    // User-uploaded songs deliver their audio path in `oss`; it can contain
+    // spaces and other characters that need percent-encoding.
+    guard let oss, !oss.isEmpty else { return nil }
+    let cleanPath = oss.hasPrefix("/") ? String(oss.dropFirst()) : oss
+    let encodedPath = cleanPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? cleanPath
+    return URL(string: "\(StorageHost.base)/\(encodedPath)")
   }
 
   var displayTitle: String {

--- a/TwinskaraokeShared/Services/ArtworkURLBuilder.swift
+++ b/TwinskaraokeShared/Services/ArtworkURLBuilder.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+nonisolated enum ArtworkImageVariant {
+  case row
+  case thumbnail
+  case card
+  case hero
+  case fullHD
+  case blur
+  case download
+
+  var width: Int {
+    switch self {
+    case .row: 180
+    case .thumbnail: 240
+    case .card: 480
+    case .hero: 960
+    case .fullHD, .download: 1920
+    case .blur: 32
+    }
+  }
+
+  var quality: Int {
+    switch self {
+    case .row: 78
+    case .thumbnail: 80
+    case .card: 85
+    case .hero: 88
+    case .fullHD, .download: 90
+    case .blur: 30
+    }
+  }
+
+  var extraOptions: [String] {
+    switch self {
+    case .blur:
+      ["blur=30", "format=webp"]
+    default:
+      ["format=webp"]
+    }
+  }
+}
+
+nonisolated enum ArtworkURLBuilder {
+  static func imageURL(cloudflareID: String?, path: String?, variant: ArtworkImageVariant) -> URL? {
+    if let cloudflareID, !cloudflareID.isEmpty {
+      return cloudflareImageURL(path: cloudflareID, variant: variant)
+    }
+    guard let path, !path.isEmpty else { return nil }
+    return cloudflareImageURL(path: path, variant: variant)
+  }
+
+  static func storageResizedURL(path: String?, variant: ArtworkImageVariant) -> URL? {
+    guard let path, !path.isEmpty else { return nil }
+    return URL(string: "\(StorageHost.base)/cdn-cgi/image/\(options(for: variant))\(normalizedPath(path))")
+  }
+
+  static func variantURL(from baseURL: URL, variant: ArtworkImageVariant) -> URL? {
+    guard let components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false),
+          let host = components.host
+    else { return baseURL }
+
+    if host.contains("images.neurokaraoke.com") {
+      guard let path = cloudflareDeliveryPath(from: components.path) else { return baseURL }
+      return cloudflareImageURL(path: path, variant: variant)
+    } else if host.contains("storage.neurokaraoke.com") {
+      guard let path = storageDeliveryPath(from: components.path) else { return baseURL }
+      return storageResizedURL(path: path, variant: variant)
+    } else {
+      return baseURL
+    }
+  }
+
+  static func normalizedPath(_ rawPath: String) -> String {
+    rawPath.hasPrefix("/") ? rawPath : "/\(rawPath)"
+  }
+
+  private static func options(for variant: ArtworkImageVariant) -> String {
+    var parts = ["width=\(variant.width)", "quality=\(variant.quality)"]
+    parts.append(contentsOf: variant.extraOptions)
+    return parts.joined(separator: ",")
+  }
+
+  private static func cloudflareImageURL(path: String, variant: ArtworkImageVariant) -> URL? {
+    guard let deliveryPath = cloudflareDeliveryPath(from: normalizedPath(path)) else { return nil }
+    return URL(string: "\(StorageHost.images)/cdn-cgi/image/\(options(for: variant))/\(deliveryPath)")
+  }
+
+  private static func cloudflareDeliveryPath(from rawPath: String) -> String? {
+    var path = normalizedPath(rawPath)
+    let resizePrefix = "/cdn-cgi/image/"
+
+    if path.hasPrefix(resizePrefix) {
+      let resizedPath = path.dropFirst(resizePrefix.count)
+      guard let imagePathStart = resizedPath.firstIndex(of: "/") else { return nil }
+      path = String(resizedPath[imagePathStart...])
+    }
+
+    if let range = path.range(of: "/width=", options: [.backwards]) {
+      path = String(path[..<range.lowerBound])
+    } else if let range = path.range(of: "/quality=", options: [.backwards]) {
+      path = String(path[..<range.lowerBound])
+    } else if !path.hasSuffix("/public") {
+      let parts = path.split(separator: "/")
+      if let last = parts.last, last.contains("=") {
+        path = "/" + parts.dropLast().joined(separator: "/")
+      }
+    }
+
+    if !path.hasSuffix("/public") {
+      path += "/public"
+    }
+
+    let deliveryPath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    return deliveryPath.isEmpty ? nil : deliveryPath
+  }
+
+  private static func storageDeliveryPath(from rawPath: String) -> String? {
+    var path = normalizedPath(rawPath)
+    let resizePrefix = "/cdn-cgi/image/"
+
+    if path.hasPrefix(resizePrefix) {
+      let resizedPath = path.dropFirst(resizePrefix.count)
+      guard let imagePathStart = resizedPath.firstIndex(of: "/") else { return nil }
+      path = String(resizedPath[imagePathStart...])
+    }
+
+    if let range = path.range(of: "/width=", options: [.backwards]) {
+      path = String(path[..<range.lowerBound])
+    } else if let range = path.range(of: "/quality=", options: [.backwards]) {
+      path = String(path[..<range.lowerBound])
+    }
+
+    return path == "/" ? nil : path
+  }
+}

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -21,15 +21,27 @@ struct SongModelTests {
 
         #expect(
             song.imageURL?.absoluteString
-                == "https://images.neurokaraoke.com/image-id/width=480,quality=85,format=auto"
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=480,quality=85,format=webp/image-id/public"
+        )
+        #expect(
+            song.rowImageURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=180,quality=78,format=webp/image-id/public"
+        )
+        #expect(
+            song.thumbnailURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=240,quality=80,format=webp/image-id/public"
+        )
+        #expect(
+            song.heroImageURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=960,quality=88,format=webp/image-id/public"
         )
         #expect(
             song.fullHDImageURL?.absoluteString
-                == "https://images.neurokaraoke.com/image-id/width=1920,quality=90,format=auto"
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=1920,quality=90,format=webp/image-id/public"
         )
     }
 
-    @Test("downloadCoverImageURL produces a JPEG URL for songs with artwork")
+    @Test("downloadCoverImageURL produces a WebP URL for songs with artwork")
     func downloadCoverImageURLWithArtwork() {
         UserDefaults.standard.set("global", forKey: "nk.storageRegion")
         let song = Song(
@@ -46,8 +58,44 @@ struct SongModelTests {
 
         #expect(
             song.downloadCoverImageURL?.absoluteString
-                == "https://images.neurokaraoke.com/image-id/width=1920,quality=90,format=jpeg"
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=1920,quality=90,format=webp/image-id/public"
         )
+    }
+
+    @Test("ArtworkURLBuilder upgrades Cloudflare delivery URLs to the resize route")
+    func artworkVariantURLUsesCloudflareResizeRoute() throws {
+        let legacyURL = try #require(
+            URL(string: "https://images.neurokaraoke.com/account-hash/image-id/width=180,quality=78,format=webp")
+        )
+        let resizedURL = ArtworkURLBuilder.variantURL(from: legacyURL, variant: .card)
+
+        #expect(
+            resizedURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=480,quality=85,format=webp/account-hash/image-id/public"
+        )
+    }
+
+    @Test("ArtworkURLBuilder keeps storage artwork on the storage resize route")
+    func artworkVariantURLKeepsStorageResizeRoute() throws {
+        let storageURL = try #require(
+            URL(string: "https://storage.neurokaraoke.com/cdn-cgi/image/width=180,quality=78,format=webp/media/artist/example.png")
+        )
+        let resizedURL = ArtworkURLBuilder.variantURL(from: storageURL, variant: .card)
+
+        #expect(
+            resizedURL?.absoluteString
+                == "https://storage.neurokaraoke.com/cdn-cgi/image/width=480,quality=85,format=webp/media/artist/example.png"
+        )
+    }
+
+    @Test("ArtworkURLBuilder leaves unsupported artwork hosts unchanged")
+    func artworkVariantURLLeavesUnsupportedHostsUnchanged() throws {
+        let externalURL = try #require(
+            URL(string: "https://cdn.example.com/artwork/image.jpg")
+        )
+        let resizedURL = ArtworkURLBuilder.variantURL(from: externalURL, variant: .thumbnail)
+
+        #expect(resizedURL == externalURL)
     }
 
     @Test("downloadCoverImageURL is nil for songs without their own artwork")

--- a/TwinskaraokeWatchApp/App/ContentView.swift
+++ b/TwinskaraokeWatchApp/App/ContentView.swift
@@ -164,7 +164,7 @@ struct WatchSongRow: View {
     var body: some View {
         HStack(spacing: 10) {
             WatchSongArtwork(
-                url: song.imageURL,
+                url: song.rowImageURL,
                 size: artworkSize,
                 isCurrent: isCurrent,
                 isPlaying: isPlaying

--- a/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
@@ -147,7 +147,7 @@ private struct WatchPlaylistCard: View {
                             .font(.system(size: 22, weight: .semibold))
                             .foregroundColor(.secondary.opacity(0.65))
                     }
-                AsyncImage(url: playlist.imageURL) { image in
+                AsyncImage(url: playlist.thumbnailURL ?? playlist.imageURL) { image in
                     image.resizable().scaledToFill()
                 } placeholder: {
                     Color.clear

--- a/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
@@ -90,7 +90,7 @@ struct PlayerView: View {
                 ScrollView {
                     VStack(spacing: metrics.contentSpacing) {
                         ZStack {
-                            AsyncImage(url: song.imageURL) { image in
+                            AsyncImage(url: song.thumbnailURL) { image in
                                 image.resizable().scaledToFit()
                             } placeholder: {
                                 RoundedRectangle(cornerRadius: 10)
@@ -285,7 +285,7 @@ struct PlayerView: View {
             }
             .background(
                 Group {
-                    if let url = audioManager.currentSong?.imageURL {
+                    if let url = audioManager.currentSong?.thumbnailURL {
                         AsyncImage(url: url) { image in
                             image.resizable().scaledToFill()
                         } placeholder: {

--- a/TwinskaraokeWatchApp/Features/Player/QueueView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/QueueView.swift
@@ -157,7 +157,7 @@ private struct WatchQueuedSongRow: View {
         HStack(spacing: 10) {
             ZStack(alignment: .bottomTrailing) {
                 WatchSongArtwork(
-                    url: song.imageURL,
+                    url: song.rowImageURL,
                     size: 36,
                     cornerRadius: 8
                 )
@@ -241,7 +241,7 @@ private struct WatchQueueSummaryCard: View {
             HStack(spacing: 10) {
                 ZStack {
                     WatchSongArtwork(
-                        url: song.imageURL,
+                        url: song.thumbnailURL,
                         size: 48,
                         cornerRadius: 10,
                         isCurrent: true,

--- a/TwinskaraokeWatchApp/Features/Search/SearchView.swift
+++ b/TwinskaraokeWatchApp/Features/Search/SearchView.swift
@@ -104,7 +104,7 @@ struct SearchView: View {
                                 )
                             } else {
                                 HStack(spacing: 10) {
-                                    WatchSongArtwork(url: item.imageURL, size: 38)
+                                    WatchSongArtwork(url: item.rowImageURL, size: 38)
                                         .accessibilityHidden(true)
                                     VStack(alignment: .leading, spacing: 2) {
                                         Text(item.title)

--- a/TwinskaraokeWatchAppTests/WatchSongModelTests.swift
+++ b/TwinskaraokeWatchAppTests/WatchSongModelTests.swift
@@ -23,7 +23,11 @@ struct WatchSongModelTests {
         #expect(song.audioURL?.absoluteString == "https://storage.neurokaraoke.com/watch/audio.mp3")
         #expect(
             song.imageURL?.absoluteString
-                == "https://images.neurokaraoke.com/covers/watch.jpg/width=480,quality=85,format=auto"
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=480,quality=85,format=webp/covers/watch.jpg/public"
+        )
+        #expect(
+            song.rowImageURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=180,quality=78,format=webp/covers/watch.jpg/public"
         )
         #expect(song.artistName == "Original Artist")
         #expect(song.durationText == "2:05")


### PR DESCRIPTION
## Summary

Improves artwork loading, playback startup, and main-thread responsiveness across the iOS and watchOS apps. Fixes media remote state for non-downloaded streamed songs, removes main-thread stalls in the caching and playback paths, restores the unit test suite, and clears all iOS 26 deprecation warnings.

## Changes

### Artwork

- Centralizes artwork URL generation through a shared builder.
- Routes Cloudflare artwork through the CDN image transform path.
- Tunes artwork variants by context to reduce oversized image fetches.
- Prefetches visible, home, and library artwork more deliberately.
- Preserves Cloudflare IDs for playlist and mosaic artwork instead of degrading them to legacy paths.
- Reduces repeated image decoding work in player backgrounds and artwork views.
- Extracts the ambient background color palette on a background task instead of the main queue.

### Playback

- Caches remote song audio before playback and routes non-downloaded songs through the same file playback path as downloaded media, keeping Control Center and lock screen play/pause state in sync.
- Runs the remote audio caching work (file moves, validation, LZFSE decompression) off the main actor; it previously executed on the main thread during playback startup.
- Guards the remote cache task with a request token so replaying a song that is still caching cannot be reset by the previous task's cancellation handler (which left the song paused instead of autoplaying).
- Honors seek and pause/resume positions requested while a remote song is still caching, and reports the pending position in Now Playing.
- Resolves tap-to-play file lookups without decompressing idle-compressed cache entries on the main thread; they are recovered through the existing off-main cache-hit path with a brief buffering state instead of a UI freeze.
- Improves playback startup state logging and transition handling.

### Caching

- Moves `CacheManager` maintenance (directory size scans, pruning, eviction) onto a serial utility queue; it previously walked the entire music cache on the main thread at first playback and at every track transition.

### Model & API modernization

- Supports the `oss` audio path for user-uploaded songs so their `audioURL` resolves (previously nil, leaving those songs unplayable), matching the existing Song model tests.
- Fixes all iOS 26 deprecation warnings (`Text` concatenation, `AVCaptureSessionRuntimeError`, `UIWindow()`, `UIScreen.main`, SDWebImage `avoidDecodeImage`).
- Reads the display refresh rate from the connected window scene and logs it at startup, confirming 120Hz ProMotion scheduling for the `TimelineView` animations.
- Aligns the test targets' deployment target with the app so `TwinskaraokeTests` builds and runs again.

## Root Cause

Several UI paths requested larger artwork variants than needed, and some playlist conversion paths turned Cloudflare image IDs into legacy path-shaped URLs. That bypassed the intended image transform route and caused unnecessary network and decode work on cold starts.

Regular non-downloaded songs also used a separate direct `AVPlayer` streaming path while downloaded songs used `AVEnginePlayback`. Device testing showed downloaded songs kept Control Center and lock screen play/pause state correct, but streamed songs could leave Control Center rendering a stale pause/play icon or sending a stale command after the app had already updated `MPNowPlayingInfoCenter`.

Profiling the new caching path on device surfaced additional main-thread work: the remote cache task, `CacheManager` maintenance, tap-to-play decompression, and palette extraction all ran on the main thread, stalling the UI at exactly the moments this PR aims to make responsive.

## Why Cache Remote Playback First?

The goal is to make regular remote songs follow the same playback path that was already proven correct for downloaded media.

- Downloaded media already worked because it plays a local file through `AVEnginePlayback`.
- Non-downloaded media was the outlier because it used a direct remote `AVPlayer` path.
- Tuning `MPRemoteCommandCenter` enablement, `MPNowPlayingInfoPropertyPlaybackRate`, and session behavior improved some surfaces but did not consistently fix Control Center for remote streams.
- iOS ignored direct `playbackState` writes for third-party apps without the private MediaRemote entitlement, so the reliable public control surface remained Now Playing metadata plus command handlers.
- Caching the remote audio first converts the remote song into the same local-file playback case as a downloaded song.
- After the cache completes, remote songs produce the same control flow as downloaded songs: `AVEnginePlayback` plays `main.mp3`, remote pause is handled as `pause.file.remote.pause`, and remote play is handled as `resume.file.remote.play`.

The tradeoff is that the first play of an uncached remote song waits for the audio cache write before playback starts. Subsequent plays are cache hits. This is preferable here because it removes the split playback implementation that caused media remote desync, and it also reuses existing cache validation, source URL checks, and local-file recovery behavior.

Radio remains on the direct `AVPlayer` path because live streams cannot be converted into the same finite cached-song file workflow.

## Validation

- `xcodebuild … -scheme Twinskaraoke -destination generic/platform=iOS build` — no warnings from project sources
- `xcodebuild … -scheme TwinskaraokeWatchApp -destination generic/platform=watchOS build`
- `xcodebuild … -only-testing:TwinskaraokeTests test` — all tests pass
- Device smoke testing: cold startup, playlist artwork, stream-cached playback, downloaded playback, Control Center and lock screen play/pause state, seek during caching, download queue completion, and the 120 fps startup log.

## Summary by Sourcery

Centralize artwork URL generation and optimize image delivery, caching, and prefetching to improve playback startup and artwork responsiveness across iOS and watchOS.

New Features:
- Introduce an ArtworkURLBuilder with standardized artwork variants for songs, playlists, search results, gallery items, artists, badges, and fallback art.
- Add support for multiple artwork sizes (row, thumbnail, card, hero, fullHD, blur, download) and use them consistently in player, home, radio, library, and watch interfaces.
- Warm player artwork around playback transitions to reduce perceived startup latency.

Enhancements:
- Route Cloudflare and storage artwork through their respective CDN resize paths and upgrade legacy artwork URLs where possible.
- Increase image cache and downloader limits and add centralized SDWebImage context configurations for visible and cached artwork.
- Refine artwork prefetching strategies for visible songs, playlists, library, search, radio, and downloaded content using appropriate variants.
- Simplify RemoteArtworkImage and player background image decoding paths to rely on shared cache contexts and reduce redundant resize logic.
- Preserve Cloudflare IDs in playlist media and mosaic artwork instead of converting them into legacy paths, improving transform routing.

Tests:
- Extend song and watch song model tests to cover new artwork variants and Cloudflare/storage resize URL behaviors.
- Add tests for ArtworkURLBuilder to verify Cloudflare and storage URLs are correctly upgraded to CDN resize routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out consistent, size-appropriate artwork variants across the app (card/thumbnail/row/hero/full HD), with improved low-resolution placeholders while images load.
  * Enhanced preloading to fetch the right artwork sizes for faster, smoother browsing and playback.
* **Bug Fixes**
  * Refined artwork selection and fallback behavior in key views (including art detail and artwork headers) to consistently prefer the best available image/variant.
* **Chores**
  * Updated artwork caching/prefetch configuration (variant-aware prefetching, warmup behavior, and adjusted prefetch concurrency/limits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


