### PR TITLE
Add MagicBytes as app maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ All credits go to the website creator "Soul". This is a companion app for the we
 
 This App Created By
 - [@ytsodacan](https://github.com/ytsodacan) (SillyProotSoda) 
-- [@XiaoYuan151](https://github.com/XiaoYuan151) (XiaoYuan151).  
-
+- [@XiaoYuan151](https://github.com/XiaoYuan151) (XiaoYuan151)
+- [@Mag1cByt3s](https://github.com/Mag1cByt3s) (MagicBytes).
 
 > Warning : currently the installation means you must sideload the app every 7 days.
 
@@ -216,4 +216,3 @@ After 7 days, the app will crash immediately when you try to open it. **You do n
 
 ## License
 This project is licensed under the [Apache-2.0 License](LICENSE).
-

--- a/Twinskaraoke/Features/Account/CreditsView.swift
+++ b/Twinskaraoke/Features/Account/CreditsView.swift
@@ -33,7 +33,7 @@ struct CreditsView: View {
             Section("iOS App Developers") {
                 creditRow(name: "XiaoYuan151", detail: "Main Developer", url: "https://github.com/XiaoYuan151")
                 creditRow(name: "SillyProotSoda", detail: "Main Developer", url: "https://sillyprootsoda.com")
-                creditRow(name: "MagicBytes", detail: "did like 18 pull requests lule", url: "https://github.com/Mag1cByt3s")
+                creditRow(name: "MagicBytes", detail: "Maintainer", url: "https://github.com/Mag1cByt3s")
             }
             
             Section("Banner & Branding") {


### PR DESCRIPTION
## Summary

- Add MagicBytes to the app creator list in the README.
- Update the in-app credits to identify MagicBytes as a maintainer.

## Why

Reflect the current project maintenance responsibilities in both the repository documentation and the app.

## Impact

Credits only; there are no runtime behavior changes.

## Validation

- `git diff --check`
- Tests not run (documentation and display-copy changes only).

## Summary by Sourcery

Update project credits to reflect MagicBytes as an app maintainer across documentation and in-app UI.

Enhancements:
- Update the in-app credits to list MagicBytes as an iOS app maintainer instead of a contributor description.

Documentation:
- Add MagicBytes to the app creator list in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributor credits in the README.
  * Added an Apache-2.0 license section and link.

* **Credits**
  * Updated a contributor’s description from a pull request reference to “Maintainer.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->