### PR TITLE
Fix uploaded song playback

### DIFF
--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -50,6 +50,10 @@ class PlaylistDetailViewModel: ObservableObject {
                 )
             } catch {
                 guard !Task.isCancelled else { return }
+                DebugLogger.log(
+                    "Playlist \(playlistID) load failed: \(String(describing: error))",
+                    category: .network
+                )
                 self?.applyLoadedSongs(nil, playlistID: playlistID, requestFailed: true)
             }
         }

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -556,7 +556,12 @@ class AudioPlayerManager: ObservableObject {
                 )
                 AudioCacheStore.removeSongCache(for: song.id)
                 currentPlaybackURL = nil
-                play(song: song, context: [], resetTransitionVolume: true)
+                play(
+                    song: song,
+                    context: [],
+                    resetTransitionVolume: true,
+                    preserveCacheRecoveryState: true
+                )
                 return
             }
             setPlaybackState(
@@ -1198,11 +1203,18 @@ class AudioPlayerManager: ObservableObject {
     }
 
     func play(song: Song, context: [Song] = []) {
-        cacheRecoverySongID = nil
         play(song: song, context: context, resetTransitionVolume: true)
     }
 
-    private func play(song: Song, context: [Song] = [], resetTransitionVolume: Bool) {
+    private func play(
+        song: Song,
+        context: [Song] = [],
+        resetTransitionVolume: Bool,
+        preserveCacheRecoveryState: Bool = false
+    ) {
+        if !preserveCacheRecoveryState {
+            cacheRecoverySongID = nil
+        }
         DebugLogger.log("Play requested: \(song.title) (id: \(song.id))", category: .playback)
         let previousSongID = currentSong?.id
         let effectToResume = currentActiveEffect ?? deferredAIEffect
@@ -2202,8 +2214,11 @@ class AudioPlayerManager: ObservableObject {
             throw RemotePlaybackCacheError.invalidAudio
         }
 
-        AudioCacheStore.removeMainAudioFiles(for: songID)
-        try FileManager.default.moveItem(at: partialURL, to: finalURL)
+        try AudioCacheStore.commitMainAudioFile(
+            at: partialURL,
+            to: finalURL,
+            for: songID
+        )
         AudioCacheStore.writeMainSourceURL(remoteURL, for: songID)
         DebugLogger.log("Remote playback cache complete for \(songID)", category: .cache)
         return finalURL

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -347,6 +347,7 @@ class AudioPlayerManager: ObservableObject {
     private var streamPlaybackRequested = false
     private var remotePlaybackCacheTask: Task<Void, Never>?
     private var remotePlaybackCacheToken: UUID?
+    private var cacheRecoverySongID: String?
     private var lastKnownPlaybackTime: TimeInterval = 0
     private var pollTimer: Timer?
     private var streamFadeTimer: Timer?
@@ -534,13 +535,28 @@ class AudioPlayerManager: ObservableObject {
                let playbackURL = currentPlaybackURL,
                playbackURL.path.hasPrefix(AudioPlayerManager.audioCacheDir.path)
             {
+                guard cacheRecoverySongID != song.id else {
+                    DebugLogger.log(
+                        "Remote cache retry exhausted for \(song.id)",
+                        category: .playback
+                    )
+                    AudioCacheStore.removeSongCache(for: song.id)
+                    currentPlaybackURL = nil
+                    setPlaybackState(
+                        playing: false,
+                        buffering: false,
+                        reason: "avEngine.cacheRetryExhausted"
+                    )
+                    return
+                }
+                cacheRecoverySongID = song.id
                 DebugLogger.log(
                     "Removing broken cache and retrying from remote for \(song.id)",
                     category: .cache
                 )
                 AudioCacheStore.removeSongCache(for: song.id)
                 currentPlaybackURL = nil
-                play(song: song)
+                play(song: song, context: [], resetTransitionVolume: true)
                 return
             }
             setPlaybackState(
@@ -1182,6 +1198,7 @@ class AudioPlayerManager: ObservableObject {
     }
 
     func play(song: Song, context: [Song] = []) {
+        cacheRecoverySongID = nil
         play(song: song, context: context, resetTransitionVolume: true)
     }
 
@@ -2143,9 +2160,10 @@ class AudioPlayerManager: ObservableObject {
         }
 
         _ = AudioCacheStore.ensureSongDirectory(for: songID)
-        let songFiles = AudioCacheStore.files(for: songID)
+        let finalURL = AudioCacheStore.mainAudioURL(for: songID, sourceURL: remoteURL)
+        let partialURL = AudioCacheStore.mainPartialAudioURL(for: songID, sourceURL: remoteURL)
         DebugLogger.log("Remote playback cache start for \(songID)", category: .cache)
-        try? FileManager.default.removeItem(at: songFiles.mainPartial)
+        try? FileManager.default.removeItem(at: partialURL)
 
         let configuration = URLSessionConfiguration.ephemeral
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
@@ -2162,33 +2180,33 @@ class AudioPlayerManager: ObservableObject {
             throw RemotePlaybackCacheError.invalidResponse
         }
 
-        try? FileManager.default.removeItem(at: songFiles.mainPartial)
+        try? FileManager.default.removeItem(at: partialURL)
         do {
-            try FileManager.default.moveItem(at: temporaryURL, to: songFiles.mainPartial)
+            try FileManager.default.moveItem(at: temporaryURL, to: partialURL)
         } catch {
-            try FileManager.default.copyItem(at: temporaryURL, to: songFiles.mainPartial)
+            try FileManager.default.copyItem(at: temporaryURL, to: partialURL)
             try? FileManager.default.removeItem(at: temporaryURL)
         }
         try Task.checkCancellation()
 
-        guard AudioCacheStore.isPlayableAudioFile(at: songFiles.mainPartial) else {
-            try? FileManager.default.removeItem(at: songFiles.mainPartial)
+        guard AudioCacheStore.isPlayableAudioFile(at: partialURL) else {
+            try? FileManager.default.removeItem(at: partialURL)
             throw RemotePlaybackCacheError.invalidAudio
         }
-        let actualDuration = AudioCacheStore.audioDuration(at: songFiles.mainPartial)
+        let actualDuration = AudioCacheStore.audioDuration(at: partialURL)
         guard AudioCacheStore.durationAppearsComplete(
             actualDuration: actualDuration,
             expectedDuration: expectedDuration
         ) else {
-            try? FileManager.default.removeItem(at: songFiles.mainPartial)
+            try? FileManager.default.removeItem(at: partialURL)
             throw RemotePlaybackCacheError.invalidAudio
         }
 
-        try? FileManager.default.removeItem(at: songFiles.main)
-        try FileManager.default.moveItem(at: songFiles.mainPartial, to: songFiles.main)
+        AudioCacheStore.removeMainAudioFiles(for: songID)
+        try FileManager.default.moveItem(at: partialURL, to: finalURL)
         AudioCacheStore.writeMainSourceURL(remoteURL, for: songID)
         DebugLogger.log("Remote playback cache complete for \(songID)", category: .cache)
-        return songFiles.main
+        return finalURL
     }
 
     private enum RemotePlaybackCacheError: LocalizedError {

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -269,7 +269,11 @@ final class TransitionCoordinator {
 
     private func predownload(song: Song, from remoteURL: URL) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            let session = PredownloadSession(songID: song.id, expectedDuration: song.duration > 0 ? TimeInterval(song.duration) : nil)
+            let session = PredownloadSession(
+                songID: song.id,
+                expectedDuration: song.duration > 0 ? TimeInterval(song.duration) : nil,
+                remoteURL: remoteURL
+            )
             self.predownloadSession = session
             session.onCompletion = { [weak self] in
                 DebugLogger.log(
@@ -370,12 +374,11 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
     private var isCancelled = false
     var onCompletion: (() -> Void)?
 
-    init(songID: String, expectedDuration: TimeInterval?) {
+    init(songID: String, expectedDuration: TimeInterval?, remoteURL: URL) {
         self.songID = songID
         self.expectedDuration = expectedDuration
-        let songFiles = AudioCacheStore.files(for: songID)
-        finalURL = songFiles.main
-        partialURL = songFiles.mainPartial
+        finalURL = AudioCacheStore.mainAudioURL(for: songID, sourceURL: remoteURL)
+        partialURL = AudioCacheStore.mainPartialAudioURL(for: songID, sourceURL: remoteURL)
         super.init()
     }
 
@@ -462,7 +465,7 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
             let status = (task.response as? HTTPURLResponse)?.statusCode ?? 0
             DebugLogger.log("Predownload completed for \(songID) with HTTP \(status)", category: .playback)
             do {
-                try? FileManager.default.removeItem(at: finalURL)
+                AudioCacheStore.removeMainAudioFiles(for: songID)
                 try FileManager.default.moveItem(at: partialURL, to: finalURL)
                 AudioCacheStore.writeMainSourceURL(remoteURL, for: songID)
             } catch {

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -465,13 +465,15 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
             let status = (task.response as? HTTPURLResponse)?.statusCode ?? 0
             DebugLogger.log("Predownload completed for \(songID) with HTTP \(status)", category: .playback)
             do {
-                AudioCacheStore.removeMainAudioFiles(for: songID)
-                try FileManager.default.moveItem(at: partialURL, to: finalURL)
+                try AudioCacheStore.commitMainAudioFile(
+                    at: partialURL,
+                    to: finalURL,
+                    for: songID
+                )
                 AudioCacheStore.writeMainSourceURL(remoteURL, for: songID)
             } catch {
                 DebugLogger.log("Predownload move failed for \(songID): \(error)", category: .playback)
                 try? FileManager.default.removeItem(at: partialURL)
-                AudioCacheStore.writeMainSourceURL(nil, for: songID)
             }
         } else {
             DebugLogger.log(

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -5,8 +5,6 @@ import Foundation
 nonisolated enum AudioCacheStore {
     struct SongFiles {
         let directory: URL
-        let main: URL
-        let mainPartial: URL
         let mainSource: URL
         let vocals: URL
         let instruments: URL
@@ -20,6 +18,9 @@ nonisolated enum AudioCacheStore {
     private nonisolated(unsafe) static let compressionAlgorithm: Algorithm = .lzfse
     private static let chunkSize = 64 * 1024
     private static let maximumPlayableFileSize: Int64 = 256 * 1024 * 1024
+    private static let supportedMainAudioExtensions: Set<String> = [
+        "aac", "aif", "aiff", "caf", "flac", "m4a", "m4b", "mp3", "mp4", "wav",
+    ]
     private static let cacheDirectory: URL = {
         let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
             .appendingPathComponent("AudioCache", isDirectory: true)
@@ -36,11 +37,29 @@ nonisolated enum AudioCacheStore {
         )
     }
 
+    static func mainAudioURL(for songID: String, sourceURL: URL) -> URL {
+        files(for: songID).directory.appendingPathComponent(
+            "main.\(mainAudioExtension(for: sourceURL))"
+        )
+    }
+
+    static func mainPartialAudioURL(for songID: String, sourceURL: URL) -> URL {
+        files(for: songID).directory.appendingPathComponent(
+            "main.partial.\(mainAudioExtension(for: sourceURL))"
+        )
+    }
+
+    static func removeMainAudioFiles(for songID: String) {
+        let directory = files(for: songID).directory
+        for url in cachedMainAudioURLs(in: directory) {
+            try? fm.removeItem(at: url)
+            try? fm.removeItem(at: compressedURL(for: url))
+        }
+    }
+
     private static func songFiles(in directory: URL) -> SongFiles {
         return SongFiles(
             directory: directory,
-            main: directory.appendingPathComponent("main.mp3"),
-            mainPartial: directory.appendingPathComponent("main.mp3.partial"),
             mainSource: directory.appendingPathComponent("main.source"),
             vocals: directory.appendingPathComponent("vocals.wav"),
             instruments: directory.appendingPathComponent("instruments.wav"),
@@ -59,25 +78,32 @@ nonisolated enum AudioCacheStore {
 
     static func playableMainURL(for songID: String, expectedRemoteURL: URL? = nil, expectedDuration: TimeInterval? = nil) -> URL? {
         let songFiles = files(for: songID)
-        guard let playable = playableURL(for: songFiles.main) else { return nil }
-        guard validateMainSource(for: songID, expectedRemoteURL: expectedRemoteURL) else {
-            return nil
-        }
-        if let expectedDuration, expectedDuration.isFinite, expectedDuration > 1.0 {
-            let actualDuration = audioDuration(at: playable)
-            guard durationAppearsComplete(
-                actualDuration: actualDuration,
-                expectedDuration: expectedDuration
-            ) else {
-                DebugLogger.log(
-                    "Discarding audio cache for \(songID) due to duration mismatch: expected \(expectedDuration)s, got \(actualDuration)s",
-                    category: .cache
-                )
-                removeSongCache(for: songID)
+        for candidate in mainAudioCandidates(
+            in: songFiles.directory,
+            songID: songID,
+            expectedRemoteURL: expectedRemoteURL
+        ) {
+            guard let playable = playableURL(for: candidate) else { continue }
+            guard validateMainSource(for: songID, expectedRemoteURL: expectedRemoteURL) else {
                 return nil
             }
+            if let expectedDuration, expectedDuration.isFinite, expectedDuration > 1.0 {
+                let actualDuration = audioDuration(at: playable)
+                guard durationAppearsComplete(
+                    actualDuration: actualDuration,
+                    expectedDuration: expectedDuration
+                ) else {
+                    DebugLogger.log(
+                        "Discarding audio cache for \(songID) due to duration mismatch: expected \(expectedDuration)s, got \(actualDuration)s",
+                        category: .cache
+                    )
+                    removeSongCache(for: songID)
+                    return nil
+                }
+            }
+            return playable
         }
-        return playable
+        return nil
     }
 
     /// Like `playableMainURL`, but never decompresses: returns nil when only the
@@ -89,26 +115,35 @@ nonisolated enum AudioCacheStore {
         expectedDuration: TimeInterval? = nil
     ) -> URL? {
         let songFiles = files(for: songID)
-        guard fm.fileExists(atPath: songFiles.main.path),
-              validateMainSource(for: songID, expectedRemoteURL: expectedRemoteURL),
-              isValidAudioFile(at: songFiles.main)
-        else { return nil }
-        if let expectedDuration, expectedDuration.isFinite, expectedDuration > 1.0 {
-            let actualDuration = audioDuration(at: songFiles.main)
-            guard durationAppearsComplete(
-                actualDuration: actualDuration,
-                expectedDuration: expectedDuration
-            ) else {
-                DebugLogger.log(
-                    "Discarding immediate audio cache for \(songID) due to duration mismatch: expected \(expectedDuration)s, got \(actualDuration)s",
-                    category: .cache
-                )
-                removeSongCache(for: songID)
+        for candidate in mainAudioCandidates(
+            in: songFiles.directory,
+            songID: songID,
+            expectedRemoteURL: expectedRemoteURL
+        ) {
+            guard fm.fileExists(atPath: candidate.path), isValidAudioFile(at: candidate) else {
+                continue
+            }
+            guard validateMainSource(for: songID, expectedRemoteURL: expectedRemoteURL) else {
                 return nil
             }
+            if let expectedDuration, expectedDuration.isFinite, expectedDuration > 1.0 {
+                let actualDuration = audioDuration(at: candidate)
+                guard durationAppearsComplete(
+                    actualDuration: actualDuration,
+                    expectedDuration: expectedDuration
+                ) else {
+                    DebugLogger.log(
+                        "Discarding immediate audio cache for \(songID) due to duration mismatch: expected \(expectedDuration)s, got \(actualDuration)s",
+                        category: .cache
+                    )
+                    removeSongCache(for: songID)
+                    return nil
+                }
+            }
+            touch(candidate)
+            return candidate
         }
-        touch(songFiles.main)
-        return songFiles.main
+        return nil
     }
 
     static func playableStems(
@@ -273,7 +308,43 @@ nonisolated enum AudioCacheStore {
         modifiedAt: Date,
         createdBefore cutoff: Date
     ) -> Bool {
-        name.hasSuffix(".partial") && modifiedAt < cutoff
+        (name.hasSuffix(".partial") || name.contains(".partial.")) && modifiedAt < cutoff
+    }
+
+    private static func mainAudioExtension(for sourceURL: URL) -> String {
+        let pathExtension = sourceURL.pathExtension.lowercased()
+        return supportedMainAudioExtensions.contains(pathExtension) ? pathExtension : "mp3"
+    }
+
+    private static func mainAudioCandidates(
+        in directory: URL,
+        songID: String,
+        expectedRemoteURL: URL?
+    ) -> [URL] {
+        if let expectedRemoteURL {
+            // The container extension is part of Core Audio's file-type
+            // selection. Do not reuse a legacy `main.mp3` that contains M4A
+            // bytes from the same source URL.
+            return [mainAudioURL(for: songID, sourceURL: expectedRemoteURL)]
+        }
+        return cachedMainAudioURLs(in: directory)
+    }
+
+    private static func cachedMainAudioURLs(in directory: URL) -> [URL] {
+        guard let entries = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        return entries
+            .filter { url in
+                let name = url.lastPathComponent
+                return name.hasPrefix("main.")
+                    && !name.contains(".partial.")
+                    && !name.contains(".promoting-")
+                    && supportedMainAudioExtensions.contains(url.pathExtension.lowercased())
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
     }
 
     static func compressIdleAssets(excluding songIDs: Set<String>) {

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -49,12 +49,27 @@ nonisolated enum AudioCacheStore {
         )
     }
 
-    static func removeMainAudioFiles(for songID: String) {
+    static func removeMainAudioFiles(for songID: String, excluding preservedURL: URL? = nil) {
         let directory = files(for: songID).directory
+        let preservedURL = preservedURL?.standardizedFileURL
         for url in cachedMainAudioURLs(in: directory) {
+            guard url.standardizedFileURL != preservedURL else { continue }
             try? fm.removeItem(at: url)
             try? fm.removeItem(at: compressedURL(for: url))
         }
+    }
+
+    static func commitMainAudioFile(at stagedURL: URL, to finalURL: URL, for songID: String) throws {
+        if fm.fileExists(atPath: finalURL.path) {
+            _ = try fm.replaceItemAt(finalURL, withItemAt: stagedURL)
+        } else {
+            try fm.moveItem(at: stagedURL, to: finalURL)
+        }
+
+        // A newly committed uncompressed file supersedes any compressed copy
+        // and alternate legacy-extension variants.
+        try? fm.removeItem(at: compressedURL(for: finalURL))
+        removeMainAudioFiles(for: songID, excluding: finalURL)
     }
 
     private static func songFiles(in directory: URL) -> SongFiles {
@@ -77,9 +92,7 @@ nonisolated enum AudioCacheStore {
     }
 
     static func playableMainURL(for songID: String, expectedRemoteURL: URL? = nil, expectedDuration: TimeInterval? = nil) -> URL? {
-        let songFiles = files(for: songID)
         for candidate in mainAudioCandidates(
-            in: songFiles.directory,
             songID: songID,
             expectedRemoteURL: expectedRemoteURL
         ) {
@@ -114,9 +127,7 @@ nonisolated enum AudioCacheStore {
         expectedRemoteURL: URL? = nil,
         expectedDuration: TimeInterval? = nil
     ) -> URL? {
-        let songFiles = files(for: songID)
         for candidate in mainAudioCandidates(
-            in: songFiles.directory,
             songID: songID,
             expectedRemoteURL: expectedRemoteURL
         ) {
@@ -316,18 +327,14 @@ nonisolated enum AudioCacheStore {
         return supportedMainAudioExtensions.contains(pathExtension) ? pathExtension : "mp3"
     }
 
-    private static func mainAudioCandidates(
-        in directory: URL,
-        songID: String,
-        expectedRemoteURL: URL?
-    ) -> [URL] {
+    private static func mainAudioCandidates(songID: String, expectedRemoteURL: URL?) -> [URL] {
         if let expectedRemoteURL {
             // The container extension is part of Core Audio's file-type
             // selection. Do not reuse a legacy `main.mp3` that contains M4A
             // bytes from the same source URL.
             return [mainAudioURL(for: songID, sourceURL: expectedRemoteURL)]
         }
-        return cachedMainAudioURLs(in: directory)
+        return cachedMainAudioURLs(in: files(for: songID).directory)
     }
 
     private static func cachedMainAudioURLs(in directory: URL) -> [URL] {

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -791,14 +791,6 @@ nonisolated enum SongPayloadDecoder {
     if let list = (try? decoder.decode(SongCollection.self, from: data))?.songs, !list.isEmpty {
       return list
     }
-    if let wrapped = try? decoder.decode(LossyArray<FavoriteSongEnvelope>.self, from: data) {
-      let songs = wrapped.elements.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
-    if let wrapped = try? decoder.decode([FavoriteSongEnvelope].self, from: data) {
-      let songs = wrapped.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
     return nil
   }
 }

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -19,6 +19,56 @@ nonisolated struct LossyArray<Element: Decodable>: Decodable, Sendable where Ele
 
 nonisolated private struct DiscardedDecodable: Decodable, Sendable {}
 
+nonisolated private struct FlexibleArtist: Decodable, Sendable {
+  let name: String
+
+  private enum CodingKeys: String, CodingKey {
+    case name, artistName, displayName, title
+  }
+
+  init(from decoder: Decoder) throws {
+    if let container = try? decoder.singleValueContainer(),
+      let value = try? container.decode(String.self)
+    {
+      name = value
+      return
+    }
+
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    for key in [CodingKeys.name, .artistName, .displayName, .title] {
+      if let value = try? container.decode(String.self, forKey: key) {
+        name = value
+        return
+      }
+    }
+    throw DecodingError.dataCorrupted(
+      .init(codingPath: decoder.codingPath, debugDescription: "Artist has no name")
+    )
+  }
+}
+
+nonisolated private struct FlexibleArtistList: Decodable, Sendable {
+  let values: [String]
+
+  init(from decoder: Decoder) throws {
+    if let artist = try? FlexibleArtist(from: decoder) {
+      let value = artist.name.trimmingCharacters(in: .whitespacesAndNewlines)
+      values = value.isEmpty ? [] : [value]
+      return
+    }
+
+    var container = try decoder.unkeyedContainer()
+    var decoded: [String] = []
+    while !container.isAtEnd {
+      let elementDecoder = try container.superDecoder()
+      guard let artist = try? FlexibleArtist(from: elementDecoder) else { continue }
+      let value = artist.name.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !value.isEmpty { decoded.append(value) }
+    }
+    values = decoded
+  }
+}
+
 nonisolated enum SongCountText {
   static func songs(_ count: Int) -> String {
     count == 1 ? "1 song" : "\(count) songs"
@@ -39,7 +89,8 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
 
   enum CodingKeys: String, CodingKey {
     case id, title, duration, absolutePath, coverArt, originalArtists, coverArtists, userUploaded, oss
-    case cloudflareID = "cloudflareId"
+    case cloudflareId
+    case cloudflareID
   }
 
   init(
@@ -64,6 +115,52 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
     self.coverArtists = coverArtists
     self.userUploaded = userUploaded
     self.oss = oss
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    guard let decodedID = Self.decodeString(from: container, keys: [.id]),
+      !decodedID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      throw DecodingError.keyNotFound(
+        CodingKeys.id,
+        .init(codingPath: decoder.codingPath, debugDescription: "Song is missing an id")
+      )
+    }
+    guard let decodedTitle = Self.decodeString(from: container, keys: [.title]),
+      !decodedTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      throw DecodingError.keyNotFound(
+        CodingKeys.title,
+        .init(codingPath: decoder.codingPath, debugDescription: "Song is missing a title")
+      )
+    }
+
+    id = decodedID
+    title = decodedTitle
+    duration = Self.decodeDuration(from: container)
+    absolutePath = Self.decodeString(from: container, keys: [.absolutePath])
+    cloudflareID = Self.decodeString(from: container, keys: [.cloudflareId, .cloudflareID])
+    coverArt = try? container.decodeIfPresent(Media.self, forKey: .coverArt)
+    originalArtists = Self.decodeArtists(from: container, forKey: .originalArtists)
+    coverArtists = Self.decodeArtists(from: container, forKey: .coverArtists)
+    userUploaded = Self.decodeBool(from: container, forKey: .userUploaded)
+    oss = Self.decodeString(from: container, keys: [.oss])
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(title, forKey: .title)
+    try container.encode(duration, forKey: .duration)
+    try container.encodeIfPresent(absolutePath, forKey: .absolutePath)
+    try container.encodeIfPresent(cloudflareID, forKey: .cloudflareId)
+    try container.encodeIfPresent(coverArt, forKey: .coverArt)
+    try container.encodeIfPresent(originalArtists, forKey: .originalArtists)
+    try container.encodeIfPresent(coverArtists, forKey: .coverArtists)
+    try container.encodeIfPresent(userUploaded, forKey: .userUploaded)
+    try container.encodeIfPresent(oss, forKey: .oss)
   }
 
   init(
@@ -159,16 +256,10 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   }
 
   var audioURL: URL? {
-    if let path = absolutePath {
-      let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
-      return URL(string: "\(StorageHost.base)/\(cleanPath)")
+    for source in [absolutePath, oss].compactMap({ $0 }) {
+      if let url = Self.audioURL(from: source) { return url }
     }
-    // User-uploaded songs deliver their audio path in `oss`; it can contain
-    // spaces and other characters that need percent-encoding.
-    guard let oss, !oss.isEmpty else { return nil }
-    let cleanPath = oss.hasPrefix("/") ? String(oss.dropFirst()) : oss
-    let encodedPath = cleanPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? cleanPath
-    return URL(string: "\(StorageHost.base)/\(encodedPath)")
+    return nil
   }
 
   var displayTitle: String {
@@ -215,6 +306,115 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
 
   static func == (lhs: Song, rhs: Song) -> Bool { lhs.id == rhs.id }
 
+  private static func decodeString(
+    from container: KeyedDecodingContainer<CodingKeys>,
+    keys: [CodingKeys]
+  ) -> String? {
+    for key in keys {
+      if let value = try? container.decode(String.self, forKey: key) { return value }
+    }
+    return nil
+  }
+
+  private static func decodeDuration(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) -> Int {
+    if let value = try? container.decode(Int.self, forKey: .duration) {
+      return max(0, value)
+    }
+    if let value = try? container.decode(Double.self, forKey: .duration), value.isFinite {
+      return max(0, Int(value))
+    }
+    if let value = try? container.decode(String.self, forKey: .duration),
+      let parsed = Double(value.trimmingCharacters(in: .whitespacesAndNewlines)),
+      parsed.isFinite
+    {
+      return max(0, Int(parsed))
+    }
+    return 0
+  }
+
+  private static func decodeArtists(
+    from container: KeyedDecodingContainer<CodingKeys>,
+    forKey key: CodingKeys
+  ) -> [String]? {
+    guard container.contains(key),
+      (try? container.decodeNil(forKey: key)) != true
+    else { return nil }
+    return (try? container.decode(FlexibleArtistList.self, forKey: key))?.values
+  }
+
+  private static func decodeBool(
+    from container: KeyedDecodingContainer<CodingKeys>,
+    forKey key: CodingKeys
+  ) -> Bool? {
+    if let value = try? container.decode(Bool.self, forKey: key) { return value }
+    if let value = try? container.decode(Int.self, forKey: key) { return value != 0 }
+    if let value = try? container.decode(String.self, forKey: key) {
+      switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+      case "true", "1", "yes": return true
+      case "false", "0", "no": return false
+      default: return nil
+      }
+    }
+    return nil
+  }
+
+  private static func audioURL(from source: String) -> URL? {
+    let value = source.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !value.isEmpty else { return nil }
+
+    if value.hasPrefix("//") {
+      return URL(string: "https:\(value)")
+    }
+    if let url = URL(string: value),
+      let scheme = url.scheme?.lowercased(),
+      ["http", "https"].contains(scheme),
+      url.host != nil
+    {
+      return url
+    }
+
+    guard var components = URLComponents(string: StorageHost.base) else { return nil }
+    let segments = value.split(separator: "/", omittingEmptySubsequences: true)
+    guard !segments.isEmpty else { return nil }
+    let encodedSegments = segments.map { segment in
+      let decoded = String(segment).removingPercentEncoding ?? String(segment)
+      return decoded.addingPercentEncoding(withAllowedCharacters: audioPathSegmentAllowed) ?? decoded
+    }
+    let basePath = components.percentEncodedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    components.percentEncodedPath = "/" + ([basePath] + encodedSegments)
+      .filter { !$0.isEmpty }
+      .joined(separator: "/")
+    return components.url
+  }
+
+  private static let audioPathSegmentAllowed: CharacterSet = {
+    var allowed = CharacterSet.urlPathAllowed
+    allowed.remove(charactersIn: "/%?#")
+    return allowed
+  }()
+
+}
+
+nonisolated private struct SongCollection: Decodable, Sendable {
+  let songs: [Song]
+
+  init(from decoder: Decoder) throws {
+    var container = try decoder.unkeyedContainer()
+    var decoded: [Song] = []
+    while !container.isAtEnd {
+      let elementDecoder = try container.superDecoder()
+      if let song = try? Song(from: elementDecoder) {
+        decoded.append(song)
+      } else if let envelope = try? FavoriteSongEnvelope(from: elementDecoder),
+        let song = envelope.song
+      {
+        decoded.append(song)
+      }
+    }
+    songs = decoded
+  }
 }
 
 nonisolated struct Playlist: Codable, Identifiable, Hashable, Sendable {
@@ -342,21 +542,7 @@ nonisolated struct Playlist: Codable, Identifiable, Hashable, Sendable {
     from container: KeyedDecodingContainer<CodingKeys>,
     forKey key: CodingKeys
   ) -> [Song]? {
-    if let decoded = try? container.decode(LossyArray<Song>.self, forKey: key) {
-      return decoded.elements
-    }
-    if let decoded = try? container.decode([Song].self, forKey: key) {
-      return decoded
-    }
-    if let decoded = try? container.decode(LossyArray<FavoriteSongEnvelope>.self, forKey: key) {
-      let songs = decoded.elements.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
-    if let decoded = try? container.decode([FavoriteSongEnvelope].self, forKey: key) {
-      let songs = decoded.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
-    return nil
+    (try? container.decode(SongCollection.self, forKey: key))?.songs
   }
 }
 
@@ -408,21 +594,7 @@ nonisolated struct PlaylistListItem: Decodable, Identifiable, Sendable {
     from container: KeyedDecodingContainer<CodingKeys>,
     forKey key: CodingKeys
   ) -> [Song]? {
-    if let decoded = try? container.decode(LossyArray<Song>.self, forKey: key) {
-      return decoded.elements
-    }
-    if let decoded = try? container.decode([Song].self, forKey: key) {
-      return decoded
-    }
-    if let decoded = try? container.decode(LossyArray<FavoriteSongEnvelope>.self, forKey: key) {
-      let songs = decoded.elements.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
-    if let decoded = try? container.decode([FavoriteSongEnvelope].self, forKey: key) {
-      let songs = decoded.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
-    return nil
+    (try? container.decode(SongCollection.self, forKey: key))?.songs
   }
 }
 
@@ -467,6 +639,36 @@ nonisolated struct PlaylistDetail: Codable, Sendable {
   let id: String
   let name: String
   let songListDTOs: [Song]
+
+  private enum CodingKeys: String, CodingKey {
+    case id, name, songListDTOs, items, songs, favorites
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    songListDTOs =
+      Self.decodeSongs(from: container, forKey: .songListDTOs)
+      ?? Self.decodeSongs(from: container, forKey: .items)
+      ?? Self.decodeSongs(from: container, forKey: .songs)
+      ?? Self.decodeSongs(from: container, forKey: .favorites)
+      ?? []
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(name, forKey: .name)
+    try container.encode(songListDTOs, forKey: .songListDTOs)
+  }
+
+  private static func decodeSongs(
+    from container: KeyedDecodingContainer<CodingKeys>,
+    forKey key: CodingKeys
+  ) -> [Song]? {
+    (try? container.decode(SongCollection.self, forKey: key))?.songs
+  }
 }
 
 nonisolated struct SearchResponse: Codable, Sendable {
@@ -572,21 +774,7 @@ nonisolated struct SongArrayContainer: Decodable, Sendable {
     from container: KeyedDecodingContainer<CodingKeys>,
     forKey key: CodingKeys
   ) -> [Song]? {
-    if let decoded = try? container.decode(LossyArray<Song>.self, forKey: key) {
-      return decoded.elements
-    }
-    if let decoded = try? container.decode([Song].self, forKey: key) {
-      return decoded
-    }
-    if let decoded = try? container.decode(LossyArray<FavoriteSongEnvelope>.self, forKey: key) {
-      let songs = decoded.elements.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
-    if let decoded = try? container.decode([FavoriteSongEnvelope].self, forKey: key) {
-      let songs = decoded.compactMap(\.song)
-      if !songs.isEmpty { return songs }
-    }
-    return nil
+    (try? container.decode(SongCollection.self, forKey: key))?.songs
   }
 }
 
@@ -600,10 +788,7 @@ nonisolated enum SongPayloadDecoder {
     {
       return wrapped.songs
     }
-    if let list = (try? decoder.decode(LossyArray<Song>.self, from: data))?.elements, !list.isEmpty {
-      return list
-    }
-    if let list = try? decoder.decode([Song].self, from: data), !list.isEmpty {
+    if let list = (try? decoder.decode(SongCollection.self, from: data))?.songs, !list.isEmpty {
       return list
     }
     if let wrapped = try? decoder.decode(LossyArray<FavoriteSongEnvelope>.self, from: data) {

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -62,6 +62,62 @@ struct DownloadManagerTests {
         )
     }
 
+    @Test("Playback cache commit replaces its destination and removes legacy variants")
+    func playbackCacheCommitReplacesDestinationSafely() throws {
+        let songID = "cache-commit-\(UUID().uuidString)"
+        defer { AudioCacheStore.removeSongCache(for: songID) }
+
+        let m4aSource = try #require(URL(string: "https://storage.example.com/song.m4a"))
+        let mp3Source = try #require(URL(string: "https://storage.example.com/song.mp3"))
+        let finalURL = AudioCacheStore.mainAudioURL(for: songID, sourceURL: m4aSource)
+        let stagedURL = AudioCacheStore.mainPartialAudioURL(for: songID, sourceURL: m4aSource)
+        let legacyURL = AudioCacheStore.mainAudioURL(for: songID, sourceURL: mp3Source)
+        _ = AudioCacheStore.ensureSongDirectory(for: songID)
+
+        try Data("old".utf8).write(to: finalURL)
+        try Data("legacy".utf8).write(to: legacyURL)
+        try Data("new".utf8).write(to: stagedURL)
+
+        try AudioCacheStore.commitMainAudioFile(
+            at: stagedURL,
+            to: finalURL,
+            for: songID
+        )
+
+        #expect(try Data(contentsOf: finalURL) == Data("new".utf8))
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+        #expect(!FileManager.default.fileExists(atPath: stagedURL.path))
+    }
+
+    @Test("Failed playback cache commit preserves the existing destination")
+    func failedPlaybackCacheCommitPreservesDestination() throws {
+        let songID = "cache-commit-failure-\(UUID().uuidString)"
+        defer { AudioCacheStore.removeSongCache(for: songID) }
+
+        let sourceURL = try #require(URL(string: "https://storage.example.com/song.m4a"))
+        let finalURL = AudioCacheStore.mainAudioURL(for: songID, sourceURL: sourceURL)
+        let missingStagedURL = AudioCacheStore.mainPartialAudioURL(
+            for: songID,
+            sourceURL: sourceURL
+        )
+        _ = AudioCacheStore.ensureSongDirectory(for: songID)
+        try Data("old".utf8).write(to: finalURL)
+
+        var commitFailed = false
+        do {
+            try AudioCacheStore.commitMainAudioFile(
+                at: missingStagedURL,
+                to: finalURL,
+                for: songID
+            )
+        } catch {
+            commitFailed = true
+        }
+
+        #expect(commitFailed)
+        #expect(try Data(contentsOf: finalURL) == Data("old".utf8))
+    }
+
     @Test("Only uncompressed stem formats are selected for compression")
     func cacheCompressionSkipsAlreadyCompressedAudio() {
         #expect(AudioCacheStore.shouldCompressPlayableFile(at: URL(fileURLWithPath: "/tmp/vocals.wav")))

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -37,6 +37,29 @@ struct DownloadManagerTests {
                 createdBefore: cutoff
             )
         )
+        #expect(
+            AudioCacheStore.shouldRemovePartialFile(
+                named: "main.partial.m4a",
+                modifiedAt: cutoff.addingTimeInterval(-1),
+                createdBefore: cutoff
+            )
+        )
+    }
+
+    @Test("Playback cache preserves the remote audio container extension")
+    func playbackCachePreservesRemoteContainerExtension() throws {
+        let remoteURL = try #require(
+            URL(string: "https://storage.example.com/Imported%20Song.m4a")
+        )
+
+        #expect(
+            AudioCacheStore.mainAudioURL(for: "uploaded-song", sourceURL: remoteURL)
+                .lastPathComponent == "main.m4a"
+        )
+        #expect(
+            AudioCacheStore.mainPartialAudioURL(for: "uploaded-song", sourceURL: remoteURL)
+                .lastPathComponent == "main.partial.m4a"
+        )
     }
 
     @Test("Only uncompressed stem formats are selected for compression")

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -198,6 +198,48 @@ struct SongModelTests {
         #expect(url?.contains("%20") == true)
     }
 
+    @Test("audioURL falls back to oss when absolutePath is blank")
+    func songAudioURLFallsBackToOssWhenAbsolutePathIsBlank() {
+        useGlobalStorageRegion()
+        let song = Song(
+            id: "song-blank-path",
+            title: "Uploaded File",
+            duration: 90,
+            absolutePath: "  ",
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: nil,
+            userUploaded: true,
+            oss: "uploads/My Song.mp3"
+        )
+
+        #expect(
+            song.audioURL?.absoluteString
+                == "https://storage.neurokaraoke.com/uploads/My%20Song.mp3"
+        )
+    }
+
+    @Test("audioURL preserves complete remote URLs")
+    func songAudioURLPreservesRemoteURL() {
+        let song = Song(
+            id: "song-remote",
+            title: "Remote Upload",
+            duration: 90,
+            absolutePath: "https://uploads.example.com/audio/My%20Song.mp3?token=abc",
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: nil,
+            userUploaded: true
+        )
+
+        #expect(
+            song.audioURL?.absoluteString
+                == "https://uploads.example.com/audio/My%20Song.mp3?token=abc"
+        )
+    }
+
     @Test("audioURL is nil when both absolutePath and oss are nil")
     func songAudioURLNilWithoutAnyPath() {
         let song = Song(
@@ -225,6 +267,86 @@ struct SongModelTests {
         #expect(song != nil)
         #expect(song?.oss == "audio/test.mp3")
         #expect(song?.audioURL?.absoluteString == "https://storage.neurokaraoke.com/audio/test.mp3")
+    }
+
+    @Test("Song decodes flexible metadata used by uploaded YouTube songs")
+    func songDecodesFlexibleUploadedMetadata() throws {
+        let json = """
+        {
+          "id": "youtube-1",
+          "title": "Imported Song",
+          "duration": "213.8",
+          "absolutePath": "youtube/Imported Song.mp3",
+          "cloudflareId": "artwork-id",
+          "originalArtists": [{"name": "Original Artist"}],
+          "coverArtists": "Uploader",
+          "userUploaded": 1
+        }
+        """.data(using: .utf8)!
+
+        let song = try JSONDecoder().decode(Song.self, from: json)
+
+        #expect(song.duration == 213)
+        #expect(song.originalArtists == ["Original Artist"])
+        #expect(song.coverArtists == ["Uploader"])
+        #expect(song.userUploaded == true)
+        #expect(song.cloudflareID == "artwork-id")
+    }
+
+    @Test("Favorite responses decode uploaded songs wrapped in an envelope")
+    func favoriteEnvelopeDecodesUploadedSong() throws {
+        let json = """
+        {
+          "items": [
+            {
+              "song": {
+                "id": "favorite-upload",
+                "title": "Uploaded Favorite",
+                "duration": 123.4,
+                "absolutePath": null,
+                "oss": "uploads/Uploaded Favorite.mp3",
+                "userUploaded": "true"
+              }
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let songs = try #require(SongPayloadDecoder.decodeSongs(from: json))
+
+        #expect(songs.map(\.id) == ["favorite-upload"])
+        #expect(songs.first?.userUploaded == true)
+        #expect(
+            songs.first?.audioURL?.absoluteString
+                == "https://storage.neurokaraoke.com/uploads/Uploaded%20Favorite.mp3"
+        )
+    }
+
+    @Test("Playlist detail skips malformed songs instead of failing the playlist")
+    func playlistDetailSkipsMalformedSong() throws {
+        let json = """
+        {
+          "id": "playlist-1",
+          "name": "Uploads",
+          "songListDTOs": [
+            {
+              "id": "youtube-1",
+              "title": "YouTube Upload",
+              "duration": "180",
+              "absolutePath": "youtube/song.mp3",
+              "originalArtists": [{"artistName": "Artist"}],
+              "userUploaded": true
+            },
+            {
+              "title": "Missing ID"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let playlist = try JSONDecoder().decode(PlaylistDetail.self, from: json)
+
+        #expect(playlist.songListDTOs.map(\.id) == ["youtube-1"])
     }
 
     @Test("Display artist combines original and cover artists")


### PR DESCRIPTION
## Summary

- Decode uploaded songs with flexible API field types and wrapped favorites responses.
- Skip malformed playlist entries instead of failing the entire playlist.
- Preserve the remote audio container extension through playback caching and transition preloads.
- Replace incompatible legacy cache variants and limit cache recovery attempts.

## Root cause

Uploaded YouTube audio can be delivered as M4A, but the playback cache always stored the downloaded bytes as `main.mp3`. Core Audio consequently selected its MP3 parser for M4A data and rejected the file. Uploaded-song metadata can also use alternate field types or response envelopes, which previously caused an entire favorites or playlist response to fail decoding.

## Impact

Uploaded songs now appear reliably in favorites and playlists, malformed entries no longer prevent a playlist from loading, and cached uploaded audio plays using its actual container format.

## Validation

- Confirmed uploaded-song playlist display, artwork, and playback on a physical device.
- Complete unit suite: 48 tests passed.
- Unsigned Release simulator build succeeded.
- Diff whitespace validation passed.

## Summary by Sourcery

Improve robustness of uploaded song handling, metadata decoding, and playback caching for favorites and playlists.

New Features:
- Support flexible song metadata formats for uploaded content, including alternative field names and wrapped favorites payloads.
- Respect remote audio URLs and container extensions when resolving song playback URLs and caching remote audio.

Bug Fixes:
- Prevent malformed or partially invalid playlist and favorites entries from breaking decoding, skipping only invalid songs.
- Ensure cached uploaded audio uses a container extension compatible with its actual data so Core Audio can play it.
- Limit repeated cache recovery attempts when playback fails to avoid infinite retry loops.

Enhancements:
- Unify song collection decoding across multiple response shapes using a dedicated SongCollection type.
- Relax duration and boolean decoding to accept numeric and string representations used by backend APIs.

Tests:
- Add unit tests covering flexible song metadata decoding, envelope-wrapped favorites, playlist error tolerance, audio URL resolution, partial-file cleanup, and preservation of remote container extensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio caching to support source file extensions such as `.m4a`.
  * Added more flexible song and artist data handling across playlist and favorite responses.
  * Added fallback audio URL support when the primary path is unavailable.

* **Bug Fixes**
  * Prevented repeated recovery attempts for corrupted cached audio.
  * Improved recovery and cleanup when cached playback fails.
  * Malformed songs are now skipped instead of preventing entire playlists from loading.
  * Added network failure logging for playlist loading.

* **Tests**
  * Added coverage for audio cache recovery, URL handling, flexible metadata, and playlist decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->