### PR TITLE
Harden iOS reliability and performance

### DIFF
--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -971,7 +971,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Twinskaraoke Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Twinskaraoke Watch App";
-				WATCHOS_DEPLOYMENT_TARGET = 9.6;
+				WATCHOS_DEPLOYMENT_TARGET = 10.6;
 			};
 			name = Debug;
 		};
@@ -999,7 +999,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Twinskaraoke Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Twinskaraoke Watch App";
-				WATCHOS_DEPLOYMENT_TARGET = 9.6;
+				WATCHOS_DEPLOYMENT_TARGET = 10.6;
 			};
 			name = Release;
 		};
@@ -1025,7 +1025,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_TARGET_NAME = "Twinskaraoke Watch App";
-				WATCHOS_DEPLOYMENT_TARGET = 9.6;
+				WATCHOS_DEPLOYMENT_TARGET = 10.6;
 			};
 			name = Debug;
 		};
@@ -1051,7 +1051,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_TARGET_NAME = "Twinskaraoke Watch App";
-				WATCHOS_DEPLOYMENT_TARGET = 9.6;
+				WATCHOS_DEPLOYMENT_TARGET = 10.6;
 			};
 			name = Release;
 		};

--- a/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
+++ b/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
@@ -3,33 +3,36 @@ import SwiftUI
 struct PlaylistActionsMenuItems: View {
     let playlist: Playlist
     let songs: [Song]
-    @ObservedObject private var savedStore: SavedPlaylistsStore = .shared
-    @ObservedObject private var downloads = DownloadManager.shared
+    private let isSaved: Bool
+    private let pendingSongs: [Song]
+    private let inFlightCount: Int
 
-    private var downloadState: (pendingSongs: [Song], inFlightCount: Int) {
-        songs.reduce(into: (pendingSongs: [], inFlightCount: 0)) { state, song in
+    init(playlist: Playlist, songs: [Song]) {
+        self.playlist = playlist
+        self.songs = songs
+        isSaved = SavedPlaylistsStore.shared.isSaved(playlist)
+
+        let downloads = DownloadManager.shared
+        let state = songs.reduce(into: (pendingSongs: [Song](), inFlightCount: 0)) { state, song in
             if downloads.isDownloading(song.id) {
                 state.inFlightCount += 1
             } else if !downloads.isDownloaded(song.id) {
                 state.pendingSongs.append(song)
             }
         }
+        pendingSongs = state.pendingSongs
+        inFlightCount = state.inFlightCount
     }
 
     private var canSaveToLibrary: Bool {
         !playlist.isFavorites && !playlist.isPersonal
     }
 
-    private var isSaved: Bool {
-        savedStore.isSaved(playlist)
-    }
-
     var body: some View {
-        let downloadState = downloadState
-        let pendingCount = downloadState.pendingSongs.count
+        let pendingCount = pendingSongs.count
         let allDownloaded = !songs.isEmpty
             && pendingCount == 0
-            && downloadState.inFlightCount == 0
+            && inFlightCount == 0
 
         if !songs.isEmpty {
             Button {
@@ -54,7 +57,7 @@ struct PlaylistActionsMenuItems: View {
         if canSaveToLibrary {
             Button {
                 AppHaptic.selection.play()
-                savedStore.toggle(playlist)
+                SavedPlaylistsStore.shared.toggle(playlist)
             } label: {
                 if isSaved {
                     Label("Remove from Library", systemImage: "checkmark.circle.fill")
@@ -65,8 +68,8 @@ struct PlaylistActionsMenuItems: View {
         }
 
         if !songs.isEmpty {
-            if downloadState.inFlightCount > 0 {
-                Label("Downloading \(downloadState.inFlightCount)…", systemImage: "arrow.down.circle")
+            if inFlightCount > 0 {
+                Label("Downloading \(inFlightCount)…", systemImage: "arrow.down.circle")
             } else if allDownloaded {
                 Button(role: .destructive) {
                     AppHaptic.warning.play()
@@ -77,7 +80,7 @@ struct PlaylistActionsMenuItems: View {
             } else {
                 Button {
                     AppHaptic.success.play()
-                    DownloadManager.shared.download(songs: downloadState.pendingSongs)
+                    DownloadManager.shared.download(songs: pendingSongs)
                 } label: {
                     let label = pendingCount < songs.count ? "Download Remaining" : "Download"
                     Label(label, systemImage: "arrow.down.circle")

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -159,13 +159,20 @@ final class ArtworkFailureBackoff {
         let now = Date()
         lock.lock()
         defer { lock.unlock() }
-        blockedUntil = blockedUntil.filter { $0.value > now }
         guard let until = blockedUntil[url] else { return false }
-        return until > now
+        guard until > now else {
+            blockedUntil.removeValue(forKey: url)
+            return false
+        }
+        return true
     }
 
     func recordFailure(_ url: URL) {
         lock.lock()
+        if blockedUntil.count > 256 {
+            let now = Date()
+            blockedUntil = blockedUntil.filter { $0.value > now }
+        }
         blockedUntil[url] = Date().addingTimeInterval(cooldown)
         lock.unlock()
     }

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -98,7 +98,7 @@ struct SongRow: View {
                         .fill(Color.appArtworkOverlay)
                         .frame(width: size.artSize, height: size.artSize)
 
-                    EqualizerBars(isAnimating: false)
+                    EqualizerBars(isAnimating: playback.isPlaying)
                         .frame(width: size.indicatorSize, height: size.indicatorSize)
                         .foregroundStyle(.primary)
                 }

--- a/Twinskaraoke/Models/Home/HomeViewModel.swift
+++ b/Twinskaraoke/Models/Home/HomeViewModel.swift
@@ -20,6 +20,8 @@ final class HomeViewModel: ObservableObject {
     private var topPicksPage = 0
     private let topPicksPageSize = 12
     private var topPicksSource: TopPicksSource = .setlists
+    private var dataGeneration = 0
+    private var homeLoadTask: Task<Void, Never>?
 
     init() {
         fetchHomeData()
@@ -32,53 +34,44 @@ final class HomeViewModel: ObservableObject {
         }
 
         if hasLoaded, !force { return }
+        homeLoadTask?.cancel()
+        dataGeneration += 1
+        let generation = dataGeneration
         hasLoaded = true
         isLoading = true
+        isLoadingMoreTopPicks = false
         topPicksPage = 0
         canLoadMoreTopPicks = true
-        let group = DispatchGroup()
-        group.enter()
-        Task { [weak self] in
-            let response = try? await KaraokeAPIClient.trendingSongs(take: 20)
-            await MainActor.run {
-                if let response { self?.trending = response }
-                group.leave()
+        homeLoadTask = Task { [weak self] in
+            guard let self else { return }
+            async let trendingResult = try? KaraokeAPIClient.trendingSongs(take: 20)
+            async let suggestionsResult = try? KaraokeAPIClient.songSuggestions(take: 20)
+            async let topPicksResult = fetchTopPicks(startIndex: 0)
+            async let releasesResult = try? KaraokeAPIClient.latestReleases()
+
+            let (loadedTrending, loadedSuggestions, loadedTopPicks, loadedReleases) = await (
+                trendingResult,
+                suggestionsResult,
+                topPicksResult,
+                releasesResult
+            )
+            guard !Task.isCancelled, dataGeneration == generation else { return }
+
+            if let loadedTrending { trending = loadedTrending }
+            if let loadedSuggestions { suggestions = loadedSuggestions }
+            if let playlists = loadedTopPicks.playlists {
+                topPicksSource = loadedTopPicks.source
+                recentPlaylists = playlists
+                topPicksPage = 1
+                canLoadMoreTopPicks = playlists.count == topPicksPageSize
             }
+            let releases = loadedReleases ?? []
+            newReleases = releases
+            latestSingle = releases.first
+            latestSingleContext = releases
+            isLoading = false
+            homeLoadTask = nil
         }
-        group.enter()
-        Task { [weak self] in
-            let response = try? await KaraokeAPIClient.songSuggestions(take: 20)
-            await MainActor.run {
-                if let response { self?.suggestions = response }
-                group.leave()
-            }
-        }
-        group.enter()
-        fetchTopPicks(startIndex: 0) { [weak self] response in
-            DispatchQueue.main.async {
-                if let response {
-                    self?.recentPlaylists = response
-                    self?.topPicksPage = 1
-                    self?.canLoadMoreTopPicks = response.count == (self?.topPicksPageSize ?? 0)
-                }
-                group.leave()
-            }
-        }
-        group.enter()
-        Task { [weak self] in
-            let songs = await (try? KaraokeAPIClient.latestReleases()) ?? []
-            await MainActor.run {
-                guard let self else {
-                    group.leave()
-                    return
-                }
-                self.newReleases = songs
-                self.latestSingle = songs.first
-                self.latestSingleContext = songs
-                group.leave()
-            }
-        }
-        group.notify(queue: .main) { [weak self] in self?.isLoading = false }
     }
 
     func loadMoreTopPicksIfNeeded(current: Playlist) {
@@ -102,6 +95,7 @@ final class HomeViewModel: ObservableObject {
         let startIndex = topPicksPage * topPicksPageSize
         let source = topPicksSource
         let pageSize = topPicksPageSize
+        let generation = dataGeneration
         Task { [weak self] in
             let playlists: [Playlist] = switch source {
             case .setlists:
@@ -118,7 +112,7 @@ final class HomeViewModel: ObservableObject {
                 )) ?? []
             }
             await MainActor.run {
-                guard let self else { return }
+                guard let self, self.dataGeneration == generation else { return }
                 if !playlists.isEmpty {
                     let existing = Set(self.recentPlaylists.map(\.id))
                     self.recentPlaylists += playlists.filter { !existing.contains($0.id) }
@@ -132,33 +126,25 @@ final class HomeViewModel: ObservableObject {
         }
     }
 
-    private func fetchTopPicks(startIndex: Int, completion: @escaping ([Playlist]?) -> Void) {
+    private func fetchTopPicks(
+        startIndex: Int
+    ) async -> (source: TopPicksSource, playlists: [Playlist]?) {
         let pageSize = topPicksPageSize
-        Task { [weak self] in
-            let setlists = await (try? KaraokeAPIClient.playlists(
-                startIndex: startIndex,
-                pageSize: pageSize,
-                isSetlist: true,
-                sortDescending: true
-            )) ?? []
-            if !setlists.isEmpty {
-                await MainActor.run {
-                    self?.topPicksSource = .setlists
-                    completion(setlists)
-                }
-                return
-            }
-
-            let fallback =
-                try? await KaraokeAPIClient.publicPlaylists(
-                    startIndex: startIndex,
-                    pageSize: pageSize
-                )
-            await MainActor.run {
-                self?.topPicksSource = .publicPlaylists
-                completion(fallback)
-            }
+        let setlists = await (try? KaraokeAPIClient.playlists(
+            startIndex: startIndex,
+            pageSize: pageSize,
+            isSetlist: true,
+            sortDescending: true
+        )) ?? []
+        if !setlists.isEmpty {
+            return (.setlists, setlists)
         }
+
+        let fallback = try? await KaraokeAPIClient.publicPlaylists(
+            startIndex: startIndex,
+            pageSize: pageSize
+        )
+        return (.publicPlaylists, fallback)
     }
 
     private func applyUITestFixture() {
@@ -232,5 +218,9 @@ final class HomeViewModel: ObservableObject {
                 coverArtists: ["Neuro"]
             ),
         ]
+    }
+
+    deinit {
+        homeLoadTask?.cancel()
     }
 }

--- a/Twinskaraoke/Models/Library/ArtistsViewModel.swift
+++ b/Twinskaraoke/Models/Library/ArtistsViewModel.swift
@@ -8,6 +8,8 @@ final class ArtistsViewModel: ObservableObject {
     @Published var canLoadMore = true
     private var page = 0
     private let pageSize = 25
+    private var loadGeneration = 0
+    private var activeTask: URLSessionDataTask?
     func fetchInitial() {
         guard artists.isEmpty, !isLoading else { return }
         page = 0
@@ -16,6 +18,10 @@ final class ArtistsViewModel: ObservableObject {
     }
 
     func refresh() {
+        activeTask?.cancel()
+        activeTask = nil
+        loadGeneration += 1
+        isLoading = false
         page = 0
         canLoadMore = true
         load(reset: true)
@@ -35,19 +41,43 @@ final class ArtistsViewModel: ObservableObject {
             "\(StorageHost.api)/api/artists?startIndex=\(startIndex)&pageSize=\(pageSize)&search=&sortBy=Name&sortDescending=False"
         guard let url = URL(string: urlString) else { return }
         isLoading = true
+        loadGeneration += 1
+        let generation = loadGeneration
         var request = URLRequest(url: url)
         GuestIdentity.applyIfNeeded(to: &request)
-        URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
-            Task { @MainActor [weak self, data, reset] in
-                self?.applyArtistsResponse(data, reset: reset)
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            Task { @MainActor [weak self, data, response, error, reset, generation] in
+                self?.applyArtistsResponse(
+                    data,
+                    response: response,
+                    error: error,
+                    reset: reset,
+                    generation: generation
+                )
             }
-        }.resume()
+        }
+        activeTask = task
+        task.resume()
     }
 
-    private func applyArtistsResponse(_ data: Data?, reset: Bool) {
-        defer { isLoading = false }
+    private func applyArtistsResponse(
+        _ data: Data?,
+        response: URLResponse?,
+        error: Error?,
+        reset: Bool,
+        generation: Int
+    ) {
+        guard generation == loadGeneration else { return }
+        defer {
+            activeTask = nil
+            isLoading = false
+        }
 
-        guard let data, let decoded = try? JSONDecoder().decode([Artist].self, from: data) else {
+        guard error == nil,
+              (response as? HTTPURLResponse).map({ (200 ... 299).contains($0.statusCode) }) != false,
+              let data,
+              let decoded = try? JSONDecoder().decode([Artist].self, from: data)
+        else {
             return
         }
 
@@ -60,6 +90,10 @@ final class ArtistsViewModel: ObservableObject {
         page += 1
         canLoadMore = decoded.count == pageSize
     }
+
+    deinit {
+        activeTask?.cancel()
+    }
 }
 
 @MainActor
@@ -69,11 +103,17 @@ final class ArtistDetailViewModel: ObservableObject {
     @Published private(set) var hasLoadedDetail = false
     @Published var errorMessage: String?
     private var loadedID: String?
+    private var loadGeneration = 0
+    private var activeTask: URLSessionDataTask?
 
     func load(id: String, fallback: Artist?, force: Bool = false) {
         if !force, loadedID == id, hasLoadedDetail { return }
         if artist == nil || loadedID != id { artist = fallback }
         loadedID = id
+        activeTask?.cancel()
+        activeTask = nil
+        loadGeneration += 1
+        let generation = loadGeneration
         hasLoadedDetail = false
         errorMessage = nil
         guard let request = try? KaraokeAPIClient.request(
@@ -84,19 +124,42 @@ final class ArtistDetailViewModel: ObservableObject {
             return
         }
         isLoading = true
-        URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
-            Task { @MainActor [weak self, data, id] in
-                self?.applyArtistDetailResponse(data, id: id)
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            Task { @MainActor [weak self, data, response, error, id, generation] in
+                self?.applyArtistDetailResponse(
+                    data,
+                    response: response,
+                    error: error,
+                    id: id,
+                    generation: generation
+                )
             }
-        }.resume()
+        }
+        activeTask = task
+        task.resume()
     }
 
-    private func applyArtistDetailResponse(_ data: Data?, id: String) {
-        guard loadedID == id else { return }
-        defer { isLoading = false }
+    private func applyArtistDetailResponse(
+        _ data: Data?,
+        response: URLResponse?,
+        error: Error?,
+        id: String,
+        generation: Int
+    ) {
+        guard loadedID == id, generation == loadGeneration else { return }
+        defer {
+            activeTask = nil
+            isLoading = false
+        }
 
-        guard let data else {
+        guard error == nil else {
             errorMessage = "Check your connection and try again."
+            return
+        }
+        guard (response as? HTTPURLResponse).map({ (200 ... 299).contains($0.statusCode) }) != false,
+              let data
+        else {
+            errorMessage = "The artist could not be loaded right now."
             return
         }
 
@@ -108,5 +171,9 @@ final class ArtistDetailViewModel: ObservableObject {
         artist = decoded
         hasLoadedDetail = true
         errorMessage = nil
+    }
+
+    deinit {
+        activeTask?.cancel()
     }
 }

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -17,6 +17,7 @@ final class LibrarySongsViewModel: ObservableObject {
     private var canLoadMore = true
     private var page = 1
     private var requestToken = 0
+    private var activeTask: URLSessionDataTask?
     private let pageSize = 40
 
     private func rebuildDisplayedSongs() {
@@ -51,6 +52,11 @@ final class LibrarySongsViewModel: ObservableObject {
     }
 
     func refresh() {
+        activeTask?.cancel()
+        activeTask = nil
+        requestToken += 1
+        isLoading = false
+        isLoadingMore = false
         hasLoaded = false
         canLoadMore = true
         fetch(page: 1, replace: true)
@@ -100,7 +106,7 @@ final class LibrarySongsViewModel: ObservableObject {
             "sortDescending": true,
         ])
 
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             Task { @MainActor [weak self, data, response, error, page, replace, token] in
                 self?.applyResponse(
                     data,
@@ -111,7 +117,9 @@ final class LibrarySongsViewModel: ObservableObject {
                     token: token
                 )
             }
-        }.resume()
+        }
+        activeTask = task
+        task.resume()
     }
 
     private func applyResponse(
@@ -124,6 +132,7 @@ final class LibrarySongsViewModel: ObservableObject {
     ) {
         guard token == requestToken else { return }
         defer {
+            activeTask = nil
             isLoading = false
             isLoadingMore = false
         }
@@ -170,5 +179,9 @@ final class LibrarySongsViewModel: ObservableObject {
             return decoded.items
         }
         return SongPayloadDecoder.decodeSongs(from: data) ?? []
+    }
+
+    deinit {
+        activeTask?.cancel()
     }
 }

--- a/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
+++ b/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
@@ -90,14 +90,26 @@ final class VideoGalleryViewModel: ObservableObject {
             return
         }
 
+        let previousCount = reset ? 0 : videos.count
         if reset {
-            videos = decoded.items
+            videos = Self.uniqueVideos(decoded.items)
         } else {
-            videos += decoded.items
+            var seen = Set(videos.map(\.id))
+            videos += decoded.items.filter { seen.insert($0.id).inserted }
         }
         page += 1
-        canLoadMore = videos.count < decoded.totalCount
+        let addedCount = videos.count - previousCount
+        canLoadMore = addedCount > 0 && videos.count < decoded.totalCount
         errorMessage = nil
+    }
+
+    private static func uniqueVideos(_ videos: [GalleryVideo]) -> [GalleryVideo] {
+        var seen = Set<String>()
+        return videos.filter { seen.insert($0.id).inserted }
+    }
+
+    deinit {
+        activeTask?.cancel()
     }
 }
 

--- a/Twinskaraoke/Services/Artwork/ImageSaver.swift
+++ b/Twinskaraoke/Services/Artwork/ImageSaver.swift
@@ -32,7 +32,7 @@
         }
 
         @objc private func didFinishSaving(
-            _: UIImage, didFinishSavingWithError error: Error?, contextInfo _: UnsafeRawPointer
+            _: UIImage, didFinishSavingWithError error: Error?, contextInfo _: UnsafeRawPointer?
         ) {
             let completion = activeCompletion
             activeCompletion = nil

--- a/Twinskaraoke/Services/Artwork/ImageSaver.swift
+++ b/Twinskaraoke/Services/Artwork/ImageSaver.swift
@@ -1,26 +1,49 @@
 #if canImport(UIKit)
     import UIKit
 
+    @MainActor
     final class ImageSaver: NSObject {
         static let shared = ImageSaver()
-        private var completion: ((Result<Void, Error>) -> Void)?
+
+        private struct SaveRequest {
+            let image: UIImage
+            let completion: (Result<Void, Error>) -> Void
+        }
+
+        private var pendingRequests: [SaveRequest] = []
+        private var activeCompletion: ((Result<Void, Error>) -> Void)?
 
         func save(image: UIImage, completion: @escaping (Result<Void, Error>) -> Void) {
-            self.completion = completion
+            pendingRequests.append(SaveRequest(image: image, completion: completion))
+            startNextRequestIfNeeded()
+        }
+
+        private func startNextRequestIfNeeded() {
+            guard activeCompletion == nil, !pendingRequests.isEmpty else { return }
+
+            let request = pendingRequests.removeFirst()
+            activeCompletion = request.completion
             UIImageWriteToSavedPhotosAlbum(
-                image, self, #selector(didFinishSaving(_:didFinishSavingWithError:contextInfo:)), nil
+                request.image,
+                self,
+                #selector(didFinishSaving(_:didFinishSavingWithError:contextInfo:)),
+                nil
             )
         }
 
         @objc private func didFinishSaving(
             _: UIImage, didFinishSavingWithError error: Error?, contextInfo _: UnsafeRawPointer
         ) {
+            let completion = activeCompletion
+            activeCompletion = nil
+
             if let error {
                 completion?(.failure(error))
             } else {
                 completion?(.success(()))
             }
-            completion = nil
+
+            startNextRequestIfNeeded()
         }
     }
 #endif

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -10,6 +10,16 @@ private nonisolated struct LoadedMediaTransfer<Value>: @unchecked Sendable {
     let value: Value
 }
 
+/// Transfers detached timers to the main queue for invalidation without
+/// retaining their actor-isolated owner during teardown.
+private nonisolated struct TimerInvalidationTransfer: @unchecked Sendable {
+    let timers: [Timer]
+
+    func invalidate() {
+        timers.forEach { $0.invalidate() }
+    }
+}
+
 enum AVEnginePlaybackRampStyle {
     case equalPower
     case linear
@@ -27,7 +37,9 @@ extension AVAudioTime {
 }
 
 final class SimpleAudioPlayer {
-    let playerNode = AVAudioPlayerNode()
+    // AVAudioPlayerNode.stop() is thread-safe and is also used during
+    // nonisolated owner teardown.
+    nonisolated(unsafe) let playerNode = AVAudioPlayerNode()
     // Invoked from the audio render callback thread, hence @Sendable and
     // accessible off the main actor.
     nonisolated(unsafe) var completionHandler: (@Sendable () -> Void)?
@@ -346,23 +358,29 @@ final class AVEnginePlayback {
     }
 
     deinit {
-        MainActor.assumeIsolated {
-            if let engineConfigObserver {
-                NotificationCenter.default.removeObserver(engineConfigObserver)
-            }
-            crossfadeTimer?.invalidate()
-            handoffBlendTimer?.invalidate()
-            singleLoadTask?.cancel()
-            stemsLoadTask?.cancel()
-            switchToStemsLoadTask?.cancel()
-            crossfadePreloadTask?.cancel()
-            crossfadeFinalizeTask?.cancel()
-            mainPlayer.stop()
-            crossfadePlayer.stop()
-            stemVocals.stop()
-            stemInstrumental.stop()
-            engine.stop()
+        if let engineConfigObserver {
+            NotificationCenter.default.removeObserver(engineConfigObserver)
         }
+        let timers = TimerInvalidationTransfer(
+            timers: [crossfadeTimer, handoffBlendTimer].compactMap { $0 }
+        )
+        crossfadeTimer = nil
+        handoffBlendTimer = nil
+        if !timers.timers.isEmpty {
+            DispatchQueue.main.async {
+                timers.invalidate()
+            }
+        }
+        singleLoadTask?.cancel()
+        stemsLoadTask?.cancel()
+        switchToStemsLoadTask?.cancel()
+        crossfadePreloadTask?.cancel()
+        crossfadeFinalizeTask?.cancel()
+        mainPlayer.playerNode.stop()
+        crossfadePlayer.playerNode.stop()
+        stemVocals.playerNode.stop()
+        stemInstrumental.playerNode.stop()
+        engine.stop()
     }
 
     func startEngineIfNeeded() {

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -345,6 +345,26 @@ final class AVEnginePlayback {
         }
     }
 
+    deinit {
+        MainActor.assumeIsolated {
+            if let engineConfigObserver {
+                NotificationCenter.default.removeObserver(engineConfigObserver)
+            }
+            crossfadeTimer?.invalidate()
+            handoffBlendTimer?.invalidate()
+            singleLoadTask?.cancel()
+            stemsLoadTask?.cancel()
+            switchToStemsLoadTask?.cancel()
+            crossfadePreloadTask?.cancel()
+            crossfadeFinalizeTask?.cancel()
+            mainPlayer.stop()
+            crossfadePlayer.stop()
+            stemVocals.stop()
+            stemInstrumental.stop()
+            engine.stop()
+        }
+    }
+
     func startEngineIfNeeded() {
         if !engine.isRunning {
             do {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -322,6 +322,7 @@ class AudioPlayerManager: ObservableObject {
     private var lastNowPlayingElapsedSecond: Int?
     private var lastNowPlayingPlaybackRate: Double?
     private var lastLoggedNowPlayingElapsedSecond: Int?
+    private var lastRemoteCommandDiagnosticState: String?
     private static func loadCrossfadeSeconds() -> Double {
         let raw = UserDefaults.standard.object(forKey: "nk.crossfadeSeconds") as? Double ?? 6.0
         return min(15, max(1, raw))
@@ -2726,8 +2727,12 @@ class AudioPlayerManager: ObservableObject {
         cc.nextTrackCommand.isEnabled = hasCurrentItem && !isRadioMode
         cc.previousTrackCommand.isEnabled = hasCurrentItem && !isRadioMode
         cc.changePlaybackPositionCommand.isEnabled = hasCurrentItem && !isRadioMode
+        let diagnosticState =
+            "item=\(hasCurrentItem), play=\(cc.playCommand.isEnabled), pause=\(cc.pauseCommand.isEnabled), toggle=\(cc.togglePlayPauseCommand.isEnabled), requested=\(isPlaybackRequested)"
+        guard lastRemoteCommandDiagnosticState != diagnosticState else { return }
+        lastRemoteCommandDiagnosticState = diagnosticState
         DebugLogger.log(
-            "Remote commands availability: item=\(hasCurrentItem), play=\(cc.playCommand.isEnabled), pause=\(cc.pauseCommand.isEnabled), toggle=\(cc.togglePlayPauseCommand.isEnabled), requested=\(isPlaybackRequested)",
+            "Remote commands availability: \(diagnosticState)",
             category: .playback
         )
     }

--- a/Twinskaraoke/Services/Audio/BPMDetector.swift
+++ b/Twinskaraoke/Services/Audio/BPMDetector.swift
@@ -4,14 +4,19 @@ import Foundation
 
 nonisolated enum BPMDetector {
     static func detect(url: URL) async -> Double? {
-        let asset = AVURLAsset(url: url)
-        guard let track = try? await asset.loadTracks(withMediaType: .audio).first else { return nil }
-        let duration = await (try? asset.load(.duration)) ?? .invalid
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .utility).async {
-                let result = detectSync(asset: asset, track: track, duration: duration)
-                continuation.resume(returning: result)
-            }
+        let worker = Task.detached(priority: .utility) { () -> Double? in
+            let asset = AVURLAsset(url: url)
+            guard !Task.isCancelled,
+                  let track = try? await asset.loadTracks(withMediaType: .audio).first
+            else { return nil }
+            let duration = await (try? asset.load(.duration)) ?? .invalid
+            guard !Task.isCancelled else { return nil }
+            return detectSync(asset: asset, track: track, duration: duration)
+        }
+        return await withTaskCancellationHandler {
+            await worker.value
+        } onCancel: {
+            worker.cancel()
         }
     }
 
@@ -30,11 +35,12 @@ nonisolated enum BPMDetector {
     private static let confidenceThreshold: Float = 1.4
 
     private static func detectSync(asset: AVURLAsset, track: AVAssetTrack, duration: CMTime) -> Double? {
+        guard !Task.isCancelled else { return nil }
         guard let samples = loadMonoSamples(asset: asset, track: track, duration: duration) else { return nil }
-        guard samples.count > windowSize else { return nil }
+        guard !Task.isCancelled, samples.count > windowSize else { return nil }
 
         let envelope = onsetEnvelope(samples)
-        guard envelope.count > 2 else { return nil }
+        guard !Task.isCancelled, envelope.count > 2 else { return nil }
 
         return bpmFromAutocorrelation(envelope)
     }
@@ -52,11 +58,16 @@ nonisolated enum BPMDetector {
             AVLinearPCMIsNonInterleaved: false,
         ]
         let output = AVAssetReaderTrackOutput(track: track, outputSettings: outputSettings)
+        guard reader.canAdd(output) else { return nil }
         reader.add(output)
 
         let totalSeconds = duration.seconds
+        guard totalSeconds.isFinite, totalSeconds > 0 else {
+            let cap = Int(analysisSeconds * analysisSR) + 8192
+            return readAllSamples(reader: reader, output: output, maxFrames: cap)
+        }
         guard totalSeconds > 5 else {
-            let cap = Int(max(totalSeconds, 30) * analysisSR) + 8192
+            let cap = Int(totalSeconds * analysisSR) + 8192
             return readAllSamples(reader: reader, output: output, maxFrames: cap)
         }
         let analysisLen = min(analysisSeconds, totalSeconds * 0.6)
@@ -79,6 +90,10 @@ nonisolated enum BPMDetector {
         var all = [Float]()
         let cap = maxFrames ?? Int.max
         while reader.status == .reading {
+            guard !Task.isCancelled else {
+                reader.cancelReading()
+                return nil
+            }
             guard let sb = output.copyNextSampleBuffer(),
                   let bb = CMSampleBufferGetDataBuffer(sb)
             else { break }
@@ -92,9 +107,10 @@ nonisolated enum BPMDetector {
                 ) == noErr,
                 let dataPtr
             else { continue }
-            let floatPtr = UnsafeRawPointer(dataPtr).bindMemory(to: Float.self, capacity: sampleCount)
-            let toAppend = min(sampleCount, cap - all.count)
+            let availableSamples = length / MemoryLayout<Float>.stride
+            let toAppend = min(sampleCount, availableSamples, cap - all.count)
             guard toAppend > 0 else { break }
+            let floatPtr = UnsafeRawPointer(dataPtr).bindMemory(to: Float.self, capacity: toAppend)
             all.append(contentsOf: UnsafeBufferPointer(start: floatPtr, count: toAppend))
             if all.count >= cap { break }
         }
@@ -107,6 +123,7 @@ nonisolated enum BPMDetector {
 
         var rms = [Float](repeating: 0, count: frameCount)
         for i in 0 ..< frameCount {
+            guard !Task.isCancelled else { return [] }
             let offset = i * hopSize
             let end = min(offset + windowSize, samples.count)
             let count = end - offset
@@ -139,6 +156,7 @@ nonisolated enum BPMDetector {
 
         envelope.withUnsafeBufferPointer { buf in
             for i in 0 ..< lagCount {
+                guard !Task.isCancelled else { return }
                 let lag = minLag + i
                 let overlapLen = n - lag
                 guard overlapLen > 0 else { continue }
@@ -152,6 +170,7 @@ nonisolated enum BPMDetector {
                 acf[i] = dot / Float(overlapLen)
             }
         }
+        guard !Task.isCancelled else { return nil }
 
         var peakVal: Float = 0
         var peakIdx: vDSP_Length = 0

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -231,7 +231,9 @@ final class TransitionCoordinator {
     static func computeFade(
         outBPM: Double?, inBPM: Double?
     ) -> (duration: TimeInterval, style: AVEnginePlayback.RampStyle) {
-        guard let out = outBPM, let inB = inBPM else {
+        guard let out = outBPM, let inB = inBPM,
+              out.isFinite, inB.isFinite, out > 0, inB > 0
+        else {
             return (6.0, .equalPower)
         }
         let diff = harmonicBPMDifference(out, inB)
@@ -451,7 +453,11 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
         self.session = nil
         guard !cancelled else { return }
         if error == nil, AudioCacheStore.acceptsAudioResponse(task.response),
-           AudioCacheStore.isPlayableAudioFile(at: partialURL)
+           AudioCacheStore.isPlayableAudioFile(at: partialURL),
+           AudioCacheStore.durationAppearsComplete(
+               actualDuration: AudioCacheStore.audioDuration(at: partialURL),
+               expectedDuration: expectedDuration
+           )
         {
             let status = (task.response as? HTTPURLResponse)?.statusCode ?? 0
             DebugLogger.log("Predownload completed for \(songID) with HTTP \(status)", category: .playback)
@@ -466,7 +472,7 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
             }
         } else {
             DebugLogger.log(
-                "Predownload failed for \(songID): \(error?.localizedDescription ?? "bad response")",
+                "Predownload failed for \(songID): \(error?.localizedDescription ?? "incomplete or invalid audio")",
                 category: .playback
             )
             try? FileManager.default.removeItem(at: partialURL)

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -306,12 +306,18 @@ nonisolated enum AudioCacheStore {
     }
 
     static func touch(_ url: URL) {
-        let now = Date()
-        try? fm.setAttributes([.modificationDate: now], ofItemAtPath: url.path)
+        let standardizedURL = url.standardizedFileURL
+        let standardizedCacheDirectory = cacheDirectory.standardizedFileURL
+        let cachePathPrefix = standardizedCacheDirectory.path + "/"
+        guard standardizedURL.path.hasPrefix(cachePathPrefix) else { return }
 
-        let rootPath = cacheDirectory.path
-        let songDirectory = url.hasDirectoryPath ? url : url.deletingLastPathComponent()
-        if songDirectory.path.hasPrefix(rootPath), songDirectory.path != rootPath {
+        let now = Date()
+        try? fm.setAttributes([.modificationDate: now], ofItemAtPath: standardizedURL.path)
+
+        let songDirectory = standardizedURL.hasDirectoryPath
+            ? standardizedURL
+            : standardizedURL.deletingLastPathComponent()
+        if songDirectory != standardizedCacheDirectory {
             try? fm.setAttributes([.modificationDate: now], ofItemAtPath: songDirectory.path)
         }
     }

--- a/Twinskaraoke/Services/Storage/CacheManager.swift
+++ b/Twinskaraoke/Services/Storage/CacheManager.swift
@@ -315,10 +315,17 @@ final class CacheManager: ObservableObject {
         for file in sortedFiles {
             guard currentSize > limit else { break }
             let size = fileSize(at: file)
-            try? fm.removeItem(at: file)
-            currentSize -= size
-            evicted += 1
-            DebugLogger.log("Evicted: \(file.lastPathComponent) (\(formatBytes(size)))", category: .cache)
+            do {
+                try fm.removeItem(at: file)
+                currentSize = currentSize > size ? currentSize - size : 0
+                evicted += 1
+                DebugLogger.log("Evicted: \(file.lastPathComponent) (\(formatBytes(size)))", category: .cache)
+            } catch {
+                DebugLogger.log(
+                    "Could not evict \(file.lastPathComponent): \(error)",
+                    category: .cache
+                )
+            }
         }
 
         DebugLogger.log(
@@ -347,9 +354,16 @@ final class CacheManager: ObservableObject {
             guard currentSize > limit else { break }
             if protectedIDs.contains(folder.lastPathComponent) { continue }
             let size = directorySize(at: folder)
-            try? fm.removeItem(at: folder)
-            currentSize = currentSize > size ? currentSize - size : 0
-            DebugLogger.log("Evicted song cache: \(folder.lastPathComponent) (\(formatBytes(size)))", category: .cache)
+            do {
+                try fm.removeItem(at: folder)
+                currentSize = currentSize > size ? currentSize - size : 0
+                DebugLogger.log("Evicted song cache: \(folder.lastPathComponent) (\(formatBytes(size)))", category: .cache)
+            } catch {
+                DebugLogger.log(
+                    "Could not evict song cache \(folder.lastPathComponent): \(error)",
+                    category: .cache
+                )
+            }
         }
     }
 
@@ -372,8 +386,10 @@ final class CacheManager: ObservableObject {
                 let modified = values.contentModificationDate,
                 modified < cutoff
             else { continue }
-            try? fm.removeItem(at: fileURL)
-            count += 1
+            do {
+                try fm.removeItem(at: fileURL)
+                count += 1
+            } catch {}
         }
         return count
     }
@@ -405,8 +421,10 @@ final class CacheManager: ObservableObject {
             else {
                 continue
             }
-            try? fm.removeItem(at: folder)
-            count += 1
+            do {
+                try fm.removeItem(at: folder)
+                count += 1
+            } catch {}
         }
         return count
     }

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -123,9 +123,10 @@ final class DownloadManager: ObservableObject {
         startNetworkMonitoring()
         // The startup scan opens every downloaded audio file to validate it;
         // that per-file decode work must stay off the main thread at launch.
+        let scanStartedAt = Date()
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
-            let scan = scanExistingDownloadsBlocking()
+            let scan = scanExistingDownloadsBlocking(createdBefore: scanStartedAt)
             await MainActor.run {
                 self.applyStartupScan(scan)
             }
@@ -713,10 +714,12 @@ final class DownloadManager: ObservableObject {
         failedInCurrentQueue = 0
     }
 
-    /// Read-only for song directories: the scan runs concurrently with live
-    /// downloads, so destructive cleanup is deferred to `applyStartupScan`,
-    /// which runs on the main actor and can defer to live download state.
-    private nonisolated func scanExistingDownloadsBlocking() -> StartupScanResult {
+    /// The scan runs concurrently with live downloads. It only removes
+    /// promotion staging files that predate this launch; all other destructive
+    /// cleanup is deferred to `applyStartupScan` so live state wins.
+    private nonisolated func scanExistingDownloadsBlocking(
+        createdBefore scanStartedAt: Date
+    ) -> StartupScanResult {
         migrateLegacyDownloadsIfNeeded()
         let fm = FileManager.default
         var ids = Set<String>()
@@ -746,6 +749,7 @@ final class DownloadManager: ObservableObject {
                 try? fm.removeItem(at: entry)
                 continue
             }
+            Self.removePromotionStagingFiles(in: entry, createdBefore: scanStartedAt)
             // Read from the directory itself because unsafe IDs are stored under a hash.
             let metadata = readMetadata(at: entry.appendingPathComponent("metadata.json"))
             let directoryKey = entry.lastPathComponent
@@ -781,6 +785,26 @@ final class DownloadManager: ObservableObject {
             repairs: repairs,
             junkDirectories: junkDirectories
         )
+    }
+
+    nonisolated static func removePromotionStagingFiles(
+        in directory: URL,
+        createdBefore cutoff: Date
+    ) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for entry in entries where entry.lastPathComponent.contains(".promoting-") {
+            let modifiedAt = try? entry.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate
+            if let modifiedAt, modifiedAt > cutoff { continue }
+            try? fm.removeItem(at: entry)
+        }
     }
 
     private func applyStartupScan(_ scan: StartupScanResult) {

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -83,6 +83,7 @@ final class DownloadManager: ObservableObject {
     var inProgress: Set<String> { publishedState.inProgress }
     private let cacheDir: URL
     private var tasks: [String: URLSessionDownloadTask] = [:]
+    private var cachePromotionTasks: [String: Task<Void, Never>] = [:]
     private var queuedDownloads: [String: Song] = [:]
     private var queuedDownloadOrder: [String] = []
     private var isLoggingDownloadQueue = false
@@ -132,6 +133,9 @@ final class DownloadManager: ObservableObject {
     }
 
     deinit {
+        for task in cachePromotionTasks.values {
+            task.cancel()
+        }
         downloadSession.invalidateAndCancel()
         networkMonitor.cancel()
     }
@@ -249,7 +253,7 @@ final class DownloadManager: ObservableObject {
     }
 
     var hasActiveQueue: Bool {
-        !tasks.isEmpty || !queuedDownloadOrder.isEmpty
+        !tasks.isEmpty || !cachePromotionTasks.isEmpty || !queuedDownloadOrder.isEmpty
     }
 
     func download(song: Song) {
@@ -284,7 +288,7 @@ final class DownloadManager: ObservableObject {
     }
 
     private func startQueuedDownloadsIfPossible() {
-        while tasks.count < Self.maxConcurrentDownloads, !queuedDownloadOrder.isEmpty {
+        while activeDownloadWorkCount < Self.maxConcurrentDownloads, !queuedDownloadOrder.isEmpty {
             let songID = queuedDownloadOrder.removeFirst()
             guard let song = queuedDownloads.removeValue(forKey: songID) else { continue }
             guard inProgress.contains(songID), !downloadedIDs.contains(songID) else {
@@ -301,16 +305,114 @@ final class DownloadManager: ObservableObject {
             return
         }
         let songID = song.id
-        let songFiles = files(for: songID)
         let token = UUID()
         let taskRegistry = taskRegistry
         taskRegistry.register(songID: songID, token: token)
         ensureSongDirectory(for: songID)
+        let promotionTask = Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let promoted = self.promotePlaybackCacheIfAvailable(
+                for: song,
+                remoteURL: remote,
+                token: token
+            )
+            await MainActor.run { [weak self] in
+                self?.finishCachePromotion(
+                    song: song,
+                    remoteURL: remote,
+                    token: token,
+                    promoted: promoted
+                )
+            }
+        }
+        cachePromotionTasks[songID] = promotionTask
+    }
+
+    private var activeDownloadWorkCount: Int {
+        tasks.count + cachePromotionTasks.count
+    }
+
+    private nonisolated func promotePlaybackCacheIfAvailable(
+        for song: Song,
+        remoteURL: URL,
+        token: UUID
+    ) -> Bool {
+        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+        guard let cachedURL = AudioCacheStore.playableMainURL(
+            for: song.id,
+            expectedRemoteURL: remoteURL,
+            expectedDuration: expectedDuration
+        ), !Task.isCancelled else { return false }
+
+        let songFiles = files(for: song.id)
+        let stagedAudio = songFiles.directory.appendingPathComponent(
+            "main.mp3.promoting-\(token.uuidString)"
+        )
+        let stagedSource = songFiles.directory.appendingPathComponent(
+            "main.source.promoting-\(token.uuidString)"
+        )
+        let fm = FileManager.default
+        defer {
+            try? fm.removeItem(at: stagedAudio)
+            try? fm.removeItem(at: stagedSource)
+        }
+
+        do {
+            try fm.createDirectory(at: songFiles.directory, withIntermediateDirectories: true)
+            try fm.copyItem(at: cachedURL, to: stagedAudio)
+            guard !Task.isCancelled,
+                  Self.isValidDownloadedAudio(at: stagedAudio, expectedDuration: expectedDuration),
+                  let sourceData = remoteURL.absoluteString.data(using: .utf8)
+            else { return false }
+            try sourceData.write(to: stagedSource, options: [.atomic])
+
+            return try taskRegistry.performIfActive(songID: song.id, token: token) {
+                try? fm.removeItem(at: songFiles.audio)
+                try? fm.removeItem(at: songFiles.source)
+                try fm.moveItem(at: stagedAudio, to: songFiles.audio)
+                try fm.moveItem(at: stagedSource, to: songFiles.source)
+                return true
+            } ?? false
+        } catch {
+            DebugLogger.log(
+                "Playback cache promotion failed for \(song.id): \(error.localizedDescription)",
+                category: .cache
+            )
+            return false
+        }
+    }
+
+    private func finishCachePromotion(
+        song: Song,
+        remoteURL: URL,
+        token: UUID,
+        promoted: Bool
+    ) {
+        cachePromotionTasks.removeValue(forKey: song.id)
+        if promoted {
+            DebugLogger.log("Download promoted from playback cache: \(song.id)", category: .cache)
+            finishDownload(songID: song.id, song: song, moved: true, token: token)
+            return
+        }
+
+        let isCurrentTask = taskRegistry.performIfActive(songID: song.id, token: token) { true } ?? false
+        guard isCurrentTask, inProgress.contains(song.id) else {
+            startQueuedDownloadsIfPossible()
+            logDownloadQueueCompletionIfNeeded()
+            return
+        }
+        startNetworkDownload(song: song, remoteURL: remoteURL, token: token)
+    }
+
+    private func startNetworkDownload(song: Song, remoteURL: URL, token: UUID) {
+        let songID = song.id
+        let songFiles = files(for: songID)
+        let taskRegistry = taskRegistry
         DebugLogger.log(
             "Download started: \(songID) (active=\(tasks.count + 1), queued=\(queuedDownloadOrder.count))",
             category: .network
         )
-        let task = downloadSession.downloadTask(with: remote) { [weak self] tempURL, response, error in
+        let task = downloadSession.downloadTask(with: remoteURL) { [weak self] tempURL, response, error in
             var moved = false
             let expectedBytes = response?.expectedContentLength ?? NSURLSessionTransferSizeUnknown
             let downloadedBytes = tempURL.map { Self.downloadedByteCount(at: $0) } ?? 0
@@ -331,7 +433,7 @@ final class DownloadManager: ObservableObject {
                         try? FileManager.default.removeItem(at: songFiles.source)
                         FileManager.default.createFile(
                             atPath: songFiles.source.path,
-                            contents: remote.absoluteString.data(using: .utf8)
+                            contents: remoteURL.absoluteString.data(using: .utf8)
                         )
                         return true
                     } ?? false
@@ -365,7 +467,7 @@ final class DownloadManager: ObservableObject {
                 self?.finishDownload(songID: songID, song: song, moved: moved, token: token)
             }
         }
-        tasks[song.id] = task
+        tasks[songID] = task
         task.resume()
     }
 
@@ -385,6 +487,7 @@ final class DownloadManager: ObservableObject {
             taskRegistry.cancel(songID: songID)
         }
         tasks.removeValue(forKey: songID)
+        cachePromotionTasks.removeValue(forKey: songID)
         let wasInProgress = inProgress.contains(songID)
         guard wasInProgress else {
             startQueuedDownloadsIfPossible()
@@ -423,6 +526,8 @@ final class DownloadManager: ObservableObject {
 
     private func cancelWork(songID: String) {
         taskRegistry.cancel(songID: songID)
+        cachePromotionTasks[songID]?.cancel()
+        cachePromotionTasks.removeValue(forKey: songID)
         tasks[songID]?.cancel()
         tasks.removeValue(forKey: songID)
         queuedDownloads.removeValue(forKey: songID)
@@ -546,7 +651,11 @@ final class DownloadManager: ObservableObject {
         for task in tasks.values {
             task.cancel()
         }
+        for task in cachePromotionTasks.values {
+            task.cancel()
+        }
         tasks.removeAll()
+        cachePromotionTasks.removeAll()
         queuedDownloads.removeAll()
         queuedDownloadOrder.removeAll()
         isLoggingDownloadQueue = false
@@ -590,7 +699,11 @@ final class DownloadManager: ObservableObject {
     }
 
     private func logDownloadQueueCompletionIfNeeded() {
-        guard isLoggingDownloadQueue, tasks.isEmpty, queuedDownloadOrder.isEmpty else { return }
+        guard isLoggingDownloadQueue,
+              tasks.isEmpty,
+              cachePromotionTasks.isEmpty,
+              queuedDownloadOrder.isEmpty
+        else { return }
         DebugLogger.log(
             "Download queue complete: completed=\(completedInCurrentQueue), failed=\(failedInCurrentQueue)",
             category: .network

--- a/Twinskaraoke/Services/User/AuthManager.swift
+++ b/Twinskaraoke/Services/User/AuthManager.swift
@@ -5,7 +5,22 @@ import Foundation
 import Security
 
 @MainActor
-final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresentationContextProviding {
+private final class WebAuthenticationPresentationContextProvider:
+    NSObject, ASWebAuthenticationPresentationContextProviding
+{
+    private let anchor: ASPresentationAnchor
+
+    init(anchor: ASPresentationAnchor) {
+        self.anchor = anchor
+    }
+
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        anchor
+    }
+}
+
+@MainActor
+final class AuthManager: NSObject, ObservableObject {
     @Published private(set) var isLoggedIn = false
     @Published private(set) var currentUsername: String?
     @Published private(set) var currentUserId: String?
@@ -15,7 +30,7 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
     private(set) var authToken: String?
     private let defaults = UserDefaults.standard
     private var webAuthenticationSession: ASWebAuthenticationSession?
-    private var webAuthenticationAnchor: ASPresentationAnchor?
+    private var webAuthenticationContextProvider: WebAuthenticationPresentationContextProvider?
 
     private enum K {
         static let userId = "nk.userId"
@@ -166,7 +181,7 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
                 ) { [weak self] url, error in
                     Task { @MainActor [weak self] in
                         self?.webAuthenticationSession = nil
-                        self?.webAuthenticationAnchor = nil
+                        self?.webAuthenticationContextProvider = nil
                     }
                     if let error {
                         cont.resume(throwing: Self.mappedWebAuthenticationError(error))
@@ -178,13 +193,16 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
                     }
                     cont.resume(returning: url)
                 }
-                session.presentationContextProvider = self
+                let contextProvider = WebAuthenticationPresentationContextProvider(
+                    anchor: presentationAnchor
+                )
+                session.presentationContextProvider = contextProvider
                 session.prefersEphemeralWebBrowserSession = true
-                webAuthenticationAnchor = presentationAnchor
+                webAuthenticationContextProvider = contextProvider
                 webAuthenticationSession = session
                 guard session.start() else {
                     webAuthenticationSession = nil
-                    webAuthenticationAnchor = nil
+                    webAuthenticationContextProvider = nil
                     cont.resume(throwing: AuthError.invalidCallback)
                     return
                 }
@@ -205,7 +223,7 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
             )
         } catch {
             webAuthenticationSession = nil
-            webAuthenticationAnchor = nil
+            webAuthenticationContextProvider = nil
             isLoading = false
             if case AuthError.cancelled = error { return }
             errorMessage = friendlyError(error)
@@ -410,19 +428,6 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
             }
         }
         return error.localizedDescription
-    }
-
-    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        if let webAuthenticationAnchor {
-            return webAuthenticationAnchor
-        }
-        if let current = activePresentationAnchor() {
-            return current
-        }
-        // The sign-in path verifies and retains an anchor before starting the
-        // authentication session, so this is only reachable for a protocol
-        // call made outside that lifecycle.
-        preconditionFailure("presentationAnchor requested with no connected window scene")
     }
 
     private func activePresentationAnchor() -> ASPresentationAnchor? {

--- a/Twinskaraoke/Services/User/AuthManager.swift
+++ b/Twinskaraoke/Services/User/AuthManager.swift
@@ -15,6 +15,7 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
     private(set) var authToken: String?
     private let defaults = UserDefaults.standard
     private var webAuthenticationSession: ASWebAuthenticationSession?
+    private var webAuthenticationAnchor: ASPresentationAnchor?
 
     private enum K {
         static let userId = "nk.userId"
@@ -141,6 +142,9 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
         isLoading = true
         errorMessage = nil
         do {
+            guard let presentationAnchor = activePresentationAnchor() else {
+                throw AuthError.invalidCallback
+            }
             let verifier = makeVerifier()
             let challenge = makeChallenge(verifier)
             let state = makeVerifier()
@@ -162,6 +166,7 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
                 ) { [weak self] url, error in
                     Task { @MainActor [weak self] in
                         self?.webAuthenticationSession = nil
+                        self?.webAuthenticationAnchor = nil
                     }
                     if let error {
                         cont.resume(throwing: Self.mappedWebAuthenticationError(error))
@@ -175,8 +180,14 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
                 }
                 session.presentationContextProvider = self
                 session.prefersEphemeralWebBrowserSession = true
+                webAuthenticationAnchor = presentationAnchor
                 webAuthenticationSession = session
-                session.start()
+                guard session.start() else {
+                    webAuthenticationSession = nil
+                    webAuthenticationAnchor = nil
+                    cont.resume(throwing: AuthError.invalidCallback)
+                    return
+                }
             }
             guard
                 let cbComps = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
@@ -193,6 +204,8 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
                 avatar: profile.avatar
             )
         } catch {
+            webAuthenticationSession = nil
+            webAuthenticationAnchor = nil
             isLoading = false
             if case AuthError.cancelled = error { return }
             errorMessage = friendlyError(error)
@@ -400,16 +413,26 @@ final class AuthManager: NSObject, ObservableObject, ASWebAuthenticationPresenta
     }
 
     func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if let webAuthenticationAnchor {
+            return webAuthenticationAnchor
+        }
+        if let current = activePresentationAnchor() {
+            return current
+        }
+        // The sign-in path verifies and retains an anchor before starting the
+        // authentication session, so this is only reachable for a protocol
+        // call made outside that lifecycle.
+        preconditionFailure("presentationAnchor requested with no connected window scene")
+    }
+
+    private func activePresentationAnchor() -> ASPresentationAnchor? {
         let scenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
         let windows = scenes.flatMap(\.windows)
         if let window = windows.first(where: \.isKeyWindow) ?? windows.first {
             return window
         }
-        guard let scene = scenes.first else {
-            // Auth UI is only requested while a scene is connected.
-            preconditionFailure("presentationAnchor requested with no connected window scene")
-        }
+        guard let scene = scenes.first else { return nil }
         return ASPresentationAnchor(windowScene: scene)
     }
 

--- a/TwinskaraokeShared/Services/NetworkRetry.swift
+++ b/TwinskaraokeShared/Services/NetworkRetry.swift
@@ -10,9 +10,13 @@ nonisolated enum NetworkRetry {
     var lastError: Error?
 
     for attempt in 0...maxRetries {
+      try Task.checkCancellation()
       do {
         return try await operation()
+      } catch is CancellationError {
+        throw CancellationError()
       } catch {
+        try Task.checkCancellation()
         lastError = error
 
         guard attempt < maxRetries else {
@@ -20,7 +24,7 @@ nonisolated enum NetworkRetry {
         }
 
         let delay = baseDelay * pow(2.0, Double(attempt))
-        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
       }
     }
 
@@ -34,9 +38,13 @@ nonisolated enum NetworkRetry {
     var lastError: Error?
 
     for attempt in 0...maxRetries {
+      try Task.checkCancellation()
       do {
         return try await operation()
+      } catch is CancellationError {
+        throw CancellationError()
       } catch {
+        try Task.checkCancellation()
         lastError = error
 
         guard shouldRetry(error) else {
@@ -48,7 +56,7 @@ nonisolated enum NetworkRetry {
         }
 
         let delay = baseDelay * pow(2.0, Double(attempt))
-        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
       }
     }
 

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -108,4 +108,37 @@ struct DownloadManagerTests {
         let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
         #expect(attributes[.modificationDate] as? Date == originalDate)
     }
+
+    @Test("Startup cleanup removes only stale promotion staging files")
+    func startupCleanupRemovesStalePromotionFiles() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let stale = directory.appendingPathComponent("main.mp3.promoting-stale")
+        let current = directory.appendingPathComponent("main.source.promoting-current")
+        let download = directory.appendingPathComponent("main.mp3")
+        for file in [stale, current, download] {
+            #expect(FileManager.default.createFile(atPath: file.path, contents: Data([0])))
+        }
+
+        let cutoff = Date()
+        try FileManager.default.setAttributes(
+            [.modificationDate: cutoff.addingTimeInterval(-1)],
+            ofItemAtPath: stale.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: cutoff.addingTimeInterval(1)],
+            ofItemAtPath: current.path
+        )
+
+        DownloadManager.removePromotionStagingFiles(in: directory, createdBefore: cutoff)
+
+        #expect(!FileManager.default.fileExists(atPath: stale.path))
+        #expect(FileManager.default.fileExists(atPath: current.path))
+        #expect(FileManager.default.fileExists(atPath: download.path))
+    }
 }

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -84,4 +84,28 @@ struct DownloadManagerTests {
             )
         )
     }
+
+    @Test("Audio cache access does not mutate persistent download files")
+    func cacheTouchLeavesExternalFilesUnchanged() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("main.mp3")
+        #expect(FileManager.default.createFile(atPath: fileURL.path, contents: Data([0])))
+
+        let originalDate = Date(timeIntervalSince1970: 946_684_800)
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate],
+            ofItemAtPath: fileURL.path
+        )
+
+        AudioCacheStore.touch(fileURL)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        #expect(attributes[.modificationDate] as? Date == originalDate)
+    }
 }

--- a/TwinskaraokeTests/NetworkRetryTests.swift
+++ b/TwinskaraokeTests/NetworkRetryTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Network retry cancellation")
+struct NetworkRetryTests {
+    @Test("A cancelled retry exits with cancellation instead of retrying")
+    func cancellationStopsRetries() async {
+        let task = Task<Int, Error> {
+            try await NetworkRetry.execute {
+                throw URLError(.timedOut)
+            }
+        }
+
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected the cancelled retry task to throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+    }
+
+    @Test("Conditional retries do not swallow cancellation")
+    func conditionalCancellationStopsRetries() async {
+        let task = Task<Int, Error> {
+            try await NetworkRetry.execute(shouldRetry: { _ in true }) {
+                throw URLError(.networkConnectionLost)
+            }
+        }
+
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected the cancelled conditional retry task to throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+    }
+}

--- a/TwinskaraokeTests/TransitionCoordinatorTests.swift
+++ b/TwinskaraokeTests/TransitionCoordinatorTests.swift
@@ -27,6 +27,17 @@ struct TransitionCoordinatorTests {
         #expect(isEqualPower(result.style))
     }
 
+    @Test("Auto Mix rejects invalid cached tempos")
+    func autoMixFadeWithInvalidBPM() {
+        let zero = TransitionCoordinator.computeFade(outBPM: 0, inBPM: 120)
+        let nonFinite = TransitionCoordinator.computeFade(outBPM: .infinity, inBPM: 120)
+
+        #expect(zero.duration == 6.0)
+        #expect(isEqualPower(zero.style))
+        #expect(nonFinite.duration == 6.0)
+        #expect(isEqualPower(nonFinite.style))
+    }
+
     @Test("Harmonic BPM comparison treats double-time tempos as compatible")
     func harmonicBPMDifferenceUsesDoubleTime() {
         #expect(TransitionCoordinator.harmonicBPMDifference(90, 180) == 0)

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -622,29 +622,56 @@ class AudioManager: ObservableObject {
 
     private func setupRemoteCommands() {
         let cc = MPRemoteCommandCenter.shared()
+        func performOnMain(
+            _ action: @escaping @MainActor () -> MPRemoteCommandHandlerStatus
+        ) -> MPRemoteCommandHandlerStatus {
+            if Thread.isMainThread {
+                return MainActor.assumeIsolated { action() }
+            }
+            var status: MPRemoteCommandHandlerStatus = .commandFailed
+            DispatchQueue.main.sync {
+                status = MainActor.assumeIsolated { action() }
+            }
+            return status
+        }
+
         let playTarget = cc.playCommand.addTarget { [weak self] _ in
-            guard let self, !self.playbackRequested else { return .commandFailed }
-            return resumePlayback() ? .success : .commandFailed
+            guard let self else { return .commandFailed }
+            return performOnMain {
+                guard !self.playbackRequested else { return .commandFailed }
+                return self.resumePlayback() ? .success : .commandFailed
+            }
         }
         remoteCommandTargets.append((cc.playCommand, playTarget))
         let pauseTarget = cc.pauseCommand.addTarget { [weak self] _ in
-            guard let self, playbackRequested else { return .commandFailed }
-            return pausePlayback() ? .success : .commandFailed
+            guard let self else { return .commandFailed }
+            return performOnMain {
+                guard self.playbackRequested else { return .commandFailed }
+                return self.pausePlayback() ? .success : .commandFailed
+            }
         }
         remoteCommandTargets.append((cc.pauseCommand, pauseTarget))
         let toggleTarget = cc.togglePlayPauseCommand.addTarget { [weak self] _ in
             guard let self else { return .commandFailed }
-            return togglePlayPause() ? .success : .commandFailed
+            return performOnMain {
+                self.togglePlayPause() ? .success : .commandFailed
+            }
         }
         remoteCommandTargets.append((cc.togglePlayPauseCommand, toggleTarget))
         let nextTarget = cc.nextTrackCommand.addTarget { [weak self] _ in
-            self?.playNext()
-            return .success
+            guard let self else { return .commandFailed }
+            return performOnMain {
+                self.playNext()
+                return .success
+            }
         }
         remoteCommandTargets.append((cc.nextTrackCommand, nextTarget))
         let previousTarget = cc.previousTrackCommand.addTarget { [weak self] _ in
-            self?.playPrevious()
-            return .success
+            guard let self else { return .commandFailed }
+            return performOnMain {
+                self.playPrevious()
+                return .success
+            }
         }
         remoteCommandTargets.append((cc.previousTrackCommand, previousTarget))
     }

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -34,6 +34,7 @@ class AudioManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var downloadTask: URLSessionDownloadTask?
     private var downloadToken: UUID?
+    private var remoteCommandTargets: [(command: MPRemoteCommand, target: Any)] = []
     private var recoveringFromBrokenCache: Set<String> = []
     private var playbackRequested = false
     private var shouldResumeAfterInterruption = false
@@ -507,6 +508,10 @@ class AudioManager: ObservableObject {
                   playbackRequested || isLoading
             else { return }
             if valid {
+                try? FileManager.default.setAttributes(
+                    [.modificationDate: Date()],
+                    ofItemAtPath: cacheURL.path
+                )
                 setupPlayer(with: cacheURL)
                 return
             }
@@ -617,26 +622,31 @@ class AudioManager: ObservableObject {
 
     private func setupRemoteCommands() {
         let cc = MPRemoteCommandCenter.shared()
-        cc.playCommand.addTarget { [weak self] _ in
+        let playTarget = cc.playCommand.addTarget { [weak self] _ in
             guard let self, !self.playbackRequested else { return .commandFailed }
             return resumePlayback() ? .success : .commandFailed
         }
-        cc.pauseCommand.addTarget { [weak self] _ in
+        remoteCommandTargets.append((cc.playCommand, playTarget))
+        let pauseTarget = cc.pauseCommand.addTarget { [weak self] _ in
             guard let self, playbackRequested else { return .commandFailed }
             return pausePlayback() ? .success : .commandFailed
         }
-        cc.togglePlayPauseCommand.addTarget { [weak self] _ in
+        remoteCommandTargets.append((cc.pauseCommand, pauseTarget))
+        let toggleTarget = cc.togglePlayPauseCommand.addTarget { [weak self] _ in
             guard let self else { return .commandFailed }
             return togglePlayPause() ? .success : .commandFailed
         }
-        cc.nextTrackCommand.addTarget { [weak self] _ in
+        remoteCommandTargets.append((cc.togglePlayPauseCommand, toggleTarget))
+        let nextTarget = cc.nextTrackCommand.addTarget { [weak self] _ in
             self?.playNext()
             return .success
         }
-        cc.previousTrackCommand.addTarget { [weak self] _ in
+        remoteCommandTargets.append((cc.nextTrackCommand, nextTarget))
+        let previousTarget = cc.previousTrackCommand.addTarget { [weak self] _ in
             self?.playPrevious()
             return .success
         }
+        remoteCommandTargets.append((cc.previousTrackCommand, previousTarget))
     }
 
     private func setupInterruptionHandler() {
@@ -688,6 +698,9 @@ class AudioManager: ObservableObject {
         }
         if let observer = endTimeObserver {
             NotificationCenter.default.removeObserver(observer)
+        }
+        for target in remoteCommandTargets {
+            target.command.removeTarget(target.target)
         }
         player?.pause()
     }


### PR DESCRIPTION
## Summary

- Harden asynchronous loading and cancellation across home, library, artist, and gallery models so stale work cannot overwrite newer state.
- Improve playback and Auto Mix reliability with safer BPM handling, stronger engine cleanup, coalesced remote-command diagnostics, and robust transition state.
- Fix download and cache correctness, including persistent-download timestamp protection, cache eviction accounting, and promotion of validated playback audio into offline downloads without another network transfer.
- Reduce UI and background work through stable playlist action snapshots, bounded artwork failure tracking, serialized image saving, and tighter watchOS audio cleanup.
- Add regression coverage for cancellation, invalid transition tempos, download validation, and persistent-file cache isolation.

## Why

Several independent lifecycle and concurrency paths could retain obsolete work, publish stale results, or perform avoidable disk and network operations. The most visible download issue came from generic cache access updating files in `Documents/Downloads`; that changed the modification date used by the fast validation cache and could make a valid offline song fall back to remote playback. A fully cached streamed song was also downloaded a second time when the user requested offline storage.

## Impact

- Downloaded songs remain on the local playback path across repeated plays.
- Previously streamed songs can become persistent downloads without redundant network traffic.
- Rapid navigation, request cancellation, track switching, and Auto Mix transitions perform less obsolete work and recover more predictably.
- Cache maintenance and artwork-heavy screens do less main-thread and repeated work.
- watchOS playback state and observers are cleaned up more consistently.

## Validation

- 39 iOS unit tests passed across 6 suites.
- 12 iOS UI tests passed.
- 5 watchOS tests passed.
- Xcode static analysis passed.
- Optimized Release simulator build succeeded.
- On-device debug runs completed 69-song download queues with zero failures, verified local replay, playback-cache promotion, remote controls, rapid skipping, and Auto Mix crossfade handoff.
- `git diff --check` passed.

## Summary by Sourcery

Harden media download, playback, networking, and UI models against stale work, cancellation, and cache edge cases while adding safeguards and tests for audio caching, retries, and transitions.

New Features:
- Allow promoting fully cached playback audio into persistent downloads without re-downloading from the network.

Bug Fixes:
- Prevent audio cache touch operations from mutating persistent download timestamps outside the cache directory.
- Avoid stale or cancelled home, artist, library, and gallery loads from overwriting newer state or showing incorrect errors.
- Ensure network retry helpers respect task cancellation instead of continuing to delay and retry.
- Reject invalid or non-finite BPM values when computing Auto Mix fades to avoid unstable transitions.
- Stabilize watchOS playback by validating predownloaded audio duration and tracking remote command handlers for proper cleanup.
- Avoid duplicate videos in the gallery and tighten pagination so load-more stops when no new items are added.
- Ensure image saving requests to the photo library are serialized so multiple saves complete reliably.
- Stabilize authentication by validating availability of a presentation anchor, tracking it through the web auth session, and resetting state on failure.

Enhancements:
- Extend download management to account for cache-promotion work as active downloads and respect cancellation during teardown.
- Improve cache eviction accounting and logging by only decrementing size when deletions succeed and reporting failures.
- Snapshot playlist download/save state up front so menus render consistently without depending on live store observation.
- Harden BPM detection and onset analysis to be cancellation-aware and more robust to edge-case audio durations.
- Coalesce remote command diagnostics logging to emit only when the effective state changes.
- Make artwork failure backoff bounded and self-cleaning to avoid unbounded growth of tracked URLs.

Tests:
- Add regression tests to ensure audio cache touch does not mutate external download files.
- Add tests verifying NetworkRetry surfaces CancellationError immediately instead of swallowing cancellation.
- Add tests covering Auto Mix fade behavior with invalid BPM inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and refresh behavior to prevent outdated results from replacing newer content.
  * Prevented duplicate videos and improved playlist download and cache handling.
  * Improved audio validation, transitions with invalid tempos, and playback cleanup.
  * Equalizer animations now reflect actual playback state.
  * Improved Discord sign-in reliability and presentation handling.
  * Image saves are now queued instead of replacing pending requests.
  * Canceled network and audio operations now stop more reliably.

* **Chores**
  * Updated Watch test targets for newer watchOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->