### PR TITLE
Update GitHub workflow actions

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Force Latest Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -47,7 +47,7 @@ jobs:
           mkdir -p output && mv Twinskaraoke-iPhone-Sideload.ipa output/
 
       - name: Upload iPhone IPA
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Twinskaraoke-iPhone
           path: output/Twinskaraoke-iPhone-Sideload.ipa
@@ -73,7 +73,7 @@ jobs:
           mkdir -p output_watch && mv Twinskaraoke-Watch.ipa output_watch/
 
       - name: Upload Watch IPA
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Twinskaraoke-Watch
           path: output_watch/Twinskaraoke-Watch.ipa

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
       # - uses: pnpm/action-setup@v4 # Uncomment this block if you're using pnpm
@@ -37,18 +37,18 @@ jobs:
       #     version: 9 # Not needed if you've set "packageManager" in package.json
       # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm # or pnpm / yarn
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Install dependencies
         run: npm ci # or pnpm install / yarn install / bun install
       - name: Build with VitePress
         run: npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/schemes.yaml
+++ b/.github/workflows/schemes.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: List Xcode Project Information
         run: |


### PR DESCRIPTION
## Summary

- update `actions/checkout` to v7 across all active workflows
- update `actions/upload-artifact` to v7 for both IPA artifacts
- update the documentation workflow to `actions/setup-node` v7, `actions/configure-pages` v6, `actions/upload-pages-artifact` v5, and `actions/deploy-pages` v5
- retain `setup-xcode@v1` and `release-action@v1`, which already track their current major releases

## Why

This keeps the repository workflows on the current supported action runtimes and dependency stacks without changing application code or workflow behavior.

## Validation

- all four edited workflow files parse as valid YAML
- `actionlint` v1.7.12 passes with no findings
- `git diff --check` passes
- each updated major was verified against its current upstream release

## Summary by Sourcery

Update GitHub Actions workflows to use the latest supported versions of core actions without altering workflow behavior.

Build:
- Bump actions/checkout to v7 across all active workflows.
- Update actions/upload-artifact to v7 for iPhone and Watch IPA uploads.
- Upgrade documentation deployment workflow to newer major versions of setup-node, configure-pages, upload-pages-artifact, and deploy-pages.