### PR TITLE
Keep player volume synced after foregrounding

### DIFF
--- a/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
+++ b/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PlayerVolumeRow: View {
     @EnvironmentObject var audioManager: AudioPlayerManager
+    @Environment(\.scenePhase) private var scenePhase
     var horizontalPadding: CGFloat = 32
 
     var body: some View {
@@ -33,7 +34,9 @@ struct PlayerVolumeRow: View {
                 SystemVolumeBridge(
                     volume: $audioManager.volume,
                     isUserScrubbing: $audioManager.isUserScrubbingVolume
-                ).frame(width: 0, height: 0)
+                )
+                .id(scenePhase)
+                .frame(width: 1, height: 1)
             )
         #endif
     }

--- a/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
+++ b/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PlayerVolumeRow: View {
     @EnvironmentObject var audioManager: AudioPlayerManager
     @Environment(\.scenePhase) private var scenePhase
+    @State private var volumeBridgeGeneration = 0
     var horizontalPadding: CGFloat = 32
 
     var body: some View {
@@ -35,9 +36,14 @@ struct PlayerVolumeRow: View {
                     volume: $audioManager.volume,
                     isUserScrubbing: $audioManager.isUserScrubbingVolume
                 )
-                .id(scenePhase)
+                .id(volumeBridgeGeneration)
                 .frame(width: 1, height: 1)
             )
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    volumeBridgeGeneration += 1
+                }
+            }
         #endif
     }
 }

--- a/Twinskaraoke/Features/Player/SystemVolumeBridge.swift
+++ b/Twinskaraoke/Features/Player/SystemVolumeBridge.swift
@@ -2,12 +2,23 @@
     import MediaPlayer
     import SwiftUI
 
+    enum SystemVolumeReconciliation {
+        static func value(
+            currentVolume: Double,
+            systemVolume: Float,
+            isUserScrubbing: Bool
+        ) -> Double {
+            isUserScrubbing ? currentVolume : Double(systemVolume)
+        }
+    }
+
     struct SystemVolumeBridge: UIViewRepresentable {
         @Binding var volume: Double
         @Binding var isUserScrubbing: Bool
         func makeUIView(context _: Context) -> MPVolumeView {
             let view = MPVolumeView(frame: .zero)
             view.alpha = 0.0001
+            synchronizeVolume(from: view)
             return view
         }
 
@@ -19,6 +30,21 @@
                 if abs(slider.value - target) > 0.005 {
                     slider.setValue(target, animated: false)
                     slider.sendActions(for: .valueChanged)
+                }
+            }
+        }
+
+        private func synchronizeVolume(from view: MPVolumeView) {
+            DispatchQueue.main.async {
+                view.layoutIfNeeded()
+                guard let slider = view.subviews.compactMap({ $0 as? UISlider }).first else { return }
+                let reconciledVolume = SystemVolumeReconciliation.value(
+                    currentVolume: volume,
+                    systemVolume: slider.value,
+                    isUserScrubbing: isUserScrubbing
+                )
+                if volume != reconciledVolume {
+                    volume = reconciledVolume
                 }
             }
         }

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -580,13 +580,11 @@ class AudioPlayerManager: ObservableObject {
             }
             .store(in: &cancellables)
         updateRouteIcon()
+        syncSystemVolume()
         AVAudioSession.sharedInstance().publisher(for: \.outputVolume)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] sysVol in
-                guard let self else { return }
-                guard !isUserScrubbingVolume else { return }
-                let v = Double(sysVol)
-                if abs(volume - v) > 0.01 { volume = v }
+                self?.syncSystemVolume(sysVol)
             }
             .store(in: &cancellables)
         NotificationCenter.default.publisher(for: AVAudioSession.mediaServicesWereResetNotification)
@@ -2492,6 +2490,19 @@ class AudioPlayerManager: ObservableObject {
 
     private func activateAudioSession() {
         try? AVAudioSession.sharedInstance().setActive(true, options: [.notifyOthersOnDeactivation])
+    }
+
+    private func syncSystemVolume(
+        _ systemVolume: Float = AVAudioSession.sharedInstance().outputVolume
+    ) {
+        let reconciledVolume = SystemVolumeReconciliation.value(
+            currentVolume: volume,
+            systemVolume: systemVolume,
+            isUserScrubbing: isUserScrubbingVolume
+        )
+        if volume != reconciledVolume {
+            volume = reconciledVolume
+        }
     }
 
     private func recoverFromEngineConfigChange() {

--- a/TwinskaraokeTests/SystemVolumeSyncTests.swift
+++ b/TwinskaraokeTests/SystemVolumeSyncTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Twinskaraoke
+
+@Suite("System volume synchronization")
+struct SystemVolumeSyncTests {
+    @Test("System volume replaces a stale player volume exactly")
+    func systemVolumeReplacesStaleVolume() {
+        let systemVolume: Float = 0.37
+
+        let volume = SystemVolumeReconciliation.value(
+            currentVolume: 0.8,
+            systemVolume: systemVolume,
+            isUserScrubbing: false
+        )
+
+        #expect(volume == Double(systemVolume))
+    }
+
+    @Test("System updates do not interrupt active volume scrubbing")
+    func systemVolumeWaitsForScrubbingToFinish() {
+        let currentVolume = 0.8
+
+        let volume = SystemVolumeReconciliation.value(
+            currentVolume: currentVolume,
+            systemVolume: 0.2,
+            isUserScrubbing: true
+        )
+
+        #expect(volume == currentVolume)
+    }
+}


### PR DESCRIPTION
## Summary

- Reconcile the custom player volume bar with the exact system volume.
- Recreate the hidden `MPVolumeView` bridge when the app scene becomes active and read its native slider value.
- Preserve active volume scrubbing while applying system-driven updates.
- Add regression coverage for stale-volume replacement and scrubbing behavior.

## Why

`AVAudioSession.outputVolume` observation does not reliably deliver changes made while the app is in the background. Returning to an already-open full player could therefore leave the custom volume bar showing the pre-background value.

## Impact

The player volume bar now reflects volume changes made elsewhere in iOS after the app returns to the foreground. Existing in-app volume dragging remains unchanged.

## Validation

- Confirmed on a physical iPhone using the original reproduction: background the app with the full player open, change the iOS volume, and return to the app.
- `xcodebuild test -project Twinskaraoke.xcodeproj -scheme Twinskaraoke -destination 'platform=iOS Simulator,id=193E03DE-2E19-4EE4-91ED-B314B8253E42' -parallel-testing-enabled NO -only-testing:TwinskaraokeTests`
- 35 tests passed across 5 suites.

## Summary by Sourcery

Ensure the custom player volume stays in sync with the system volume when the app returns to the foreground without disrupting active user scrubbing.

Enhancements:
- Centralize system-vs-player volume reconciliation in a shared helper used by the audio manager and the system volume bridge.
- Trigger system volume resynchronization when the player view appears and when the app scene phase changes so background changes are reflected on return.

Tests:
- Add unit tests covering replacement of stale player volume with current system volume and preservation of user scrubbing during system-driven updates.