### PR TITLE
Fix artwork for uploaded songs in favorites

### DIFF
--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -18,7 +18,7 @@ nonisolated enum AudioCacheStore {
     private nonisolated(unsafe) static let compressionAlgorithm: Algorithm = .lzfse
     private static let chunkSize = 64 * 1024
     private static let maximumPlayableFileSize: Int64 = 256 * 1024 * 1024
-    private static let supportedMainAudioExtensions: Set<String> = [
+    static let supportedMainAudioExtensions: Set<String> = [
         "aac", "aif", "aiff", "caf", "flac", "m4a", "m4b", "mp3", "mp4", "wav",
     ]
     private static let cacheDirectory: URL = {
@@ -322,7 +322,7 @@ nonisolated enum AudioCacheStore {
         (name.hasSuffix(".partial") || name.contains(".partial.")) && modifiedAt < cutoff
     }
 
-    private static func mainAudioExtension(for sourceURL: URL) -> String {
+    static func mainAudioExtension(for sourceURL: URL) -> String {
         let pathExtension = sourceURL.pathExtension.lowercased()
         return supportedMainAudioExtensions.contains(pathExtension) ? pathExtension : "mp3"
     }

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -151,16 +151,37 @@ final class DownloadManager: ObservableObject {
         networkMonitor.cancel()
     }
 
-    private nonisolated func files(for songID: String) -> SongFiles {
-        let directory = cacheDir.appendingPathComponent(
+    private nonisolated func downloadDirectory(for songID: String) -> URL {
+        cacheDir.appendingPathComponent(
             SongStorageKey.component(for: songID),
             isDirectory: true
         )
+    }
+
+    private nonisolated func sourceFileURL(for songID: String) -> URL {
+        downloadDirectory(for: songID).appendingPathComponent("main.source")
+    }
+
+    private nonisolated func metadataFileURL(for songID: String) -> URL {
+        downloadDirectory(for: songID).appendingPathComponent("metadata.json")
+    }
+
+    private nonisolated func files(for songID: String, sourceURL: URL? = nil) -> SongFiles {
+        let directory = downloadDirectory(for: songID)
+        let source = sourceFileURL(for: songID)
+        let persistedSourceURL = readSourceURL(at: source).flatMap(URL.init(string:))
+        let resolvedSourceURL = sourceURL ?? persistedSourceURL
+        let audio = if let resolvedSourceURL {
+            Self.downloadedAudioURL(in: directory, sourceURL: resolvedSourceURL)
+        } else {
+            Self.downloadedAudioURLs(in: directory).first
+                ?? directory.appendingPathComponent("main.mp3")
+        }
         return SongFiles(
             directory: directory,
-            audio: directory.appendingPathComponent("main.mp3"),
-            source: directory.appendingPathComponent("main.source"),
-            metadata: directory.appendingPathComponent("metadata.json")
+            audio: audio,
+            source: source,
+            metadata: metadataFileURL(for: songID)
         )
     }
 
@@ -176,7 +197,68 @@ final class DownloadManager: ObservableObject {
     }
 
     private nonisolated func sourceURL(for songID: String) -> URL {
-        files(for: songID).source
+        sourceFileURL(for: songID)
+    }
+
+    nonisolated static func downloadedAudioURL(in directory: URL, sourceURL: URL) -> URL {
+        directory.appendingPathComponent(
+            "main.\(AudioCacheStore.mainAudioExtension(for: sourceURL))"
+        )
+    }
+
+    private nonisolated static func promotionStagingURL(
+        in directory: URL,
+        sourceURL: URL,
+        token: UUID
+    ) -> URL {
+        directory.appendingPathComponent(
+            "main.promoting-\(token.uuidString).\(AudioCacheStore.mainAudioExtension(for: sourceURL))"
+        )
+    }
+
+    private nonisolated static func downloadedAudioURLs(in directory: URL) -> [URL] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        return entries
+            .filter { url in
+                let name = url.lastPathComponent
+                return name.hasPrefix("main.")
+                    && !name.contains(".partial.")
+                    && !name.contains(".promoting-")
+                    && AudioCacheStore.supportedMainAudioExtensions.contains(
+                        url.pathExtension.lowercased()
+                    )
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private nonisolated static func removeDownloadedAudioFiles(
+        in directory: URL,
+        excluding preservedURL: URL? = nil
+    ) {
+        let preservedURL = preservedURL?.standardizedFileURL
+        for url in downloadedAudioURLs(in: directory)
+            where url.standardizedFileURL != preservedURL
+        {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    nonisolated static func commitDownloadedAudioFile(
+        at stagedURL: URL,
+        to finalURL: URL,
+        in directory: URL
+    ) throws {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: finalURL.path) {
+            _ = try fm.replaceItemAt(finalURL, withItemAt: stagedURL)
+        } else {
+            try fm.moveItem(at: stagedURL, to: finalURL)
+        }
+        removeDownloadedAudioFiles(in: directory, excluding: finalURL)
     }
 
     nonisolated static func durationAppearsComplete(
@@ -338,9 +420,11 @@ final class DownloadManager: ObservableObject {
             expectedDuration: expectedDuration
         ), !Task.isCancelled else { return false }
 
-        let songFiles = files(for: song.id)
-        let stagedAudio = songFiles.directory.appendingPathComponent(
-            "main.mp3.promoting-\(token.uuidString)"
+        let songFiles = files(for: song.id, sourceURL: remoteURL)
+        let stagedAudio = Self.promotionStagingURL(
+            in: songFiles.directory,
+            sourceURL: remoteURL,
+            token: token
         )
         let stagedSource = songFiles.directory.appendingPathComponent(
             "main.source.promoting-\(token.uuidString)"
@@ -361,10 +445,26 @@ final class DownloadManager: ObservableObject {
             try sourceData.write(to: stagedSource, options: [.atomic])
 
             return try taskRegistry.performIfActive(songID: song.id, token: token) {
-                try? fm.removeItem(at: songFiles.audio)
-                try? fm.removeItem(at: songFiles.source)
-                try fm.moveItem(at: stagedAudio, to: songFiles.audio)
-                try fm.moveItem(at: stagedSource, to: songFiles.source)
+                try Self.commitDownloadedAudioFile(
+                    at: stagedAudio,
+                    to: songFiles.audio,
+                    in: songFiles.directory
+                )
+                if fm.fileExists(atPath: songFiles.source.path) {
+                    do {
+                        _ = try fm.replaceItemAt(songFiles.source, withItemAt: stagedSource)
+                    } catch {
+                        try? fm.removeItem(at: songFiles.audio)
+                        throw error
+                    }
+                } else {
+                    do {
+                        try fm.moveItem(at: stagedSource, to: songFiles.source)
+                    } catch {
+                        try? fm.removeItem(at: songFiles.audio)
+                        throw error
+                    }
+                }
                 return true
             } ?? false
         } catch {
@@ -400,7 +500,7 @@ final class DownloadManager: ObservableObject {
 
     private func startNetworkDownload(song: Song, remoteURL: URL, token: UUID) {
         let songID = song.id
-        let songFiles = files(for: songID)
+        let songFiles = files(for: songID, sourceURL: remoteURL)
         let taskRegistry = taskRegistry
         DebugLogger.log(
             "Download started: \(songID) (active=\(tasks.count + 1), queued=\(queuedDownloadOrder.count))",
@@ -422,13 +522,20 @@ final class DownloadManager: ObservableObject {
                             at: songFiles.directory,
                             withIntermediateDirectories: true
                         )
-                        try? FileManager.default.removeItem(at: songFiles.audio)
-                        try FileManager.default.moveItem(at: tempURL, to: songFiles.audio)
-                        try? FileManager.default.removeItem(at: songFiles.source)
-                        FileManager.default.createFile(
-                            atPath: songFiles.source.path,
-                            contents: remoteURL.absoluteString.data(using: .utf8)
+                        try Self.commitDownloadedAudioFile(
+                            at: tempURL,
+                            to: songFiles.audio,
+                            in: songFiles.directory
                         )
+                        do {
+                            try Data(remoteURL.absoluteString.utf8).write(
+                                to: songFiles.source,
+                                options: [.atomic]
+                            )
+                        } catch {
+                            try? FileManager.default.removeItem(at: songFiles.audio)
+                            throw error
+                        }
                         return true
                     } ?? false
                     if !moved {
@@ -470,8 +577,8 @@ final class DownloadManager: ObservableObject {
             let isCurrentTask = taskRegistry.performIfActive(songID: songID, token: token) { true } ?? false
             guard isCurrentTask else {
                 if moved {
-                    let songFiles = files(for: songID)
-                    try? FileManager.default.removeItem(at: songFiles.audio)
+                    let songFiles = files(for: songID, sourceURL: song.audioURL)
+                    Self.removeDownloadedAudioFiles(in: songFiles.directory)
                     try? FileManager.default.removeItem(at: songFiles.source)
                 }
                 startQueuedDownloadsIfPossible()
@@ -494,7 +601,9 @@ final class DownloadManager: ObservableObject {
             validDownloadCache[songID] = ValidDownloadCacheEntry(
                 source: song.audioURL?.absoluteString,
                 expectedDuration: song.duration > 0 ? TimeInterval(song.duration) : nil,
-                modifiedAt: Self.modificationDate(at: files(for: songID).audio)
+                modifiedAt: Self.modificationDate(
+                    at: files(for: songID, sourceURL: song.audioURL).audio
+                )
             )
             completedInCurrentQueue += 1
         } else {
@@ -751,6 +860,10 @@ final class DownloadManager: ObservableObject {
                 junkDirectories.append(entry)
                 continue
             }
+            migrateMislabeledDownloadedAudioIfNeeded(
+                for: songID,
+                expectedSourceURL: metadata?.audioURL
+            )
             if hasValidDownload(for: songID) {
                 ids.insert(songID)
                 if let metadata {
@@ -823,9 +936,9 @@ final class DownloadManager: ObservableObject {
             guard !downloadedIDs.contains(songID), !inProgress.contains(songID) else { continue }
             // A missing metadata file means the song was removed during the
             // scan; don't delete anything or resurrect it as a repair.
-            let songFiles = files(for: songID)
+            let songFiles = files(for: songID, sourceURL: song.audioURL)
             guard fm.fileExists(atPath: songFiles.metadata.path) else { continue }
-            try? fm.removeItem(at: songFiles.audio)
+            Self.removeDownloadedAudioFiles(in: songFiles.directory)
             try? fm.removeItem(at: songFiles.source)
             pendingWiFiRepairs[songID] = song
             repairCount += 1
@@ -847,7 +960,16 @@ final class DownloadManager: ObservableObject {
 
     func playableURL(for song: Song) -> URL? {
         migrateLegacyDownloadIfNeeded(for: song.id)
-        let songFiles = files(for: song.id)
+        migrateMislabeledDownloadedAudioIfNeeded(
+            for: song.id,
+            expectedSourceURL: song.audioURL
+        )
+        let cachedSource = readSourceURL(for: song.id)
+        let storedSourceURL = cachedSource.flatMap(URL.init(string:))
+        let songFiles = files(
+            for: song.id,
+            sourceURL: storedSourceURL ?? song.audioURL
+        )
         guard FileManager.default.fileExists(atPath: songFiles.audio.path) else {
             updatePublishedState { $0.downloadedIDs.remove(song.id) }
             validDownloadCache.removeValue(forKey: song.id)
@@ -856,7 +978,6 @@ final class DownloadManager: ObservableObject {
         }
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
         let expectedSource = song.audioURL?.absoluteString
-        let cachedSource = readSourceURL(for: song.id)
         if let cachedSource, let expectedSource, cachedSource != expectedSource {
             DebugLogger.log(
                 "Discarding downloaded audio for \(song.id) due to source mismatch",
@@ -917,14 +1038,19 @@ final class DownloadManager: ObservableObject {
 
     func immediatelyPlayableURL(for song: Song) -> URL? {
         guard downloadedIDs.contains(song.id) else { return nil }
-        let songFiles = files(for: song.id)
+        let cachedSource = readSourceURL(for: song.id)
+        let storedSourceURL = cachedSource.flatMap(URL.init(string:))
+        let songFiles = files(
+            for: song.id,
+            sourceURL: storedSourceURL ?? song.audioURL
+        )
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
         let expectedSource = song.audioURL?.absoluteString
         guard FileManager.default.fileExists(atPath: songFiles.audio.path),
               hasCachedValidation(
                   for: song.id,
                   audioURL: songFiles.audio,
-                  source: expectedSource,
+                  source: cachedSource ?? expectedSource,
                   expectedDuration: expectedDuration
               )
         else { return nil }
@@ -962,7 +1088,15 @@ final class DownloadManager: ObservableObject {
     @discardableResult
     func repairIfDownloadedFileIsBroken(for song: Song) -> Bool {
         guard isDownloaded(song.id) else { return false }
-        let songFiles = files(for: song.id)
+        migrateMislabeledDownloadedAudioIfNeeded(
+            for: song.id,
+            expectedSourceURL: song.audioURL
+        )
+        let storedSourceURL = readSourceURL(for: song.id).flatMap(URL.init(string:))
+        let songFiles = files(
+            for: song.id,
+            sourceURL: storedSourceURL ?? song.audioURL
+        )
         guard FileManager.default.fileExists(atPath: songFiles.audio.path) else {
             discardBrokenDownloadAndScheduleRepair(for: song, reason: "audio file is missing")
             return true
@@ -989,9 +1123,13 @@ final class DownloadManager: ObservableObject {
     }
 
     private nonisolated func hasValidDownload(for songID: String) -> Bool {
+        let metadata = readMetadata(for: songID)
+        migrateMislabeledDownloadedAudioIfNeeded(
+            for: songID,
+            expectedSourceURL: metadata?.audioURL
+        )
         let songFiles = files(for: songID)
         guard FileManager.default.fileExists(atPath: songFiles.audio.path) else { return false }
-        let metadata = readMetadata(for: songID)
         let metadataDuration = metadata?.duration ?? 0
         let expectedDuration = metadataDuration > 0 ? TimeInterval(metadataDuration) : nil
         guard Self.isValidDownloadedAudio(
@@ -1012,7 +1150,11 @@ final class DownloadManager: ObservableObject {
     }
 
     private nonisolated func readSourceURL(for songID: String) -> String? {
-        guard let data = try? Data(contentsOf: sourceURL(for: songID)),
+        readSourceURL(at: sourceURL(for: songID))
+    }
+
+    private nonisolated func readSourceURL(at sourceURL: URL) -> String? {
+        guard let data = try? Data(contentsOf: sourceURL),
               let rawValue = String(data: data, encoding: .utf8)
         else {
             return nil
@@ -1029,6 +1171,48 @@ final class DownloadManager: ObservableObject {
             atPath: source.path,
             contents: remoteURL.absoluteString.data(using: .utf8)
         )
+    }
+
+    /// Older builds stored every downloaded container as `main.mp3`. When the
+    /// saved source identifies another supported container, rename the file
+    /// before validation so Core Audio selects the correct decoder.
+    private nonisolated func migrateMislabeledDownloadedAudioIfNeeded(
+        for songID: String,
+        expectedSourceURL: URL?
+    ) {
+        let persistedSourceURL = readSourceURL(for: songID).flatMap(URL.init(string:))
+        guard let resolvedSourceURL = persistedSourceURL ?? expectedSourceURL,
+              AudioCacheStore.mainAudioExtension(for: resolvedSourceURL) != "mp3"
+        else { return }
+
+        let directory = downloadDirectory(for: songID)
+        let legacyAudio = directory.appendingPathComponent("main.mp3")
+        let resolvedAudio = Self.downloadedAudioURL(
+            in: directory,
+            sourceURL: resolvedSourceURL
+        )
+        let fm = FileManager.default
+        guard !fm.fileExists(atPath: resolvedAudio.path),
+              fm.fileExists(atPath: legacyAudio.path)
+        else { return }
+
+        do {
+            try fm.moveItem(at: legacyAudio, to: resolvedAudio)
+            guard AudioCacheStore.isPlayableAudioFile(at: resolvedAudio) else {
+                try? fm.moveItem(at: resolvedAudio, to: legacyAudio)
+                return
+            }
+            DebugLogger.log(
+                "Migrated downloaded audio container for \(songID) to .\(resolvedAudio.pathExtension)",
+                category: .cache
+            )
+        } catch {
+            if fm.fileExists(atPath: resolvedAudio.path),
+               !fm.fileExists(atPath: legacyAudio.path)
+            {
+                try? fm.moveItem(at: resolvedAudio, to: legacyAudio)
+            }
+        }
     }
 
     private func discardBrokenDownloadAndScheduleRepair(for song: Song, reason: String) {
@@ -1052,10 +1236,10 @@ final class DownloadManager: ObservableObject {
 
     private func removeBrokenAudioFiles(for song: Song) {
         cancelWork(songID: song.id)
-        let songFiles = files(for: song.id)
+        let songFiles = files(for: song.id, sourceURL: song.audioURL)
         validDownloadCache.removeValue(forKey: song.id)
         downloadedMetadata.removeValue(forKey: song.id)
-        try? FileManager.default.removeItem(at: songFiles.audio)
+        Self.removeDownloadedAudioFiles(in: songFiles.directory)
         try? FileManager.default.removeItem(at: songFiles.source)
         let storageKey = SongStorageKey.component(for: song.id)
         try? FileManager.default.removeItem(at: cacheDir.appendingPathComponent("\(storageKey).mp3"))
@@ -1162,21 +1346,24 @@ final class DownloadManager: ObservableObject {
         }
 
         guard let sourceValue = readLegacySourceURL(for: songID),
-              fm.fileExists(atPath: legacyAudio.path),
-              AudioCacheStore.isPlayableAudioFile(at: legacyAudio)
+              let remoteURL = URL(string: sourceValue),
+              fm.fileExists(atPath: legacyAudio.path)
         else {
             try? fm.removeItem(at: legacyAudio)
             try? fm.removeItem(at: legacySource)
             return
         }
 
-        let songFiles = files(for: songID)
+        let songFiles = files(for: songID, sourceURL: remoteURL)
         ensureSongDirectory(for: songID)
-        try? fm.removeItem(at: songFiles.audio)
+        Self.removeDownloadedAudioFiles(in: songFiles.directory)
         try? fm.removeItem(at: songFiles.source)
 
         do {
             try fm.moveItem(at: legacyAudio, to: songFiles.audio)
+            guard AudioCacheStore.isPlayableAudioFile(at: songFiles.audio) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
             fm.createFile(atPath: songFiles.source.path, contents: sourceValue.data(using: .utf8))
             try? fm.removeItem(at: legacySource)
             DebugLogger.log("Migrated legacy download into UUID folder for \(songID)", category: .cache)

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -237,7 +237,9 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
       title: title,
       duration: duration > 0 ? duration : canonical.duration,
       absolutePath: Self.preferredString(absolutePath, fallback: canonical.absolutePath),
-      cloudflareID: Self.preferredString(cloudflareID, fallback: canonical.cloudflareID),
+      cloudflareID: hasOwnArtwork
+        ? cloudflareID
+        : Self.preferredString(cloudflareID, fallback: canonical.cloudflareID),
       coverArt: hasUsableArtwork(coverArt) ? coverArt : canonical.coverArt,
       originalArtists: Self.preferredArtists(originalArtists, fallback: canonical.originalArtists),
       coverArtists: Self.preferredArtists(coverArtists, fallback: canonical.coverArtists),

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -212,22 +212,50 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   var downloadCoverImageURL: URL? {
     guard hasOwnArtwork else { return nil }
     return ArtworkURLBuilder.imageURL(
-      cloudflareID: cloudflareID,
-      path: coverArt?.absolutePath,
+      cloudflareID: artworkCloudflareID,
+      path: artworkPath,
       variant: .download
     )
   }
 
   private func imageURL(variant: ArtworkImageVariant) -> URL? {
     ArtworkURLBuilder.imageURL(
-      cloudflareID: cloudflareID,
-      path: coverArt?.absolutePath,
+      cloudflareID: artworkCloudflareID,
+      path: artworkPath,
       variant: variant
     ) ?? neuroFallbackImageURL
   }
 
   var hasOwnArtwork: Bool {
-    cloudflareID != nil || coverArt?.absolutePath != nil
+    artworkCloudflareID != nil || artworkPath != nil
+  }
+
+  func fillingMissingMetadata(from canonical: Song) -> Song {
+    guard id == canonical.id else { return self }
+    return Song(
+      id: id,
+      title: title,
+      duration: duration > 0 ? duration : canonical.duration,
+      absolutePath: Self.preferredString(absolutePath, fallback: canonical.absolutePath),
+      cloudflareID: Self.preferredString(cloudflareID, fallback: canonical.cloudflareID),
+      coverArt: hasUsableArtwork(coverArt) ? coverArt : canonical.coverArt,
+      originalArtists: Self.preferredArtists(originalArtists, fallback: canonical.originalArtists),
+      coverArtists: Self.preferredArtists(coverArtists, fallback: canonical.coverArtists),
+      userUploaded: userUploaded ?? canonical.userUploaded,
+      oss: Self.preferredString(oss, fallback: canonical.oss)
+    )
+  }
+
+  private var artworkCloudflareID: String? {
+    Self.preferredString(cloudflareID, fallback: coverArt?.cloudflareId)
+  }
+
+  private var artworkPath: String? {
+    Self.preferredString(coverArt?.absolutePath, fallback: nil)
+  }
+
+  private func hasUsableArtwork(_ media: Media?) -> Bool {
+    Self.preferredString(media?.cloudflareId, fallback: media?.absolutePath) != nil
   }
 
   private static let neuroArtistNames: Set<String> = ["Neuro", "Neuro v1", "Neuro v2"]
@@ -358,6 +386,16 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
       }
     }
     return nil
+  }
+
+  private static func preferredArtists(_ artists: [String]?, fallback: [String]?) -> [String]? {
+    guard let artists else { return fallback }
+    return artists.isEmpty ? fallback : artists
+  }
+
+  private static func preferredString(_ value: String?, fallback: String?) -> String? {
+    guard let value else { return fallback }
+    return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? fallback : value
   }
 
   private static func audioURL(from source: String) -> URL? {

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -1,4 +1,64 @@
 import Foundation
+import os
+
+actor UploadedSongMetadataCache {
+  private struct Entry: Sendable {
+    let songs: [Song]
+    let coveredIDs: Set<String>
+    let expiresAt: Date
+  }
+
+  private let lifetime: TimeInterval
+  private var cachedValue: Entry?
+  private var inFlight: (id: UUID, task: Task<[Song], Error>)?
+
+  init(lifetime: TimeInterval) {
+    self.lifetime = lifetime
+  }
+
+  func value(
+    for requestedIDs: Set<String>,
+    at now: Date = Date(),
+    loader: @escaping @Sendable () async throws -> [Song]
+  ) async throws -> [Song] {
+    guard !requestedIDs.isEmpty else { return [] }
+    if let cachedValue,
+      cachedValue.expiresAt > now,
+      requestedIDs.isSubset(of: cachedValue.coveredIDs)
+    {
+      return cachedValue.songs.filter { requestedIDs.contains($0.id) }
+    }
+
+    let request: (id: UUID, task: Task<[Song], Error>)
+    if let inFlight {
+      request = inFlight
+    } else {
+      let id = UUID()
+      let task = Task { try await loader() }
+      request = (id, task)
+      inFlight = request
+    }
+
+    do {
+      let songs = try await request.task.value
+      let coveredIDs = (cachedValue?.coveredIDs ?? []).union(requestedIDs)
+      cachedValue = Entry(
+        songs: songs,
+        coveredIDs: coveredIDs,
+        expiresAt: now.addingTimeInterval(lifetime)
+      )
+      if inFlight?.id == request.id {
+        inFlight = nil
+      }
+      return songs.filter { requestedIDs.contains($0.id) }
+    } catch {
+      if inFlight?.id == request.id {
+        inFlight = nil
+      }
+      throw error
+    }
+  }
+}
 
 nonisolated enum KaraokeAPIClient {
   enum APIError: Error {
@@ -8,6 +68,12 @@ nonisolated enum KaraokeAPIClient {
     case httpStatus(Int)
     case decodeFailed
   }
+
+  private static let favoriteMetadataLogger = Logger(
+    subsystem: "com.xiaoyuan151.Twinskaraoke",
+    category: "Network"
+  )
+  private static let uploadedSongMetadataCache = UploadedSongMetadataCache(lifetime: 60)
 
   static func trendingSongs(days: Int = 7, take: Int? = nil) async throws -> [Song] {
     try await trendingSongs(days: String(days), take: take)
@@ -93,18 +159,48 @@ nonisolated enum KaraokeAPIClient {
     )
     let data = try await data(for: request)
     let songs = SongPayloadDecoder.decodeSongs(from: data) ?? []
-    return await hydrateFavoriteSongs(songs)
+    return try await hydrateFavoriteSongs(songs)
   }
 
-  private static func hydrateFavoriteSongs(_ songs: [Song]) async -> [Song] {
+  private static func hydrateFavoriteSongs(_ songs: [Song]) async throws -> [Song] {
     guard !songs.isEmpty else { return songs }
-    async let canonicalResult = try? fetchSongs(ids: songs.map(\.id))
-    async let uploadedResult = try? uploadedSongs()
+    async let canonicalResult = favoriteCatalogMetadata(ids: songs.map(\.id))
+    async let uploadedResult = favoriteUploadedMetadata(ids: songs.map(\.id))
     return hydratingFavorites(
       songs,
-      canonicalSongs: await canonicalResult ?? [],
-      uploadedSongs: await uploadedResult ?? []
+      canonicalSongs: try await canonicalResult,
+      uploadedSongs: try await uploadedResult
     )
+  }
+
+  private static func favoriteCatalogMetadata(ids: [String]) async throws -> [Song] {
+    do {
+      return try await fetchSongs(ids: ids)
+    } catch {
+      try rethrowIfCancelled(error)
+      favoriteMetadataLogger.error(
+        "Favorite catalog metadata fetch failed: \(String(describing: error), privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  private static func favoriteUploadedMetadata(ids: [String]) async throws -> [Song] {
+    do {
+      return try await uploadedSongs(matching: ids)
+    } catch {
+      try rethrowIfCancelled(error)
+      favoriteMetadataLogger.error(
+        "Favorite uploaded metadata fetch failed: \(String(describing: error), privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  private static func rethrowIfCancelled(_ error: Error) throws {
+    if error is CancellationError || (error as? URLError)?.code == .cancelled {
+      throw error
+    }
   }
 
   static func hydratingFavorites(
@@ -125,7 +221,13 @@ nonisolated enum KaraokeAPIClient {
     }
   }
 
-  static func uploadedSongs() async throws -> [Song] {
+  static func uploadedSongs(matching ids: [String]) async throws -> [Song] {
+    try await uploadedSongMetadataCache.value(for: Set(ids)) {
+      try await fetchUploadedSongs()
+    }
+  }
+
+  private static func fetchUploadedSongs() async throws -> [Song] {
     let data = try await data(for: uploadedSongsRequest())
     guard let songs = SongPayloadDecoder.decodeSongs(from: data) else {
       throw APIError.decodeFailed

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -92,7 +92,51 @@ nonisolated enum KaraokeAPIClient {
       queryItems: [URLQueryItem(name: "type", value: "0")]
     )
     let data = try await data(for: request)
-    return SongPayloadDecoder.decodeSongs(from: data) ?? []
+    let songs = SongPayloadDecoder.decodeSongs(from: data) ?? []
+    return await hydrateFavoriteSongs(songs)
+  }
+
+  private static func hydrateFavoriteSongs(_ songs: [Song]) async -> [Song] {
+    guard !songs.isEmpty else { return songs }
+    async let canonicalResult = try? fetchSongs(ids: songs.map(\.id))
+    async let uploadedResult = try? uploadedSongs()
+    return hydratingFavorites(
+      songs,
+      canonicalSongs: await canonicalResult ?? [],
+      uploadedSongs: await uploadedResult ?? []
+    )
+  }
+
+  static func hydratingFavorites(
+    _ songs: [Song],
+    canonicalSongs: [Song],
+    uploadedSongs: [Song]
+  ) -> [Song] {
+    var canonicalByID = Dictionary(
+      canonicalSongs.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
+    for uploadedSong in uploadedSongs {
+      canonicalByID[uploadedSong.id] = uploadedSong
+    }
+    return songs.map { favorite in
+      guard let canonical = canonicalByID[favorite.id] else { return favorite }
+      return favorite.fillingMissingMetadata(from: canonical)
+    }
+  }
+
+  static func uploadedSongs() async throws -> [Song] {
+    let data = try await data(for: uploadedSongsRequest())
+    guard let songs = SongPayloadDecoder.decodeSongs(from: data) else {
+      throw APIError.decodeFailed
+    }
+    return songs
+  }
+
+  static func uploadedSongsRequest() throws -> URLRequest {
+    var request = try request(path: "/api/user/songs")
+    request.httpMethod = "GET"
+    return request
   }
 
   static func songSuggestions(take: Int) async throws -> [Song] {
@@ -128,6 +172,28 @@ nonisolated enum KaraokeAPIClient {
     if let songs = try? decode([Song].self, from: data), let song = songs.first { return song }
     if let song = songFromJSONObject(data) { return song }
     throw APIError.decodeFailed
+  }
+
+  static func fetchSongs(ids: [String]) async throws -> [Song] {
+    var seenIDs = Set<String>()
+    let uniqueIDs = ids.filter { id in
+      seenIDs.insert(id).inserted
+    }
+    guard !uniqueIDs.isEmpty else { return [] }
+    let request = try songsByIDsRequest(uniqueIDs)
+    let data = try await data(for: request)
+    guard let songs = SongPayloadDecoder.decodeSongs(from: data) else {
+      throw APIError.decodeFailed
+    }
+    return songs
+  }
+
+  static func songsByIDsRequest(_ ids: [String]) throws -> URLRequest {
+    var request = try request(path: "/api/songs/by-ids")
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONEncoder().encode(ids)
+    return request
   }
 
   private static func songFromJSONObject(_ data: Data) -> Song? {

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -62,6 +62,55 @@ struct DownloadManagerTests {
         )
     }
 
+    @Test("Persistent downloads preserve the remote audio container extension")
+    func persistentDownloadsPreserveRemoteContainerExtension() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        let m4aSource = try #require(URL(string: "https://storage.example.com/upload.m4a"))
+        let mp3Source = try #require(URL(string: "https://storage.example.com/catalog.mp3"))
+
+        #expect(
+            DownloadManager.downloadedAudioURL(in: directory, sourceURL: m4aSource)
+                .lastPathComponent == "main.m4a"
+        )
+        #expect(
+            DownloadManager.downloadedAudioURL(in: directory, sourceURL: mp3Source)
+                .lastPathComponent == "main.mp3"
+        )
+    }
+
+    @Test("Persistent download commit replaces legacy container variants")
+    func persistentDownloadCommitRemovesLegacyVariant() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceURL = try #require(URL(string: "https://storage.example.com/upload.m4a"))
+        let finalURL = DownloadManager.downloadedAudioURL(
+            in: directory,
+            sourceURL: sourceURL
+        )
+        let stagedURL = directory.appendingPathComponent("incoming.m4a")
+        let legacyURL = directory.appendingPathComponent("main.mp3")
+        try Data("new".utf8).write(to: stagedURL)
+        try Data("legacy".utf8).write(to: legacyURL)
+
+        try DownloadManager.commitDownloadedAudioFile(
+            at: stagedURL,
+            to: finalURL,
+            in: directory
+        )
+
+        #expect(try Data(contentsOf: finalURL) == Data("new".utf8))
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+        #expect(!FileManager.default.fileExists(atPath: stagedURL.path))
+    }
+
     @Test("Playback cache commit replaces its destination and removes legacy variants")
     func playbackCacheCommitReplacesDestinationSafely() throws {
         let songID = "cache-commit-\(UUID().uuidString)"

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -2,6 +2,19 @@ import Foundation
 import Testing
 @testable import Twinskaraoke
 
+private actor UploadedSongLoaderProbe {
+    private var calls = 0
+
+    func load() -> [Song] {
+        calls += 1
+        return []
+    }
+
+    func callCount() -> Int {
+        calls
+    }
+}
+
 @Suite("Song model")
 struct SongModelTests {
     private func useGlobalStorageRegion() {
@@ -421,6 +434,42 @@ struct SongModelTests {
         )
     }
 
+    @Test("Favorite nested artwork takes priority over canonical flat artwork")
+    func favoriteNestedArtworkTakesPriority() {
+        useGlobalStorageRegion()
+        let favorite = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 180,
+            absolutePath: "uploads/favorite.m4a",
+            cloudflareID: nil,
+            coverArt: Media(absolutePath: nil, cloudflareId: "favorite-nested-artwork-id"),
+            originalArtists: nil,
+            coverArtists: nil,
+            userUploaded: true
+        )
+        let canonical = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 180,
+            absolutePath: "uploads/favorite.m4a",
+            cloudflareID: "canonical-flat-artwork-id",
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: ["Uploader"],
+            userUploaded: true
+        )
+
+        let hydrated = favorite.fillingMissingMetadata(from: canonical)
+
+        #expect(hydrated.cloudflareID == nil)
+        #expect(hydrated.coverArt?.cloudflareId == "favorite-nested-artwork-id")
+        #expect(
+            hydrated.rowImageURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=180,quality=78,format=webp/favorite-nested-artwork-id/public"
+        )
+    }
+
     @Test("Bulk song metadata request posts the song ID array")
     func bulkSongMetadataRequestPostsIDs() throws {
         let request = try KaraokeAPIClient.songsByIDsRequest(["first-id", "second-id"])
@@ -438,6 +487,36 @@ struct SongModelTests {
 
         #expect(request.httpMethod == "GET")
         #expect(request.url?.path == "/api/user/songs")
+    }
+
+    @Test("Uploaded song metadata cache refreshes for new favorites and after expiration")
+    func uploadedSongMetadataCacheRefreshesWhenNeeded() async throws {
+        let cache = UploadedSongMetadataCache(lifetime: 60)
+        let loader = UploadedSongLoaderProbe()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        _ = try await cache.value(for: ["first"], at: start) { await loader.load() }
+        _ = try await cache.value(for: ["first"], at: start.addingTimeInterval(30)) {
+            await loader.load()
+        }
+        let callsForStableFavorites = await loader.callCount()
+
+        _ = try await cache.value(
+            for: ["first", "new-favorite"],
+            at: start.addingTimeInterval(31)
+        ) {
+            await loader.load()
+        }
+        let callsAfterAddingFavorite = await loader.callCount()
+
+        _ = try await cache.value(for: ["first"], at: start.addingTimeInterval(92)) {
+            await loader.load()
+        }
+        let callsAfterExpiration = await loader.callCount()
+
+        #expect(callsForStableFavorites == 1)
+        #expect(callsAfterAddingFavorite == 2)
+        #expect(callsAfterExpiration == 3)
     }
 
     @Test("Uploaded song metadata takes priority when hydrating favorites")

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -293,6 +293,30 @@ struct SongModelTests {
         #expect(song.cloudflareID == "artwork-id")
     }
 
+    @Test("Song uses artwork identifier nested inside coverArt")
+    func songUsesNestedCoverArtworkIdentifier() throws {
+        let json = """
+        {
+          "id": "favorite-upload",
+          "title": "Uploaded Favorite",
+          "duration": 180,
+          "absolutePath": "uploads/favorite.m4a",
+          "coverArt": {"cloudflareId": "nested-artwork-id"},
+          "userUploaded": true
+        }
+        """.data(using: .utf8)!
+
+        let song = try JSONDecoder().decode(Song.self, from: json)
+
+        #expect(song.cloudflareID == nil)
+        #expect(song.coverArt?.cloudflareId == "nested-artwork-id")
+        #expect(song.hasOwnArtwork)
+        #expect(
+            song.imageURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=480,quality=85,format=webp/nested-artwork-id/public"
+        )
+    }
+
     @Test("Favorite responses decode uploaded songs wrapped in an envelope")
     func favoriteEnvelopeDecodesUploadedSong() throws {
         let json = """
@@ -320,6 +344,184 @@ struct SongModelTests {
             songs.first?.audioURL?.absoluteString
                 == "https://storage.neurokaraoke.com/uploads/Uploaded%20Favorite.mp3"
         )
+    }
+
+    @Test("Uploaded favorites fill missing artwork from canonical song metadata")
+    func uploadedFavoriteFillsMissingArtwork() throws {
+        let favorite = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 0,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: [],
+            coverArtists: nil,
+            userUploaded: true,
+            oss: nil
+        )
+        let canonical = Song(
+            id: "favorite-upload",
+            title: "Canonical Title",
+            duration: 213,
+            absolutePath: "uploads/Uploaded Favorite.m4a",
+            cloudflareID: "uploaded-artwork-id",
+            coverArt: Media(absolutePath: "/uploads/cover.jpg"),
+            originalArtists: ["Original Artist"],
+            coverArtists: ["Uploader"],
+            userUploaded: true,
+            oss: "uploads/fallback.m4a"
+        )
+
+        let hydrated = favorite.fillingMissingMetadata(from: canonical)
+
+        #expect(hydrated.title == "Uploaded Favorite")
+        #expect(hydrated.duration == 213)
+        #expect(hydrated.absolutePath == "uploads/Uploaded Favorite.m4a")
+        #expect(hydrated.cloudflareID == "uploaded-artwork-id")
+        #expect(hydrated.coverArt?.absolutePath == "/uploads/cover.jpg")
+        #expect(hydrated.originalArtists == ["Original Artist"])
+        #expect(hydrated.coverArtists == ["Uploader"])
+        #expect(hydrated.oss == "uploads/fallback.m4a")
+        #expect(hydrated.hasOwnArtwork)
+    }
+
+    @Test("Favorite metadata hydrates when the upload flag is omitted")
+    func favoriteMetadataHydratesWithoutUploadFlag() {
+        let favorite = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 180,
+            absolutePath: "uploads/favorite.m4a",
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: nil,
+            userUploaded: nil
+        )
+        let canonical = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 180,
+            absolutePath: "uploads/favorite.m4a",
+            cloudflareID: nil,
+            coverArt: Media(absolutePath: nil, cloudflareId: "canonical-artwork-id"),
+            originalArtists: nil,
+            coverArtists: ["Uploader"],
+            userUploaded: true
+        )
+
+        let hydrated = favorite.fillingMissingMetadata(from: canonical)
+
+        #expect(hydrated.userUploaded == true)
+        #expect(hydrated.coverArt?.cloudflareId == "canonical-artwork-id")
+        #expect(
+            hydrated.rowImageURL?.absoluteString
+                == "https://images.neurokaraoke.com/cdn-cgi/image/width=180,quality=78,format=webp/canonical-artwork-id/public"
+        )
+    }
+
+    @Test("Bulk song metadata request posts the song ID array")
+    func bulkSongMetadataRequestPostsIDs() throws {
+        let request = try KaraokeAPIClient.songsByIDsRequest(["first-id", "second-id"])
+        let body = try #require(request.httpBody)
+
+        #expect(request.httpMethod == "POST")
+        #expect(request.url?.path == "/api/songs/by-ids")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(try JSONDecoder().decode([String].self, from: body) == ["first-id", "second-id"])
+    }
+
+    @Test("Uploaded song metadata request uses the authenticated uploads route")
+    func uploadedSongMetadataRequestUsesUploadsRoute() throws {
+        let request = try KaraokeAPIClient.uploadedSongsRequest()
+
+        #expect(request.httpMethod == "GET")
+        #expect(request.url?.path == "/api/user/songs")
+    }
+
+    @Test("Uploaded song metadata takes priority when hydrating favorites")
+    func uploadedSongMetadataTakesPriorityForFavorites() throws {
+        let favorite = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 180,
+            absolutePath: "uploads/favorite.m4a",
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: nil,
+            userUploaded: nil
+        )
+        let catalogVersion = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 180,
+            absolutePath: "uploads/favorite.m4a",
+            cloudflareID: "catalog-artwork-id",
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: nil,
+            userUploaded: nil
+        )
+        let uploadedVersion = Song(
+            id: "favorite-upload",
+            title: "Uploaded Favorite",
+            duration: 180,
+            absolutePath: "uploads/favorite.m4a",
+            cloudflareID: "uploaded-artwork-id",
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: ["Uploader"],
+            userUploaded: true
+        )
+
+        let hydrated = try #require(
+            KaraokeAPIClient.hydratingFavorites(
+                [favorite],
+                canonicalSongs: [catalogVersion],
+                uploadedSongs: [uploadedVersion]
+            ).first
+        )
+
+        #expect(hydrated.cloudflareID == "uploaded-artwork-id")
+        #expect(hydrated.userUploaded == true)
+        #expect(hydrated.coverArtists == ["Uploader"])
+    }
+
+    @Test("Favorite metadata keeps values already supplied by favorites endpoint")
+    func favoriteMetadataKeepsExistingValues() {
+        let favorite = Song(
+            id: "favorite-upload",
+            title: "Favorite Title",
+            duration: 180,
+            absolutePath: "favorites/audio.m4a",
+            cloudflareID: "favorite-artwork-id",
+            coverArt: Media(absolutePath: "/favorites/cover.jpg"),
+            originalArtists: ["Favorite Artist"],
+            coverArtists: ["Favorite Uploader"],
+            userUploaded: true,
+            oss: "favorites/fallback.m4a"
+        )
+        let canonical = Song(
+            id: "favorite-upload",
+            title: "Canonical Title",
+            duration: 213,
+            absolutePath: "canonical/audio.m4a",
+            cloudflareID: "canonical-artwork-id",
+            coverArt: Media(absolutePath: "/canonical/cover.jpg"),
+            originalArtists: ["Canonical Artist"],
+            coverArtists: ["Canonical Uploader"],
+            userUploaded: true,
+            oss: "canonical/fallback.m4a"
+        )
+
+        let hydrated = favorite.fillingMissingMetadata(from: canonical)
+
+        #expect(hydrated == favorite)
+        #expect(hydrated.cloudflareID == "favorite-artwork-id")
+        #expect(hydrated.coverArt?.absolutePath == "/favorites/cover.jpg")
+        #expect(hydrated.originalArtists == ["Favorite Artist"])
     }
 
     @Test("Playlist detail skips malformed songs instead of failing the playlist")


### PR DESCRIPTION
## Summary

- decode artwork identifiers nested in uploaded-song cover metadata
- hydrate favorite songs with both catalog metadata and the authenticated uploaded-songs endpoint
- prefer uploaded-song metadata for matching private song IDs while preserving complete favorite data
- add regression coverage for wrapped favorite responses, missing upload flags, request construction, metadata priority, and malformed playlist entries

## Root cause

The favorites response can omit artwork metadata for uploaded songs. The catalog bulk lookup does not reliably return private uploads, while `/api/user/songs` contains the correct cover metadata used by the uploaded-songs view. Without that source, favorites fell through to placeholder artwork that could appear unrelated to the song.

## Impact

Uploaded songs added to Favorites now retain the same cover artwork shown in uploaded-song and regular playlist views.

## Validation

- full unit test suite passed
- focused song model tests passed
- unsigned Release simulator build succeeded
- verified on a physical device

## Summary by Sourcery

Improve favorites handling so uploaded songs retain correct artwork and metadata by hydrating favorites with data from both catalog and authenticated uploaded-song endpoints and refining artwork resolution in the Song model.

Bug Fixes:
- Ensure uploaded favorites use nested cover artwork identifiers and correct artwork URLs.
- Hydrate favorite songs with canonical and uploaded-song metadata to restore missing artwork and flags while preserving existing favorite data.

Enhancements:
- Add metadata hydration logic that prefers uploaded-song metadata over catalog entries when resolving favorites.
- Introduce helpers for selecting preferred string and artist metadata and for validating usable artwork fields.

Tests:
- Extend song model tests to cover nested cover artwork, metadata hydration behavior, artwork priority, missing upload flags, malformed playlist entries, and request construction for bulk and uploaded-song metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Favorite songs now display more complete metadata, including titles, durations, artwork, artists, and upload details.
  * Existing favorite information is preserved while missing details are filled in automatically.
  * Uploaded song information takes precedence when it provides more accurate artwork or ownership details.
  * Artwork URLs and ownership indicators now work reliably with nested artwork metadata.
  * Added support for retrieving metadata for multiple songs at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->