### PR TITLE
Reduce profiled UI task and artwork churn

### DIFF
--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -42,7 +42,7 @@ struct RemoteArtworkImage: View {
             if !transparentBackground {
                 MusicArtworkPlaceholder(cornerRadius: cornerRadius)
             }
-            if let lowResURL, !fullLoaded {
+            if let lowResURL, !fullLoaded, shouldUseLowResolutionPreview {
                 WebImage(
                     url: lowResURL,
                     options: [.fromCacheOnly],
@@ -93,15 +93,12 @@ struct RemoteArtworkImage: View {
 
     private func markRendered(_ loadedURL: URL) {
         guard url == loadedURL, renderedFullURL != loadedURL || !fullLoaded || loadFailed else { return }
-        Task { @MainActor in
-            guard url == loadedURL, renderedFullURL != loadedURL || !fullLoaded || loadFailed else { return }
-            withOptionalAnimation(loadAnimation) {
-                renderedFullURL = loadedURL
-                fullLoaded = true
-                loadFailed = false
-            }
-            ArtworkFailureBackoff.shared.clear(loadedURL)
+        withOptionalAnimation(loadAnimation) {
+            renderedFullURL = loadedURL
+            fullLoaded = true
+            loadFailed = false
         }
+        ArtworkFailureBackoff.shared.clear(loadedURL)
     }
 
     private func markFinishedAfterFailure(for failedURL: URL, error: Error) {
@@ -129,6 +126,11 @@ struct RemoteArtworkImage: View {
 
     private var shouldAnimateLoad: Bool {
         guard !ScrollPerformanceState.shared.isScrolling else { return false }
+        guard let fixedDisplaySize else { return true }
+        return max(fixedDisplaySize.width, fixedDisplaySize.height) > 96
+    }
+
+    private var shouldUseLowResolutionPreview: Bool {
         guard let fixedDisplaySize else { return true }
         return max(fixedDisplaySize.width, fixedDisplaySize.height) > 96
     }

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -42,7 +42,7 @@ struct RemoteArtworkImage: View {
             if !transparentBackground {
                 MusicArtworkPlaceholder(cornerRadius: cornerRadius)
             }
-            if let lowResURL, !fullLoaded, shouldUseLowResolutionPreview {
+            if let lowResURL, !fullLoaded, shouldPreferProgressiveArtwork {
                 WebImage(
                     url: lowResURL,
                     options: [.fromCacheOnly],
@@ -91,6 +91,7 @@ struct RemoteArtworkImage: View {
         }
     }
 
+    @MainActor
     private func markRendered(_ loadedURL: URL) {
         guard url == loadedURL, renderedFullURL != loadedURL || !fullLoaded || loadFailed else { return }
         withOptionalAnimation(loadAnimation) {
@@ -125,12 +126,10 @@ struct RemoteArtworkImage: View {
     }
 
     private var shouldAnimateLoad: Bool {
-        guard !ScrollPerformanceState.shared.isScrolling else { return false }
-        guard let fixedDisplaySize else { return true }
-        return max(fixedDisplaySize.width, fixedDisplaySize.height) > 96
+        !ScrollPerformanceState.shared.isScrolling && shouldPreferProgressiveArtwork
     }
 
-    private var shouldUseLowResolutionPreview: Bool {
+    private var shouldPreferProgressiveArtwork: Bool {
         guard let fixedDisplaySize else { return true }
         return max(fixedDisplaySize.width, fixedDisplaySize.height) > 96
     }

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -10,6 +10,7 @@ private final class SongDownloadRowState: ObservableObject {
         let manager = DownloadManager.shared
         status = manager.status(for: songID)
         cancellable = manager.statusPublisher(for: songID)
+            .dropFirst()
             .sink { [weak self] status in
                 self?.status = status
             }

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -9,9 +9,10 @@ private final class SongDownloadRowState: ObservableObject {
     init(songID: String) {
         let manager = DownloadManager.shared
         status = manager.status(for: songID)
-        cancellable = manager.observeStatus(for: songID) { [weak self] status in
-            self?.status = status
-        }
+        cancellable = manager.statusPublisher(for: songID)
+            .sink { [weak self] status in
+                self?.status = status
+            }
     }
 }
 

--- a/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
+++ b/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
@@ -8,14 +8,14 @@ final class ScrollPerformanceState: ObservableObject {
     @Published private(set) var isScrolling = false
 
     private var activeScrollIDs = Set<UUID>()
-    private var scrollEndTask: Task<Void, Never>?
+    private var scrollEndWorkItem: DispatchWorkItem?
+    private var scrollEndGeneration: UInt = 0
 
     private init() {}
 
     func update(id: UUID, isScrolling scrolling: Bool) {
         if scrolling {
-            scrollEndTask?.cancel()
-            scrollEndTask = nil
+            cancelPendingScrollEnd()
             activeScrollIDs.insert(id)
         } else {
             activeScrollIDs.remove(id)
@@ -24,18 +24,28 @@ final class ScrollPerformanceState: ObservableObject {
     }
 
     private func scheduleScrollStateUpdate() {
-        scrollEndTask?.cancel()
+        cancelPendingScrollEnd()
         if !activeScrollIDs.isEmpty {
             setScrolling(true)
             return
         }
-        scrollEndTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 140_000_000)
-            guard !Task.isCancelled else { return }
-            await MainActor.run {
-                self?.setScrolling(false)
+
+        let generation = scrollEndGeneration
+        let workItem = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, self.scrollEndGeneration == generation else { return }
+                self.scrollEndWorkItem = nil
+                self.setScrolling(false)
             }
         }
+        scrollEndWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14, execute: workItem)
+    }
+
+    private func cancelPendingScrollEnd() {
+        scrollEndGeneration &+= 1
+        scrollEndWorkItem?.cancel()
+        scrollEndWorkItem = nil
     }
 
     private func setScrolling(_ scrolling: Bool) {

--- a/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
+++ b/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
@@ -31,12 +31,10 @@ final class ScrollPerformanceState: ObservableObject {
         }
 
         let generation = scrollEndGeneration
-        let workItem = DispatchWorkItem { [weak self] in
-            Task { @MainActor [weak self] in
-                guard let self, self.scrollEndGeneration == generation else { return }
-                self.scrollEndWorkItem = nil
-                self.setScrolling(false)
-            }
+        let workItem = DispatchWorkItem { @MainActor [weak self] in
+            guard let self, self.scrollEndGeneration == generation else { return }
+            self.scrollEndWorkItem = nil
+            self.setScrolling(false)
         }
         scrollEndWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.14, execute: workItem)

--- a/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
+++ b/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
@@ -32,7 +32,7 @@ final class ScrollPerformanceState: ObservableObject {
 
         let generation = scrollEndGeneration
         let workItem = DispatchWorkItem { [weak self] in
-            MainActor.assumeIsolated {
+            Task { @MainActor [weak self] in
                 guard let self, self.scrollEndGeneration == generation else { return }
                 self.scrollEndWorkItem = nil
                 self.setScrolling(false)

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -47,6 +47,17 @@ private nonisolated final class DownloadTaskRegistry: @unchecked Sendable {
 struct SongDownloadStatus: Equatable, Sendable {
     let isDownloaded: Bool
     let isDownloading: Bool
+
+    static func make(
+        downloadedIDs: Set<String>,
+        inProgress: Set<String>,
+        songID: String
+    ) -> SongDownloadStatus {
+        SongDownloadStatus(
+            isDownloaded: downloadedIDs.contains(songID),
+            isDownloading: inProgress.contains(songID)
+        )
+    }
 }
 
 @MainActor
@@ -92,7 +103,6 @@ final class DownloadManager: ObservableObject {
     private var pendingWiFiRepairs: [String: Song] = [:]
     private var validDownloadCache: [String: ValidDownloadCacheEntry] = [:]
     private var downloadedMetadata: [String: Song] = [:]
-    private var statusObservers: [String: [UUID: (SongDownloadStatus) -> Void]] = [:]
     private var isWiFiAvailable = false
     private let taskRegistry = DownloadTaskRegistry()
     private let downloadSession: URLSession
@@ -208,28 +218,24 @@ final class DownloadManager: ObservableObject {
     }
 
     func status(for songID: String) -> SongDownloadStatus {
-        SongDownloadStatus(
-            isDownloaded: downloadedIDs.contains(songID),
-            isDownloading: inProgress.contains(songID)
+        SongDownloadStatus.make(
+            downloadedIDs: downloadedIDs,
+            inProgress: inProgress,
+            songID: songID
         )
     }
 
-    func observeStatus(
-        for songID: String,
-        _ observer: @escaping (SongDownloadStatus) -> Void
-    ) -> AnyCancellable {
-        let observerID = UUID()
-        statusObservers[songID, default: [:]][observerID] = observer
-        observer(status(for: songID))
-        return AnyCancellable { [weak self] in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                statusObservers[songID]?.removeValue(forKey: observerID)
-                if statusObservers[songID]?.isEmpty == true {
-                    statusObservers.removeValue(forKey: songID)
-                }
+    func statusPublisher(for songID: String) -> AnyPublisher<SongDownloadStatus, Never> {
+        $publishedState
+            .map { state in
+                SongDownloadStatus.make(
+                    downloadedIDs: state.downloadedIDs,
+                    inProgress: state.inProgress,
+                    songID: songID
+                )
             }
-        }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
     }
 
     private func updatePublishedState(_ update: (inout PublishedState) -> Void) {
@@ -237,20 +243,7 @@ final class DownloadManager: ObservableObject {
         var next = previous
         update(&next)
         guard next != previous else { return }
-        let changedSongIDs = previous.downloadedIDs.symmetricDifference(next.downloadedIDs)
-            .union(previous.inProgress.symmetricDifference(next.inProgress))
         publishedState = next
-        for songID in changedSongIDs {
-            let status = SongDownloadStatus(
-                isDownloaded: next.downloadedIDs.contains(songID),
-                isDownloading: next.inProgress.contains(songID)
-            )
-            if let observers = statusObservers[songID] {
-                for observer in observers.values {
-                    observer(status)
-                }
-            }
-        }
     }
 
     var hasActiveQueue: Bool {

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -85,6 +85,34 @@ struct DownloadManagerTests {
         )
     }
 
+    @Test("Download status reflects only the requested song")
+    func downloadStatusUsesRequestedSong() {
+        let downloadedIDs: Set<String> = ["downloaded"]
+        let inProgress: Set<String> = ["downloading"]
+
+        #expect(
+            SongDownloadStatus.make(
+                downloadedIDs: downloadedIDs,
+                inProgress: inProgress,
+                songID: "downloaded"
+            ) == SongDownloadStatus(isDownloaded: true, isDownloading: false)
+        )
+        #expect(
+            SongDownloadStatus.make(
+                downloadedIDs: downloadedIDs,
+                inProgress: inProgress,
+                songID: "downloading"
+            ) == SongDownloadStatus(isDownloaded: false, isDownloading: true)
+        )
+        #expect(
+            SongDownloadStatus.make(
+                downloadedIDs: downloadedIDs,
+                inProgress: inProgress,
+                songID: "other"
+            ) == SongDownloadStatus(isDownloaded: false, isDownloading: false)
+        )
+    }
+
     @Test("Audio cache access does not mutate persistent download files")
     func cacheTouchLeavesExternalFilesUnchanged() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(


### PR DESCRIPTION
## Summary

- complete artwork render state updates synchronously so duplicate callbacks do not create redundant concurrency work
- use a single image pipeline for compact fixed-size artwork while retaining progressive previews for larger artwork
- replace per-row download observer teardown work with deduplicated status publishers
- debounce scroll settling with one cancellable main-queue work item
- add regression coverage for per-song download status mapping

## Why

The device profile recorded 4,694 task creations during a 134-second session. Artwork render completion created 2,247 tasks, download-row observer teardown created 1,424, and scroll settling created another 152. These bursts overlapped the busiest navigation and scrolling periods. The image pipeline was also the largest identifiable app-origin source of weighted main-thread work.

The root causes were duplicate artwork lifecycle callbacks being deferred independently, one teardown task per disappearing row, a task-based scroll debounce, and two image pipelines for compact rows that do not benefit from progressive previews.

## Impact

- less concurrency bookkeeping during fast list navigation and scrolling
- fewer image manager and loading-state updates for compact rows
- synchronous subscription cancellation without retained row observers
- unchanged progressive artwork behavior for larger cards and detail views
- unchanged download, playback, and artwork failure-retry behavior

## Validation

- 42 unit tests passed
- 12 UI tests passed
- Debug static analysis passed
- optimized Release simulator build passed

## Summary by Sourcery

Reduce redundant UI work by centralizing per-song download status publishing, tightening scroll state debouncing, and simplifying artwork loading behavior.

New Features:
- Expose a Combine-based per-song download status publisher for song rows.

Enhancements:
- Derive song download status from shared published state to avoid per-row observer bookkeeping and teardown tasks.
- Gate low-resolution artwork previews on display size and make artwork render completion updates synchronous on the main thread.
- Replace Task-based scroll end debouncing with a single cancellable main-queue work item to reduce task churn.

Tests:
- Add a unit test to verify SongDownloadStatus mapping respects the requested song ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artwork loading behavior by avoiding unnecessary progressive images for smaller displays.
  - Made download status updates more consistent and responsive.
  - Improved scrolling performance and stability when scrolling ends.

- **Tests**
  - Added coverage to verify download statuses are correctly associated with the requested song.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->