### PR TITLE
Update popup dependencies

### DIFF
--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -1137,7 +1137,7 @@
 			repositoryURL = "https://github.com/LeoNatan/LNPopupUI";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.4;
+				minimumVersion = 3.1.0;
 			};
 		};
 		D0C385962FB0BD870055284E /* XCRemoteSwiftPackageReference "swift-spleeter" */ = {

--- a/Twinskaraoke.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Twinskaraoke.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LeoNatan/LNPopupController.git",
       "state" : {
-        "revision" : "fd9d8298c811875b6a6039000ed2e0c8e9edfc0e",
-        "version" : "4.4.11"
+        "revision" : "c13a392bf6f058d80a35b93805a2eaf173e9956e",
+        "version" : "4.5.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LeoNatan/LNPopupUI",
       "state" : {
-        "revision" : "ee986ab35041c57df12ffc2eb1f25e30899edbf0",
-        "version" : "3.0.4"
+        "revision" : "619c5ccae6d844cfa02acf01a030b45cfa27ddfb",
+        "version" : "3.1.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- update LNPopupUI from 3.0.4 to 3.1.0
- update the resolved LNPopupController dependency from 4.4.11 to 4.5.0
- retain the already-current Swift and documentation dependencies

## Validation

- Release build for the generic iOS Simulator
- 40 unit tests across 6 suites
- focused full-screen player interface test
- VitePress documentation build
- npm audit: 0 vulnerabilities

## Summary by Sourcery

Update popup-related Swift package dependencies to newer minor versions while keeping other Swift and documentation dependencies unchanged.

Build:
- Bump LNPopupUI package to version 3.1.0.
- Update resolved LNPopupController dependency to version 4.5.0.