### PR TITLE
Fix mini player snap-back, toolbar profile avatar, and main-thread I/O

### DIFF
--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -1,4 +1,5 @@
 import Combine
+import SDWebImageSwiftUI
 import SwiftUI
 
 #if canImport(UIKit)
@@ -370,17 +371,28 @@ private struct TabBarBottomPaddingModifier: ViewModifier {
 
 struct AccountToolbarButton: View {
     @AppStorage("nk.username") private var username: String = ""
+    @AppStorage("nk.avatar") private var avatarUrl: String = ""
 
     var body: some View {
         NavigationLink {
             AccountView()
         } label: {
-            ToolbarIconLabel(systemImage: "person.fill")
+            if let url = avatarURL {
+                ToolbarAvatarLabel(url: url)
+            } else {
+                ToolbarIconLabel(systemImage: "person.fill")
+            }
         }
         .buttonStyle(PressableButtonStyle(scale: 0.92, dim: 0.78, haptic: .selection))
         .accessibilityIdentifier("AccountToolbarButton")
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Opens account and settings.")
+    }
+
+    private var avatarURL: URL? {
+        let trimmed = avatarUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return URL(string: trimmed)
     }
 
     private var displayName: String {
@@ -419,6 +431,38 @@ struct ToolbarCapsuleMenu<Content: View>: View {
         }
         .buttonStyle(PressableButtonStyle(scale: 0.92, dim: 0.78, haptic: .selection))
         .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+private struct ToolbarAvatarLabel: View {
+    let url: URL
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            avatarImage(diameter: 30)
+        } else {
+            ZStack {
+                ToolbarControlBackground()
+                avatarImage(diameter: 32)
+            }
+            .frame(width: 44, height: 44)
+            .contentShape(Circle())
+        }
+    }
+
+    private func avatarImage(diameter: CGFloat) -> some View {
+        WebImage(url: url, options: ImageCacheConfig.defaultOptions) { image in
+            image
+                .resizable()
+                .scaledToFill()
+        } placeholder: {
+            Image(systemName: "person.fill")
+                .font(.headline)
+                .symbolRenderingMode(.monochrome)
+                .foregroundStyle(.primary)
+        }
+        .frame(width: diameter, height: diameter)
+        .clipShape(Circle())
     }
 }
 

--- a/Twinskaraoke/Features/Account/AccountView.swift
+++ b/Twinskaraoke/Features/Account/AccountView.swift
@@ -191,11 +191,22 @@ struct AccountView: View {
             handleLevelChange(with: decoded.profile)
             profile = decoded.profile
             badges = decoded.badges ?? []
+            persistAvatarIfNeeded(decoded.profile.avatarUrl)
         }
         if let data = await limitData,
            let decoded = try? JSONDecoder().decode(UploadLimits.self, from: data)
         {
             uploadLimits = decoded
+        }
+    }
+
+    /// The toolbar avatar reads "nk.avatar"; keep it in sync with the server
+    /// profile so accounts whose login token carried no avatar still get one.
+    private func persistAvatarIfNeeded(_ avatarUrl: String?) {
+        guard let avatarUrl, !avatarUrl.isEmpty else { return }
+        let defaults = UserDefaults.standard
+        if defaults.string(forKey: "nk.avatar") != avatarUrl {
+            defaults.set(avatarUrl, forKey: "nk.avatar")
         }
     }
 

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -379,14 +379,16 @@ class AudioPlayerManager: ObservableObject {
     }()
 
     #if canImport(UIKit)
