### PR TITLE
Fix Swift 6 strict-concurrency errors and off-main isolation traps

### DIFF
--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -762,10 +762,13 @@ private protocol QRCameraControllerDelegate: AnyObject {
 
 private final class QRCameraController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
     weak var delegate: QRCameraControllerDelegate?
-    private let session = AVCaptureSession()
+    // Configured on the main actor, started/stopped on sessionQueue, and
+    // stopped from deinit; AVCaptureSession start/stop must run off-main.
+    private nonisolated(unsafe) let session = AVCaptureSession()
     private let sessionQueue = DispatchQueue(label: "org.evilneuro.Twinskaraoke.qr-camera-session", qos: .userInitiated)
     private var previewLayer: AVCaptureVideoPreviewLayer?
-    private var runtimeErrorObserver: NSObjectProtocol?
+    // Set once on the main actor; removal (deinit) is thread-safe.
+    private nonisolated(unsafe) var runtimeErrorObserver: NSObjectProtocol?
     private var hasReported = false
     private var isSessionConfigured = false
     private var hasReportedFailure = false
@@ -787,11 +790,15 @@ private final class QRCameraController: UIViewController, AVCaptureMetadataOutpu
         stopSession()
     }
 
-    isolated deinit {
+    deinit {
         if let runtimeErrorObserver {
             NotificationCenter.default.removeObserver(runtimeErrorObserver)
         }
-        stopSession()
+        nonisolated(unsafe) let capturedSession = session
+        sessionQueue.async {
+            guard capturedSession.isRunning else { return }
+            capturedSession.stopRunning()
+        }
     }
 
     private func stopSession() {

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -787,7 +787,7 @@ private final class QRCameraController: UIViewController, AVCaptureMetadataOutpu
         stopSession()
     }
 
-    deinit {
+    isolated deinit {
         if let runtimeErrorObserver {
             NotificationCenter.default.removeObserver(runtimeErrorObserver)
         }
@@ -795,7 +795,9 @@ private final class QRCameraController: UIViewController, AVCaptureMetadataOutpu
     }
 
     private func stopSession() {
-        let capturedSession = session
+        // AVCaptureSession start/stop must run off the main thread; the session
+        // is only ever touched from sessionQueue after configuration.
+        nonisolated(unsafe) let capturedSession = session
         sessionQueue.async {
             guard capturedSession.isRunning else { return }
             capturedSession.stopRunning()
@@ -855,7 +857,7 @@ private final class QRCameraController: UIViewController, AVCaptureMetadataOutpu
 
     private func startSession() {
         guard isSessionConfigured else { return }
-        let capturedSession = session
+        nonisolated(unsafe) let capturedSession = session
         sessionQueue.async {
             guard !capturedSession.isRunning else { return }
             capturedSession.startRunning()
@@ -868,7 +870,10 @@ private final class QRCameraController: UIViewController, AVCaptureMetadataOutpu
             object: session,
             queue: .main
         ) { [weak self] _ in
-            self?.reportFailure("The camera stopped unexpectedly. Check that it is working, then try again.")
+            // Delivered on the main queue (queue: .main above).
+            MainActor.assumeIsolated {
+                self?.reportFailure("The camera stopped unexpectedly. Check that it is working, then try again.")
+            }
         }
     }
 

--- a/Twinskaraoke/Services/Artwork/FallbackArtProvider.swift
+++ b/Twinskaraoke/Services/Artwork/FallbackArtProvider.swift
@@ -188,9 +188,14 @@ final nonisolated class FallbackArtProvider: ObservableObject, @unchecked Sendab
         UserDefaults.standard.set(dict, forKey: persistKey)
     }
 
+    // Collects results from concurrent fetch callbacks; guarded by syncQueue.
+    private final class ItemCollector: @unchecked Sendable {
+        var items: [FallbackArtItem] = []
+    }
+
     private func fetch() {
         let fetchCount = 48
-        var fetchedItems: [FallbackArtItem] = []
+        let fetchedItems = ItemCollector()
         let group = DispatchGroup()
         let syncQueue = DispatchQueue(label: "com.twinskaraoke.fallbackart.sync")
 
@@ -232,7 +237,7 @@ final nonisolated class FallbackArtProvider: ObservableObject, @unchecked Sendab
 
                     let fallbackItem = FallbackArtItem(url: urlWithQuality, artistName: item.artistCredit, artistLink: nil)
                     syncQueue.sync {
-                        fetchedItems.append(fallbackItem)
+                        fetchedItems.items.append(fallbackItem)
                     }
                 }
             }
@@ -240,7 +245,7 @@ final nonisolated class FallbackArtProvider: ObservableObject, @unchecked Sendab
 
         group.notify(queue: .main) { [weak self] in
             guard let self else { return }
-            let uniqueItems = fetchedItems.reduce(into: [FallbackArtItem]()) { result, item in
+            let uniqueItems = fetchedItems.items.reduce(into: [FallbackArtItem]()) { result, item in
                 guard !result.contains(where: { $0.url == item.url }) else { return }
                 result.append(item)
             }
@@ -257,7 +262,7 @@ final nonisolated class FallbackArtProvider: ObservableObject, @unchecked Sendab
         with request: URLRequest,
         maxAttempts: Int,
         attempt: Int = 1,
-        completion: @escaping (Data?, URLResponse?, Error?) -> Void
+        completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
     ) {
         URLSession.shared.dataTask(with: request) { data, response, error in
             let shouldRetry = error != nil || (response as? HTTPURLResponse).map { !((200 ... 299).contains($0.statusCode)) } ?? true

--- a/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
+++ b/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
@@ -38,14 +38,17 @@ enum ImageCacheConfig {
         let dl = SDWebImageDownloader.shared
 
         dl.config.maxConcurrentDownloads = 6
-        dl.requestModifier = SDWebImageDownloaderRequestModifier { request in
+        // Modifier blocks run on SDWebImage's download queue; they must be
+        // @Sendable so they don't inherit main-actor isolation (which would
+        // trap at runtime when invoked off the main thread).
+        dl.requestModifier = SDWebImageDownloaderRequestModifier { @Sendable request in
             var r = request
             r.cachePolicy = .returnCacheDataElseLoad
             r.timeoutInterval = 15
             r.setValue("image/webp,image/*,*/*;q=0.8", forHTTPHeaderField: "Accept")
             return r
         }
-        dl.responseModifier = SDWebImageDownloaderResponseModifier { response in
+        dl.responseModifier = SDWebImageDownloaderResponseModifier { @Sendable response in
             guard let httpResponse = response as? HTTPURLResponse,
                   let url = httpResponse.url,
                   shouldInspectArtworkResponse(url),
@@ -71,13 +74,13 @@ enum ImageCacheConfig {
 
     static let defaultOptions: SDWebImageOptions = []
 
-    private static func shouldInspectArtworkResponse(_ url: URL) -> Bool {
+    private nonisolated static func shouldInspectArtworkResponse(_ url: URL) -> Bool {
         guard let host = url.host else { return false }
         return host.contains("images.neurokaraoke.com")
             || (host.contains("storage.neurokaraoke.com") && url.path.contains("/cdn-cgi/image/"))
     }
 
-    private static func redactedURLString(_ url: URL) -> String {
+    private nonisolated static func redactedURLString(_ url: URL) -> String {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.query = nil
         components?.fragment = nil

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -3,6 +3,13 @@ import Foundation
 
 enum AVEnginePlaybackMode { case single, aiStems }
 
+/// Moves freshly loaded, uniquely referenced audio media out of a background
+/// loading task; AVAudioFile/AVAudioPCMBuffer are not Sendable but the loader
+/// hands over its only reference.
+private nonisolated struct LoadedMediaTransfer<Value>: @unchecked Sendable {
+    let value: Value
+}
+
 enum AVEnginePlaybackRampStyle {
     case equalPower
     case linear
@@ -21,7 +28,9 @@ extension AVAudioTime {
 
 final class SimpleAudioPlayer {
     let playerNode = AVAudioPlayerNode()
-    var completionHandler: (() -> Void)?
+    // Invoked from the audio render callback thread, hence @Sendable and
+    // accessible off the main actor.
+    nonisolated(unsafe) var completionHandler: (@Sendable () -> Void)?
 
     private var loadedFile: AVAudioFile?
     private var loadedBuffer: AVAudioPCMBuffer?
@@ -203,18 +212,20 @@ final class AVEnginePlayback {
     private(set) var currentURL: URL?
     private(set) var aiStartOffset: TimeInterval = 0
 
-    private var suppressionToken: UInt64 = 0
+    // Read from audio-thread completion callbacks to detect stale completions;
+    // written only on the main actor.
+    private nonisolated(unsafe) var suppressionToken: UInt64 = 0
     private var _paused: Bool = false
 
     private(set) var isCrossfading = false
 
     private var crossfadeTimer: Timer?
     private var handoffBlendTimer: Timer?
-    private var singleLoadTask: Task<LoadedMedia, Error>?
-    private var stemsLoadTask: Task<LoadedStemTriple, Error>?
-    private var switchToStemsLoadTask: Task<LoadedStemPair, Error>?
-    private var crossfadePreloadTask: Task<LoadedMedia, Error>?
-    private var crossfadeFinalizeTask: Task<LoadedMedia, Error>?
+    private var singleLoadTask: Task<LoadedMediaTransfer<LoadedMedia>, Error>?
+    private var stemsLoadTask: Task<LoadedMediaTransfer<LoadedStemTriple>, Error>?
+    private var switchToStemsLoadTask: Task<LoadedMediaTransfer<LoadedStemPair>, Error>?
+    private var crossfadePreloadTask: Task<LoadedMediaTransfer<LoadedMedia>, Error>?
+    private var crossfadeFinalizeTask: Task<LoadedMediaTransfer<LoadedMedia>, Error>?
     private var primaryLoadGeneration: UInt64 = 0
     private var crossfadeLoadGeneration: UInt64 = 0
     private var preparedCrossfadeMedia: LoadedMedia?
@@ -298,16 +309,16 @@ final class AVEnginePlayback {
 
         mainPlayer.completionHandler = { [weak self] in
             guard let self else { return }
-            let token = suppressionToken
-            DispatchQueue.main.async {
+            let token = self.suppressionToken
+            Task { @MainActor in
                 guard self.suppressionToken == token else { return }
                 if self.mode == .single { self.onPlaybackEnded?() }
             }
         }
         stemInstrumental.completionHandler = { [weak self] in
             guard let self else { return }
-            let token = suppressionToken
-            DispatchQueue.main.async {
+            let token = self.suppressionToken
+            Task { @MainActor in
                 guard self.suppressionToken == token else { return }
                 if self.mode == .aiStems { self.onPlaybackEnded?() }
             }
@@ -686,12 +697,12 @@ final class AVEnginePlayback {
         stopAllStems(releasingMedia: true)
         releasePlayerMedia(mainPlayer, resetVolumeTo: 1)
         let loadTask = Task.detached(priority: .userInitiated) {
-            try Self.loadMedia(url: url, intent: .immediatePlayback)
+            LoadedMediaTransfer(value: try Self.loadMedia(url: url, intent: .immediatePlayback))
         }
         singleLoadTask = loadTask
         Task {
             do {
-                let media = try await loadTask.value
+                let media = try await loadTask.value.value
                 guard self.suppressionToken == token, self.primaryLoadGeneration == loadGeneration else {
                     return
                 }
@@ -741,12 +752,12 @@ final class AVEnginePlayback {
             let v = try Self.loadMedia(url: vocalsURL, intent: .immediatePlayback)
             try Task.checkCancellation()
             let i = try Self.loadMedia(url: instrumentsURL, intent: .immediatePlayback)
-            return (m, v, i)
+            return LoadedMediaTransfer(value: (m, v, i))
         }
         stemsLoadTask = loadTask
         Task {
             do {
-                let media = try await loadTask.value
+                let media = try await loadTask.value.value
                 guard self.suppressionToken == token, self.primaryLoadGeneration == loadGeneration else {
                     return
                 }
@@ -808,12 +819,12 @@ final class AVEnginePlayback {
             let v = try Self.loadMedia(url: vocalsURL, intent: .immediatePlayback)
             try Task.checkCancellation()
             let i = try Self.loadMedia(url: instrumentsURL, intent: .immediatePlayback)
-            return (v, i)
+            return LoadedMediaTransfer(value: (v, i))
         }
         switchToStemsLoadTask = loadTask
         Task {
             do {
-                let media = try await loadTask.value
+                let media = try await loadTask.value.value
                 guard self.suppressionToken == token, self.primaryLoadGeneration == loadGeneration else {
                     return
                 }
@@ -1035,12 +1046,12 @@ final class AVEnginePlayback {
         let loadGeneration = crossfadeLoadGeneration
         crossfadePreloadURL = url
         let loadTask = Task.detached(priority: .utility) {
-            try Self.loadMedia(url: url, intent: .prefetch)
+            LoadedMediaTransfer(value: try Self.loadMedia(url: url, intent: .prefetch))
         }
         crossfadePreloadTask = loadTask
         Task {
             do {
-                let media = try await loadTask.value
+                let media = try await loadTask.value.value
                 guard self.crossfadeLoadGeneration == loadGeneration else { return }
                 try self.applyMedia(media, to: self.crossfadePlayer)
                 self.preparedCrossfadeMedia = media
@@ -1260,12 +1271,12 @@ final class AVEnginePlayback {
                     crossfadeLoadGeneration &+= 1
                     let loadGeneration = crossfadeLoadGeneration
                     let loadTask = Task.detached(priority: .utility) {
-                        try Self.loadMedia(url: url, intent: .immediatePlayback)
+                        LoadedMediaTransfer(value: try Self.loadMedia(url: url, intent: .immediatePlayback))
                     }
                     crossfadeFinalizeTask = loadTask
                     Task {
                         do {
-                            let media = try await loadTask.value
+                            let media = try await loadTask.value.value
                             guard self.suppressionToken == token,
                                   self.crossfadeLoadGeneration == loadGeneration
                             else { return }
@@ -1360,7 +1371,7 @@ final class AVEnginePlayback {
             DebugLogger.log(
                 "Awaiting in-flight crossfade preload for \(url.lastPathComponent)", category: .playback
             )
-            let media = try await existingTask.value
+            let media = try await existingTask.value.value
             guard suppressionToken == token, crossfadeLoadGeneration == loadGeneration else { return }
             try applyMedia(media, to: crossfadePlayer)
             preparedCrossfadeMedia = media
@@ -1381,10 +1392,10 @@ final class AVEnginePlayback {
             "Loading crossfade media on demand for \(url.lastPathComponent)", category: .playback
         )
         let loadTask = Task.detached(priority: .userInitiated) {
-            try Self.loadMedia(url: url, intent: .prefetch)
+            LoadedMediaTransfer(value: try Self.loadMedia(url: url, intent: .prefetch))
         }
         crossfadePreloadTask = loadTask
-        let media = try await loadTask.value
+        let media = try await loadTask.value.value
         guard suppressionToken == token, crossfadeLoadGeneration == loadGeneration else { return }
         try applyMedia(media, to: crossfadePlayer)
         preparedCrossfadeMedia = media
@@ -1453,7 +1464,7 @@ final class AVEnginePlayback {
         pendingCrossfadeURL = nil
     }
 
-    private func beginCrossfadeHandoffBlend(after delay: TimeInterval, completion: @escaping () -> Void) {
+    private func beginCrossfadeHandoffBlend(after delay: TimeInterval, completion: @escaping @MainActor @Sendable () -> Void) {
         handoffBlendTimer?.invalidate()
         let duration: TimeInterval = 0.35
         let startTime = Date()
@@ -1462,25 +1473,29 @@ final class AVEnginePlayback {
                 timer.invalidate()
                 return
             }
-            MainActor.assumeIsolated {
-                guard let self else { return }
+            // The timer itself must not be touched inside the isolated closure,
+            // so it reports completion and invalidation happens out here.
+            let finished = MainActor.assumeIsolated { () -> Bool in
+                guard let self else { return true }
                 let elapsed = Date().timeIntervalSince(startTime) - delay
                 guard elapsed >= 0 else {
                     self.mainPlayer.volume = 0
                     self.crossfadePlayer.volume = 1.0
-                    return
+                    return false
                 }
                 let t = Float(min(1.0, max(0.0, elapsed / duration)))
                 self.mainPlayer.volume = t
                 self.crossfadePlayer.volume = 1.0 - t
                 if t >= 1.0 {
-                    timer.invalidate()
                     self.handoffBlendTimer = nil
                     self.mainPlayer.volume = 1.0
                     self.releasePlayerMedia(self.crossfadePlayer)
                     completion()
+                    return true
                 }
+                return false
             }
+            if finished { timer.invalidate() }
         }
         handoffBlendTimer = timer
         RunLoop.main.add(timer, forMode: .common)

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -588,30 +588,34 @@ class AudioPlayerManager: ObservableObject {
         #endif
     }
 
-    isolated deinit {
-        pollTimer?.invalidate()
-        quickCutTimer?.invalidate()
-        streamFadeTimer?.invalidate()
-        instrumentalTask?.cancel()
-        backgroundAnalysisRetryTask?.cancel()
-        remotePlaybackCacheTask?.cancel()
-        if let existing = radioTimeObserver {
-            existing.player.removeTimeObserver(existing.token)
-        }
-        artworkTask?.cancel()
-        playerArtworkWarmupTasks.values.forEach { $0.cancel() }
-        playerArtworkWarmupTasks.removeAll()
-        cacheCompressionTask?.cancel()
-        radioPlayer?.pause()
-        #if canImport(UIKit)
-            let transitionTaskID = trackTransitionTaskID
-            trackTransitionTaskID = .invalid
-            if transitionTaskID != .invalid {
-                Task { @MainActor in
-                    UIApplication.shared.endBackgroundTask(transitionTaskID)
-                }
+    deinit {
+        // AudioPlayerManager is a main-actor singleton; if it is ever torn
+        // down, the last reference is released on the main thread.
+        MainActor.assumeIsolated {
+            pollTimer?.invalidate()
+            quickCutTimer?.invalidate()
+            streamFadeTimer?.invalidate()
+            instrumentalTask?.cancel()
+            backgroundAnalysisRetryTask?.cancel()
+            remotePlaybackCacheTask?.cancel()
+            if let existing = radioTimeObserver {
+                existing.player.removeTimeObserver(existing.token)
             }
-        #endif
+            artworkTask?.cancel()
+            playerArtworkWarmupTasks.values.forEach { $0.cancel() }
+            playerArtworkWarmupTasks.removeAll()
+            cacheCompressionTask?.cancel()
+            radioPlayer?.pause()
+            #if canImport(UIKit)
+                let transitionTaskID = trackTransitionTaskID
+                trackTransitionTaskID = .invalid
+                if transitionTaskID != .invalid {
+                    Task { @MainActor in
+                        UIApplication.shared.endBackgroundTask(transitionTaskID)
+                    }
+                }
+            #endif
+        }
     }
 
     private func cancelBackgroundAnalysisRetry() {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -9,6 +9,12 @@ import SwiftUI
     import UIKit
 #endif
 
+/// Tick counter for fade timers; only mutated on the main run loop, but lives
+/// in a @Sendable timer closure so it needs an unchecked-Sendable box.
+private final class TimerStepCounter: @unchecked Sendable {
+    var step = 0
+}
+
 enum RepeatMode {
     case off, all, one
     var symbol: String {
@@ -582,7 +588,7 @@ class AudioPlayerManager: ObservableObject {
         #endif
     }
 
-    deinit {
+    isolated deinit {
         pollTimer?.invalidate()
         quickCutTimer?.invalidate()
         streamFadeTimer?.invalidate()
@@ -1358,7 +1364,7 @@ class AudioPlayerManager: ObservableObject {
                 progress: nil
             ) { [weak self] _, _, _, _, _, _ in
                 Task { @MainActor in
-                    self?.playerArtworkWarmupTasks.removeValue(forKey: key)
+                    _ = self?.playerArtworkWarmupTasks.removeValue(forKey: key)
                 }
             }
         }
@@ -2149,22 +2155,25 @@ class AudioPlayerManager: ObservableObject {
     }
 
     private func fadeOutStreamPlayer(duration: TimeInterval) {
-        guard let player = streamPlayer else { return }
+        guard streamPlayer != nil else { return }
         streamFadeTimer?.invalidate()
         let interval = AVEnginePlayback.transitionTimerInterval
         let steps = max(1, Int((duration / interval).rounded(.up)))
-        var step = 0
+        let counter = TimerStepCounter()
         let timer = Timer(timeInterval: interval, repeats: true) { [weak self] timer in
             guard self != nil else { timer.invalidate(); return }
-            MainActor.assumeIsolated {
-                step += 1
-                let t = Float(step) / Float(max(1, steps))
-                player.volume = max(0, 1.0 - t)
+            let finished = MainActor.assumeIsolated { () -> Bool in
+                guard let self else { return true }
+                counter.step += 1
+                let t = Float(counter.step) / Float(max(1, steps))
+                self.streamPlayer?.volume = max(0, 1.0 - t)
                 if t >= 1.0 {
-                    timer.invalidate()
-                    self?.streamFadeTimer = nil
+                    self.streamFadeTimer = nil
+                    return true
                 }
+                return false
             }
+            if finished { timer.invalidate() }
         }
         streamFadeTimer = timer
         RunLoop.main.add(timer, forMode: .common)
@@ -2795,7 +2804,9 @@ class AudioPlayerManager: ObservableObject {
 
     #if canImport(UIKit)
         private func applyArtwork(_ image: UIImage, for songID: String?, artworkURL requestedURL: URL) {
-            let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+            // The system may call the artwork request handler off the main
+            // thread; @Sendable keeps it from inheriting main-actor isolation.
+            let artwork = MPMediaItemArtwork(boundsSize: image.size) { @Sendable _ in image }
             DispatchQueue.main.async { [weak self] in
                 guard let self,
                       let song = self.currentSong,
@@ -2974,24 +2985,23 @@ class AudioPlayerManager: ObservableObject {
         let song = plan.nextSong
         let interval = AVEnginePlayback.transitionTimerInterval
         let steps = max(1, Int((fadeDuration / interval).rounded(.up)))
-        var step = 0
+        let counter = TimerStepCounter()
         let timer = Timer(timeInterval: interval, repeats: true) { [weak self] timer in
             guard self != nil else {
                 timer.invalidate()
                 return
             }
-            MainActor.assumeIsolated {
-                guard let self else { return }
-                guard self.quickCutGeneration == gen else { return }
+            let finished = MainActor.assumeIsolated { () -> Bool in
+                guard let self else { return true }
+                guard self.quickCutGeneration == gen else { return false }
                 guard self.transitionCoordinator.state.isCrossfading, !self.isRadioMode else {
                     self.cancelPendingTransitionWork()
-                    return
+                    return false
                 }
-                step += 1
-                let t = Float(step) / Float(max(1, steps))
+                counter.step += 1
+                let t = Float(counter.step) / Float(max(1, steps))
                 self.avEngine.setMasterVolume(1.0 - t)
                 if t >= 1.0 {
-                    timer.invalidate()
                     self.quickCutTimer = nil
                     DebugLogger.log("Quick cut transition complete -> play(\(song.id))", category: .playback)
                     self.activeCrossfadePlan = nil
@@ -2999,8 +3009,11 @@ class AudioPlayerManager: ObservableObject {
                     self.avEngine.setMasterVolume(0)
                     self.play(song: song, resetTransitionVolume: false)
                     self.avEngine.setMasterVolume(1.0)
+                    return true
                 }
+                return false
             }
+            if finished { timer.invalidate() }
         }
         quickCutTimer = timer
         RunLoop.main.add(timer, forMode: .common)

--- a/Twinskaraoke/Services/Audio/BPMDetector.swift
+++ b/Twinskaraoke/Services/Audio/BPMDetector.swift
@@ -2,7 +2,7 @@ import Accelerate
 @preconcurrency import AVFoundation
 import Foundation
 
-enum BPMDetector {
+nonisolated enum BPMDetector {
     static func detect(url: URL) async -> Double? {
         let asset = AVURLAsset(url: url)
         guard let track = try? await asset.loadTracks(withMediaType: .audio).first else { return nil }

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -353,7 +353,8 @@ final class TransitionCoordinator {
     }
 }
 
-private final class PredownloadSession: NSObject, URLSessionDataDelegate {
+// URLSession delegates must be Sendable; cross-thread state is guarded by stateLock.
+private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     private let songID: String
     private let expectedDuration: TimeInterval?
     private let partialURL: URL

--- a/Twinskaraoke/Services/Debug/DebugLogger.swift
+++ b/Twinskaraoke/Services/Debug/DebugLogger.swift
@@ -30,7 +30,8 @@ nonisolated enum DebugLogger {
     }
 
     private static let logQueue = DispatchQueue(label: "nk.debugLogger", qos: .utility)
-    private static var recentLogs: [String] = []
+    // Only accessed on logQueue.
+    private nonisolated(unsafe) static var recentLogs: [String] = []
     private static let maxStoredLogs = 500
 
     static func log(

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -13,9 +13,10 @@ nonisolated enum AudioCacheStore {
         let offset: URL
     }
 
-    private static let fm = FileManager.default
+    // FileManager.default is thread-safe; Algorithm is an immutable enum value.
+    private nonisolated(unsafe) static let fm = FileManager.default
     private static let compressionExtension = "nkz"
-    private static let compressionAlgorithm: Algorithm = .lzfse
+    private nonisolated(unsafe) static let compressionAlgorithm: Algorithm = .lzfse
     private static let chunkSize = 64 * 1024
     private static let maximumPlayableFileSize: Int64 = 256 * 1024 * 1024
     private static let cacheDirectory: URL = {

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -3,7 +3,8 @@ import Foundation
 import Network
 import SwiftUI
 
-private final class DownloadTaskRegistry: @unchecked Sendable {
+// Called from URLSession completion handlers off the main actor; NSLock-guarded.
+private nonisolated final class DownloadTaskRegistry: @unchecked Sendable {
     private let lock = NSLock()
     private var activeTokens: [String: UUID] = [:]
 


### PR DESCRIPTION
## Summary

Building with Swift 6 language mode (Xcode 26, default main-actor isolation) turns the existing concurrency warnings into hard errors and adds runtime isolation assertions. This PR makes the code's threading design explicit where it was previously implicit, without changing behavior.

### Compile-time fixes

- **AVEnginePlayback**: non-Sendable `AVAudioFile`/`AVAudioPCMBuffer` payloads moving from detached loader tasks to the main actor are wrapped in an `@unchecked Sendable` transfer box (each loader hands over its only reference). Player completion handlers are `@Sendable` — they fire on the audio render thread — and hop to the main actor for the stale-token check, preserving the existing suppression-token semantics.
- **Timer blocks** (crossfade handoff blend, stream fade-out, quick-cut): block-based `Timer` closures are `@Sendable`, so the timer can't be touched inside `MainActor.assumeIsolated`. The isolated closure now returns a "finished" flag and invalidation happens outside; tick counters live in a small Sendable box instead of captured mutable locals.
- **`isolated deinit`** where cleanup touches main-actor state (`AudioPlayerManager`, QR camera controller).
- **Lock/queue-guarded shared state** is marked `nonisolated(unsafe)` with the guarding invariant documented: `DebugLogger.recentLogs` (dispatch queue), `AudioCacheStore` statics (thread-safe `FileManager`, immutable enum), `DownloadTaskRegistry` (`NSLock`), the QR `AVCaptureSession` locals (serial session queue).
- **`PredownloadSession`** is `@unchecked Sendable` now that `URLSession` delegates must be Sendable; its cross-thread state was already `NSLock`-guarded.
- **`BPMDetector`** is `nonisolated` (pure DSP deliberately run on a background queue); **`FallbackArtProvider`**'s retry completion is `@Sendable` with results collected in a queue-guarded box.

### Runtime crash fixes

With default main-actor isolation, closures passed to un-annotated Objective-C block APIs silently inherit `@MainActor` and trap with `EXC_BREAKPOINT` when the framework invokes them on a background queue:

- SDWebImage's `requestModifier`/`responseModifier` blocks (invoked on the download queue) — this crashed reproducibly on device
- `MPMediaItemArtwork`'s request handler (documented to be callable from any thread)

Both are now explicitly `@Sendable`, with the helpers they call made `nonisolated`.

## Testing

- Full device-configuration build in Swift 6 language mode with zero remaining Sendable/actor-isolation diagnostics
- `TwinskaraokeTests` suite passes (iPhone 17 Pro simulator, iOS 26.5)
- On-device smoke test: playback, pause/resume via remote commands, seeking, auto-mix crossfade, and rapid consecutive track switching all behave correctly; the SDWebImage response-modifier crash no longer reproduces

## Summary by Sourcery

Make audio playback, timers, artwork, networking, and camera code explicitly safe under Swift 6 strict concurrency and main-actor isolation without changing behavior.

Bug Fixes:
- Prevent runtime crashes caused by implicitly main-actor-annotated Objective-C/SDWebImage block callbacks executing off the main thread.

Enhancements:
- Wrap loaded audio media in a sendable transfer container and mark audio callbacks, helpers, and pure-DSP utilities with appropriate sendability and nonisolated annotations.
- Rework fade, crossfade, and quick-cut timers to use sendable counters and main-actor-isolated bodies while handling timer invalidation outside the actor.
- Declare isolated deinits and document nonisolated(unsafe) shared state guarded by locks, queues, or thread-safe APIs across audio, storage, download, and camera components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback reliability during track changes, fades, and crossfades.
  * Reduced the chance of crashes or freezes while loading audio/artwork and during QR-based camera approval.
  * Made download and cache handling more stable so media assets load more consistently.
* **Performance**
  * Smoothed background processing for media loading and playback transitions, improving responsiveness under heavy use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->