-        private static let artworkCache: NSCache<NSURL, UIImage> = {
+        // nonisolated(unsafe): NSCache is documented thread-safe; the artwork
+        // processing task reads and writes it off the main actor.
+        private nonisolated(unsafe) static let artworkCache: NSCache<NSURL, UIImage> = {
             let cache = NSCache<NSURL, UIImage>()
             cache.countLimit = 32
             cache.totalCostLimit = 32 * 1024 * 1024
             return cache
         }()
 
-        private static let artworkMaxPixel: CGFloat = 600
+        private nonisolated static let artworkMaxPixel: CGFloat = 600
     #endif
 
     var anyAIEffectActive: Bool {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -350,6 +350,7 @@ class AudioPlayerManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var artworkURL: URL?
     private var artworkTask: (any SDWebImageOperation)?
+    private var artworkProcessingTask: Task<Void, Never>?
     private var playerArtworkWarmupTasks: [String: any SDWebImageOperation] = [:]
     private var warmedPlayerArtworkAt: [String: Date] = [:]
     private var currentPlaybackURL: URL?
@@ -593,6 +594,7 @@ class AudioPlayerManager: ObservableObject {
             existing.player.removeTimeObserver(existing.token)
         }
         artworkTask?.cancel()
+        artworkProcessingTask?.cancel()
         playerArtworkWarmupTasks.values.forEach { $0.cancel() }
         playerArtworkWarmupTasks.removeAll()
         cacheCompressionTask?.cancel()
@@ -2767,6 +2769,8 @@ class AudioPlayerManager: ObservableObject {
         let songID = currentSong?.id
         artworkTask?.cancel()
         artworkTask = nil
+        artworkProcessingTask?.cancel()
+        artworkProcessingTask = nil
         #if canImport(UIKit)
             if let cached = AudioPlayerManager.artworkCache.object(forKey: url as NSURL) {
                 applyArtwork(cached, for: songID, artworkURL: url)
@@ -2782,10 +2786,12 @@ class AudioPlayerManager: ObservableObject {
                 guard let image else { return }
                 // Square-cropping and downscaling redraw the full bitmap;
                 // keep that work off the main thread. NSCache is thread-safe.
-                Task.detached(priority: .userInitiated) { [weak self] in
+                artworkProcessingTask = Task.detached(priority: .userInitiated) { [weak self] in
+                    guard !Task.isCancelled else { return }
                     let squareImage = image.croppedToSquare().downscaled(
                         maxPixel: AudioPlayerManager.artworkMaxPixel
                     )
+                    guard !Task.isCancelled else { return }
                     let cost = Int(
                         squareImage.size.width * squareImage.size.height * squareImage.scale
                             * squareImage.scale * 4

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2780,15 +2780,23 @@ class AudioPlayerManager: ObservableObject {
             ) { [weak self] image, _, _, _, _, _ in
                 guard let self, currentSong?.id == songID else { return }
                 guard let image else { return }
-                let squareImage = image.croppedToSquare().downscaled(
-                    maxPixel: AudioPlayerManager.artworkMaxPixel
-                )
-                let cost = Int(
-                    squareImage.size.width * squareImage.size.height * squareImage.scale
-                        * squareImage.scale * 4
-                )
-                AudioPlayerManager.artworkCache.setObject(squareImage, forKey: url as NSURL, cost: cost)
-                applyArtwork(squareImage, for: songID, artworkURL: url)
+                // Square-cropping and downscaling redraw the full bitmap;
+                // keep that work off the main thread. NSCache is thread-safe.
+                Task.detached(priority: .userInitiated) { [weak self] in
+                    let squareImage = image.croppedToSquare().downscaled(
+                        maxPixel: AudioPlayerManager.artworkMaxPixel
+                    )
+                    let cost = Int(
+                        squareImage.size.width * squareImage.size.height * squareImage.scale
+                            * squareImage.scale * 4
+                    )
+                    AudioPlayerManager.artworkCache.setObject(
+                        squareImage, forKey: url as NSURL, cost: cost
+                    )
+                    await MainActor.run { [weak self] in
+                        self?.applyArtwork(squareImage, for: songID, artworkURL: url)
+                    }
+                }
             }
         #endif
     }
@@ -3078,7 +3086,9 @@ class AudioPlayerManager: ObservableObject {
 }
 
 #if canImport(UIKit)
-    extension UIImage {
+    // nonisolated: cropping and re-rendering are thread-safe and run off the
+    // main actor when preparing Now Playing artwork.
+    nonisolated extension UIImage {
         func croppedToSquare() -> UIImage {
             let originalWidth = size.width
             let originalHeight = size.height

--- a/Twinskaraoke/Services/Audio/PopupOpenIntentGate.swift
+++ b/Twinskaraoke/Services/Audio/PopupOpenIntentGate.swift
@@ -11,7 +11,9 @@ import SwiftUI
 
         private static let touchRecognizerName = "Twinskaraoke.IntentionalMiniPlayerOpen"
         private static let defaultTrailingControlHitWidth: CGFloat = 132
-        private static let radioTrailingControlHitWidth: CGFloat = 192
+        // Radio mode shows a single 44pt play/stop button, so its control zone
+        // is narrower than the two-button default.
+        private static let radioTrailingControlHitWidth: CGFloat = 96
         private static let tapMovementTolerance: CGFloat = 12
         private static let visibleBarHitHeight: CGFloat = 116
         private static let openIntentWindow: TimeInterval = 0.45
@@ -70,26 +72,35 @@ import SwiftUI
             case .began:
                 isOpenDragActive = false
                 guard Date() > suppressOpenExpiresAt,
-                      isVisibleMiniPlayerTouch(location, in: popupBar),
-                      !isTrailingControlTouch(location, in: popupBar)
+                      isVisibleMiniPlayerTouch(location, in: popupBar)
                 else {
                     touchStartLocation = nil
                     openIntentExpiresAt = .distantPast
                     return
                 }
                 touchStartLocation = location
-                openIntentExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
+                // A tap on the trailing playback controls must not open the
+                // popup, but an upward drag starting on them is still an
+                // intentional open — so only the tap intent is withheld here;
+                // .changed can still arm the drag intent.
+                openIntentExpiresAt = isTrailingControlTouch(location, in: popupBar)
+                    ? .distantPast
+                    : Date().addingTimeInterval(Self.openIntentWindow)
             case .changed:
                 guard let touchStartLocation else {
                     openIntentExpiresAt = .distantPast
                     return
                 }
 
-                if isIntentionalOpenDrag(from: touchStartLocation, to: location) {
+                if isOpenDragActive {
+                    // Once the user has committed to an open drag, keep the
+                    // intent alive even if the finger wobbles near the start;
+                    // LNPopup decides whether the gesture opens or closes.
+                    openIntentExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
+                } else if isIntentionalOpenDrag(from: touchStartLocation, to: location) {
                     isOpenDragActive = true
                     openIntentExpiresAt = Date().addingTimeInterval(Self.openIntentWindow)
                 } else if distance(from: touchStartLocation, to: location) > Self.tapMovementTolerance {
-                    isOpenDragActive = false
                     openIntentExpiresAt = .distantPast
                 }
             case .ended:
@@ -100,8 +111,15 @@ import SwiftUI
                 }
             case .cancelled, .failed:
                 touchStartLocation = nil
-                isOpenDragActive = false
-                openIntentExpiresAt = .distantPast
+                if isOpenDragActive {
+                    // LNPopup's transition takes over the touch and cancels
+                    // this recognizer mid-drag; that is still an intentional
+                    // open, so grant the same release window as .ended.
+                    isOpenDragActive = false
+                    openIntentExpiresAt = Date().addingTimeInterval(Self.openDragReleaseWindow)
+                } else {
+                    openIntentExpiresAt = .distantPast
+                }
             default:
                 break
             }

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -52,6 +52,7 @@ final class DownloadManager: ObservableObject {
         let validIDs: Set<String>
         let validEntries: [String: ValidDownloadCacheEntry]
         let repairs: [String: Song]
+        let junkSongIDs: [String]
     }
 
     static let shared = DownloadManager()
@@ -360,21 +361,31 @@ final class DownloadManager: ObservableObject {
         failedInCurrentQueue = 0
     }
 
+    /// Read-only for song directories: the scan runs concurrently with live
+    /// downloads, so destructive cleanup is deferred to `applyStartupScan`,
+    /// which runs on the main actor and can defer to live download state.
     private nonisolated func scanExistingDownloadsBlocking() -> StartupScanResult {
         migrateLegacyDownloadsIfNeeded()
         let fm = FileManager.default
         var ids = Set<String>()
         var validEntries: [String: ValidDownloadCacheEntry] = [:]
         var repairs: [String: Song] = [:]
+        var junkSongIDs: [String] = []
         guard let entries = try? fm.contentsOfDirectory(
             at: cacheDir,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
         )
-        else { return StartupScanResult(validIDs: ids, validEntries: validEntries, repairs: repairs) }
+        else {
+            return StartupScanResult(
+                validIDs: ids, validEntries: validEntries, repairs: repairs, junkSongIDs: junkSongIDs
+            )
+        }
         for entry in entries {
             let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
             guard isDirectory else {
+                // Loose files at the root are pre-migration leftovers; no
+                // live download writes them, so removal here cannot race.
                 try? fm.removeItem(at: entry)
                 continue
             }
@@ -391,31 +402,48 @@ final class DownloadManager: ObservableObject {
             } else {
                 let repairSong = readMetadata(for: songID)
                 if let repairSong, repairSong.audioURL != nil {
-                    let songFiles = files(for: songID)
-                    try? fm.removeItem(at: songFiles.audio)
-                    try? fm.removeItem(at: songFiles.source)
                     repairs[songID] = repairSong
                 } else {
-                    try? fm.removeItem(at: entry)
+                    junkSongIDs.append(songID)
                 }
             }
         }
-        return StartupScanResult(validIDs: ids, validEntries: validEntries, repairs: repairs)
+        return StartupScanResult(
+            validIDs: ids, validEntries: validEntries, repairs: repairs, junkSongIDs: junkSongIDs
+        )
     }
 
     private func applyStartupScan(_ scan: StartupScanResult) {
-        // Downloads may have started or finished while the scan ran; merge
-        // instead of overwriting, and let live state win on conflicts.
-        downloadedIDs.formUnion(scan.validIDs)
-        for (songID, entry) in scan.validEntries where validDownloadCache[songID] == nil {
+        // Downloads may have started, finished, or been removed while the
+        // scan ran; merge instead of overwriting, and let live state win.
+        let fm = FileManager.default
+        let stillExistingIDs = scan.validIDs.filter { songID in
+            fm.fileExists(atPath: files(for: songID).audio.path)
+        }
+        downloadedIDs.formUnion(stillExistingIDs)
+        for (songID, entry) in scan.validEntries
+            where stillExistingIDs.contains(songID) && validDownloadCache[songID] == nil
+        {
             validDownloadCache[songID] = entry
         }
+        var repairCount = 0
         for (songID, song) in scan.repairs {
             guard !downloadedIDs.contains(songID), !inProgress.contains(songID) else { continue }
+            // A missing metadata file means the song was removed during the
+            // scan; don't delete anything or resurrect it as a repair.
+            let songFiles = files(for: songID)
+            guard fm.fileExists(atPath: songFiles.metadata.path) else { continue }
+            try? fm.removeItem(at: songFiles.audio)
+            try? fm.removeItem(at: songFiles.source)
             pendingWiFiRepairs[songID] = song
+            repairCount += 1
+        }
+        for songID in scan.junkSongIDs {
+            guard !downloadedIDs.contains(songID), !inProgress.contains(songID) else { continue }
+            try? fm.removeItem(at: files(for: songID).directory)
         }
         DebugLogger.log(
-            "DownloadManager scan complete — \(downloadedIDs.count) existing downloads, \(scan.repairs.count) pending repair(s)",
+            "DownloadManager scan complete — \(downloadedIDs.count) existing downloads, \(repairCount) pending repair(s)",
             category: .network
         )
         startPendingWiFiRepairsIfPossible()

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -48,6 +48,12 @@ final class DownloadManager: ObservableObject {
         let modifiedAt: Date?
     }
 
+    private struct StartupScanResult {
+        let validIDs: Set<String>
+        let validEntries: [String: ValidDownloadCacheEntry]
+        let repairs: [String: Song]
+    }
+
     static let shared = DownloadManager()
     @Published private(set) var downloadedIDs: Set<String> = []
     @Published private(set) var inProgress: Set<String> = []
@@ -72,19 +78,23 @@ final class DownloadManager: ObservableObject {
             .urls(for: .documentDirectory, in: .userDomainMask).first!
             .appendingPathComponent("Downloads")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
-        refreshExistingDownloads()
         startNetworkMonitoring()
-        DebugLogger.log(
-            "DownloadManager init — \(downloadedIDs.count) existing downloads",
-            category: .network
-        )
+        // The startup scan opens every downloaded audio file to validate it;
+        // that per-file decode work must stay off the main thread at launch.
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let scan = scanExistingDownloadsBlocking()
+            await MainActor.run {
+                self.applyStartupScan(scan)
+            }
+        }
     }
 
     deinit {
         networkMonitor.cancel()
     }
 
-    private func files(for songID: String) -> SongFiles {
+    private nonisolated func files(for songID: String) -> SongFiles {
         let directory = cacheDir.appendingPathComponent(songID, isDirectory: true)
         return SongFiles(
             directory: directory,
@@ -94,7 +104,7 @@ final class DownloadManager: ObservableObject {
         )
     }
 
-    private func ensureSongDirectory(for songID: String) {
+    private nonisolated func ensureSongDirectory(for songID: String) {
         try? FileManager.default.createDirectory(
             at: files(for: songID).directory,
             withIntermediateDirectories: true
@@ -105,7 +115,7 @@ final class DownloadManager: ObservableObject {
         files(for: songID).audio
     }
 
-    private func sourceURL(for songID: String) -> URL {
+    private nonisolated func sourceURL(for songID: String) -> URL {
         files(for: songID).source
     }
 
@@ -350,16 +360,18 @@ final class DownloadManager: ObservableObject {
         failedInCurrentQueue = 0
     }
 
-    private func refreshExistingDownloads() {
+    private nonisolated func scanExistingDownloadsBlocking() -> StartupScanResult {
         migrateLegacyDownloadsIfNeeded()
         let fm = FileManager.default
+        var ids = Set<String>()
+        var validEntries: [String: ValidDownloadCacheEntry] = [:]
+        var repairs: [String: Song] = [:]
         guard let entries = try? fm.contentsOfDirectory(
             at: cacheDir,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
         )
-        else { return }
-        var ids = Set<String>()
+        else { return StartupScanResult(validIDs: ids, validEntries: validEntries, repairs: repairs) }
         for entry in entries {
             let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
             guard isDirectory else {
@@ -369,17 +381,44 @@ final class DownloadManager: ObservableObject {
             let songID = entry.lastPathComponent
             if hasValidDownload(for: songID) {
                 ids.insert(songID)
+                let metadata = readMetadata(for: songID)
+                let metadataDuration = metadata?.duration ?? 0
+                validEntries[songID] = ValidDownloadCacheEntry(
+                    source: readSourceURL(for: songID),
+                    expectedDuration: metadataDuration > 0 ? TimeInterval(metadataDuration) : nil,
+                    modifiedAt: Self.modificationDate(at: files(for: songID).audio)
+                )
             } else {
                 let repairSong = readMetadata(for: songID)
                 if let repairSong, repairSong.audioURL != nil {
-                    removeBrokenAudioFiles(for: repairSong)
-                    pendingWiFiRepairs[songID] = repairSong
+                    let songFiles = files(for: songID)
+                    try? fm.removeItem(at: songFiles.audio)
+                    try? fm.removeItem(at: songFiles.source)
+                    repairs[songID] = repairSong
                 } else {
                     try? fm.removeItem(at: entry)
                 }
             }
         }
-        downloadedIDs = ids
+        return StartupScanResult(validIDs: ids, validEntries: validEntries, repairs: repairs)
+    }
+
+    private func applyStartupScan(_ scan: StartupScanResult) {
+        // Downloads may have started or finished while the scan ran; merge
+        // instead of overwriting, and let live state win on conflicts.
+        downloadedIDs.formUnion(scan.validIDs)
+        for (songID, entry) in scan.validEntries where validDownloadCache[songID] == nil {
+            validDownloadCache[songID] = entry
+        }
+        for (songID, song) in scan.repairs {
+            guard !downloadedIDs.contains(songID), !inProgress.contains(songID) else { continue }
+            pendingWiFiRepairs[songID] = song
+        }
+        DebugLogger.log(
+            "DownloadManager scan complete — \(downloadedIDs.count) existing downloads, \(scan.repairs.count) pending repair(s)",
+            category: .network
+        )
+        startPendingWiFiRepairsIfPossible()
     }
 
     func playableURL(for song: Song) -> URL? {
@@ -515,7 +554,7 @@ final class DownloadManager: ObservableObject {
         }
     }
 
-    private func hasValidDownload(for songID: String) -> Bool {
+    private nonisolated func hasValidDownload(for songID: String) -> Bool {
         let songFiles = files(for: songID)
         guard FileManager.default.fileExists(atPath: songFiles.audio.path) else { return false }
         let metadata = readMetadata(for: songID)
@@ -538,7 +577,7 @@ final class DownloadManager: ObservableObject {
         return cachedSource == expectedSource
     }
 
-    private func readSourceURL(for songID: String) -> String? {
+    private nonisolated func readSourceURL(for songID: String) -> String? {
         guard let data = try? Data(contentsOf: sourceURL(for: songID)),
               let rawValue = String(data: data, encoding: .utf8)
         else {
@@ -548,7 +587,7 @@ final class DownloadManager: ObservableObject {
         return normalized.isEmpty ? nil : normalized
     }
 
-    private func writeSourceURL(_ remoteURL: URL, for songID: String) {
+    private nonisolated func writeSourceURL(_ remoteURL: URL, for songID: String) {
         let source = sourceURL(for: songID)
         ensureSongDirectory(for: songID)
         try? FileManager.default.removeItem(at: source)
@@ -616,20 +655,20 @@ final class DownloadManager: ObservableObject {
         }
     }
 
-    private func writeMetadata(for song: Song) {
+    private nonisolated func writeMetadata(for song: Song) {
         let songFiles = files(for: song.id)
         ensureSongDirectory(for: song.id)
         guard let data = try? JSONEncoder().encode(song) else { return }
         try? data.write(to: songFiles.metadata, options: [.atomic])
     }
 
-    private func readMetadata(for songID: String) -> Song? {
+    private nonisolated func readMetadata(for songID: String) -> Song? {
         let metadataURL = files(for: songID).metadata
         guard let data = try? Data(contentsOf: metadataURL) else { return nil }
         return try? JSONDecoder().decode(Song.self, from: data)
     }
 
-    private func migrateLegacyDownloadsIfNeeded() {
+    private nonisolated func migrateLegacyDownloadsIfNeeded() {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: cacheDir,
@@ -664,7 +703,7 @@ final class DownloadManager: ObservableObject {
         }
     }
 
-    private func migrateLegacyDownloadIfNeeded(for songID: String) {
+    private nonisolated func migrateLegacyDownloadIfNeeded(for songID: String) {
         let fm = FileManager.default
         let legacyAudio = cacheDir.appendingPathComponent("\(songID).mp3")
         let legacySource = cacheDir.appendingPathComponent("\(songID).source")
@@ -704,7 +743,7 @@ final class DownloadManager: ObservableObject {
         }
     }
 
-    private func readLegacySourceURL(for songID: String) -> String? {
+    private nonisolated func readLegacySourceURL(for songID: String) -> String? {
         let legacySource = cacheDir.appendingPathComponent("\(songID).source")
         guard let data = try? Data(contentsOf: legacySource),
               let rawValue = String(data: data, encoding: .utf8)


### PR DESCRIPTION
## Summary

### Bug fixes
- **Mini player snapped back to collapsed after dragging it open.** `PopupOpenIntentGate` discarded its open intent in three situations: when the drag started on the trailing control zone, when the finger wobbled near the drag's start point, and when LNPopup's transition cancelled the tracking recognizer mid-drag. Each caused the popup to open and immediately collapse. In radio mode this happened on every swipe because the trailing control zone was 192pt wide while the radio bar only shows a single 44pt button. Drags now always count as intentional opens (only taps on the controls are suppressed), armed drags stay armed until the touch ends, a cancelled recognizer during an open drag gets the same grace window as a normal release, and the radio control zone is sized to its actual button (96pt).
- **Account toolbar button showed a placeholder instead of the profile picture.** It now renders the signed-in user's avatar (falling back to the placeholder when signed out or no avatar exists), and `AccountView` keeps the stored avatar in sync with the server profile so accounts whose login token carried no avatar claim get their picture too.

### Performance
- `DownloadManager` validated every downloaded audio file (per-file `AVAudioFile` decode) synchronously on the main actor at launch, and again when opening the downloaded songs list. The startup scan now runs on a background task and pre-warms the validation cache, so later lookups are a cache hit plus a file-attribute check.
- Now Playing artwork square-crop/downscale (a full bitmap redraw per track change) moved off the main thread.

### Review follow-ups
- The startup scan is read-only for song directories; broken-download cleanup and junk-directory removal happen in `applyStartupScan` on the main actor, guarded by live download state, and scan results are only merged for files that still exist — so downloads finishing or being removed while the scan runs can't lose files or be resurrected (CodeRabbit).
- The detached artwork crop/downscale task is tracked and cancelled when a new artwork load starts, so rapid track skipping no longer stacks up wasted bitmap work (CodeRabbit nitpick).
- The artwork cache statics are `nonisolated` (`nonisolated(unsafe)` for the thread-safe `NSCache`) to fix Swift 6 isolation warnings introduced by the off-main processing.

## Testing
- Full simulator build succeeds with no new warnings; `TwinskaraokeTests` pass.
- Device-tested: avatar appears in the top-left toolbar, slow/wobbly drags keep the player expanded, and swiping up on the mini player while radio is playing no longer collapses back.