### PR TITLE
Add uploaded songs to Library

### DIFF
--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+private struct DownloadedSongRowIdentity: Hashable {
+    let songID: String
+    let duration: Int
+}
+
 struct DownloadedSongsView: View {
     @StateObject private var downloads = DownloadManager.shared
     @StateObject private var recentlyPlayed = RecentlyPlayedStore.shared
@@ -37,7 +42,12 @@ struct DownloadedSongsView: View {
                         LazyVStack(spacing: 0) {
                             ForEach(Array(localSongs.enumerated()), id: \.element.id) { idx, song in
                                 SongRow(song: song, size: .regular)
-                                    .id(song.duration)
+                                    .id(
+                                        DownloadedSongRowIdentity(
+                                            songID: song.id,
+                                            duration: song.duration
+                                        )
+                                    )
                                     .padding(.horizontal)
                                     .padding(.vertical, 8)
                                     .contentShape(Rectangle())

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -6,6 +6,7 @@ struct DownloadedSongsView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var localSongs: [Song] = []
     @State private var refreshTask: Task<Void, Never>?
+    @State private var durationTask: Task<Void, Never>?
 
     @State private var showsCollapsedTitle = false
     @State private var showRemoveAllConfirmation = false
@@ -36,6 +37,7 @@ struct DownloadedSongsView: View {
                         LazyVStack(spacing: 0) {
                             ForEach(Array(localSongs.enumerated()), id: \.element.id) { idx, song in
                                 SongRow(song: song, size: .regular)
+                                    .id(song.duration)
                                     .padding(.horizontal)
                                     .padding(.vertical, 8)
                                     .contentShape(Rectangle())
@@ -100,6 +102,8 @@ struct DownloadedSongsView: View {
         .onDisappear {
             refreshTask?.cancel()
             refreshTask = nil
+            durationTask?.cancel()
+            durationTask = nil
             ArtworkPrefetcher.shared.cancel(reason: "downloaded songs")
         }
     }
@@ -189,13 +193,41 @@ struct DownloadedSongsView: View {
     private func refresh() {
         let cached = recentlyPlayed.playlists.flatMap { $0.songListDTOs ?? [] }
         let songs = downloads.downloadedSongs(knownSongs: cached)
+        let localAudioURLs = songs.reduce(into: [String: URL]()) { urls, song in
+            let url = downloads.localURL(for: song.id)
+            guard FileManager.default.fileExists(atPath: url.path) else { return }
+            urls[song.id] = url
+        }
         ArtworkPrefetcher.shared.prefetchSongs(
             Array(songs.prefix(18)),
             limit: 18,
             reason: "downloaded songs",
             variant: .row
         )
-        if reduceMotion {
+        replaceLocalSongs(songs, animated: true)
+
+        durationTask?.cancel()
+        durationTask = Task { @MainActor in
+            let songsWithDurations = await UploadedSongDurationResolver.shared
+                .fillingMissingDurations(
+                    in: songs,
+                    localAudioURLs: localAudioURLs
+                )
+            guard !Task.isCancelled else { return }
+
+            let resolvedCount = songsWithDurations.filter { $0.duration > 0 }.count
+            let missingCount = songsWithDurations.count - resolvedCount
+            DebugLogger.log(
+                "Downloaded duration hydration: resolved=\(resolvedCount), missing=\(missingCount)",
+                category: .cache
+            )
+            replaceLocalSongs(songsWithDurations, animated: false)
+            durationTask = nil
+        }
+    }
+
+    private func replaceLocalSongs(_ songs: [Song], animated: Bool) {
+        if reduceMotion || !animated {
             localSongs = songs
         } else {
             withAnimation(.spring(response: 0.34, dampingFraction: 0.84)) {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -185,6 +185,11 @@ struct LibraryView: View {
                 title: "Downloaded",
                 destination: DownloadedSongsView()
             )
+            libraryLink(
+                icon: "arrow.up.circle",
+                title: "Uploaded",
+                destination: UploadedSongsView()
+            )
             libraryLink(icon: "paintpalette", title: "Art Gallery", destination: ArtGalleryView())
             libraryLink(icon: "play.rectangle", title: "Video Gallery", destination: VideoGalleryView())
             libraryLink(

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -216,6 +216,7 @@ struct PlaylistDetailView: View {
                                 }
                         }
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
+                        .id("\(song.id):\(song.duration)")
                         .accessibilityHint("Starts playback.")
                         .accessibilityIdentifier("PlaylistDetail.song.\(song.id)")
                         Divider().padding(.leading, rowHorizontalPadding + 60)

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -67,7 +67,7 @@ struct UploadedSongsView: View {
         }
         .refreshable {
             AppHaptic.selection.play()
-            viewModel.refresh()
+            await viewModel.refresh()
         }
         .task {
             viewModel.loadIfNeeded()
@@ -142,7 +142,9 @@ struct UploadedSongsView: View {
 
             if viewModel.loadFailed {
                 MusicEmptyActionButton(title: "Try Again") {
-                    viewModel.refresh()
+                    Task {
+                        await viewModel.refresh()
+                    }
                 }
             }
         }

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+struct UploadedSongsView: View {
+    @StateObject private var viewModel = UploadedSongsViewModel()
+    @Environment(\.appReduceMotion) private var reduceMotion
+
+    private var listAnimation: Animation? {
+        reduceMotion ? nil : AppMotion.spring(response: 0.34, dampingFraction: 0.84)
+    }
+
+    var body: some View {
+        let songs = viewModel.displayedSongs
+        let isSearching = !viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        List {
+            if viewModel.isLoading, songs.isEmpty {
+                loadingRow
+            } else if songs.isEmpty {
+                emptyState(isSearching: isSearching)
+                    .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            } else {
+                Section {
+                    actionButtons(songs: songs)
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                }
+
+                Section {
+                    ForEach(songs) { song in
+                        Button {
+                            play(song, context: songs)
+                        } label: {
+                            SongRow(song: song, size: .regular, showsArtwork: true)
+                                .padding(.vertical, 6)
+                                .contentShape(Rectangle())
+                                .songRowAccessibility(song: song) {
+                                    play(song, context: songs)
+                                }
+                        }
+                        .id(song.id)
+                        .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
+                        .accessibilityHint("Starts playback.")
+                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                        .listRowBackground(Color.clear)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .smoothScrolling()
+        .musicScreenBackground()
+        .navigationTitle("Uploaded")
+        .navigationBarTitleDisplayMode(.large)
+        .searchable(
+            text: $viewModel.searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Search Uploads"
+        )
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                sortMenu
+            }
+        }
+        .refreshable {
+            AppHaptic.selection.play()
+            viewModel.refresh()
+        }
+        .task {
+            viewModel.loadIfNeeded()
+        }
+        .onChange(of: Array(songs.prefix(18)).map(\.id)) { _, _ in
+            ArtworkPrefetcher.shared.prefetchSongs(
+                Array(songs.prefix(18)),
+                limit: 18,
+                reason: "uploaded visible songs",
+                variant: .row
+            )
+        }
+        .onDisappear {
+            ArtworkPrefetcher.shared.cancel(reason: "uploaded visible songs")
+        }
+        .animation(listAnimation, value: songs.map(\.id))
+        .animation(listAnimation, value: viewModel.sort)
+        .accessibilityIdentifier("Library.UploadedSongs")
+    }
+
+    private func play(_ song: Song, context: [Song]) {
+        AppHaptic.selection.play()
+        AudioPlayerManager.shared.play(song: song, context: context)
+    }
+
+    private var sortMenu: some View {
+        Menu {
+            ForEach(LibrarySongSort.allCases) { sort in
+                Button {
+                    AppHaptic.selection.play()
+                    viewModel.sort = sort
+                } label: {
+                    Label(sort.title, systemImage: viewModel.sort == sort ? "checkmark" : sort.symbol)
+                }
+            }
+        } label: {
+            Label("Sort Uploaded Songs", systemImage: "arrow.up.arrow.down")
+                .font(.headline)
+                .foregroundStyle(Color.appAccent)
+                .frame(width: 44, height: 44)
+                .labelStyle(.iconOnly)
+                .contentShape(Circle())
+        }
+        .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.72, haptic: .selection))
+    }
+
+    private func actionButtons(songs: [Song]) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                if let first = songs.first {
+                    AudioPlayerManager.shared.playInOrder(song: first, context: songs)
+                }
+            } label: {
+                LibraryActionButtonLabel(symbol: "play.fill", text: "Play")
+            }
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .accessibilityLabel("Play uploaded songs")
+
+            Button {
+                AudioPlayerManager.shared.playShuffled(from: songs)
+            } label: {
+                LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
+            }
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .accessibilityLabel("Shuffle uploaded songs")
+        }
+    }
+
+    private func emptyState(isSearching: Bool) -> some View {
+        VStack(spacing: AM.Spacing.l) {
+            MusicEmptyState(title: emptyTitle(isSearching: isSearching), message: emptyMessage(isSearching: isSearching))
+
+            if viewModel.loadFailed {
+                MusicEmptyActionButton(title: "Try Again") {
+                    viewModel.refresh()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 360)
+    }
+
+    private func emptyTitle(isSearching: Bool) -> String {
+        if isSearching { return "No Results" }
+        if viewModel.requiresSignIn { return "Sign In Required" }
+        if viewModel.loadFailed { return "Couldn't Load Uploads" }
+        return "No Uploads"
+    }
+
+    private func emptyMessage(isSearching: Bool) -> String {
+        if isSearching { return "Try another song or artist." }
+        if viewModel.requiresSignIn {
+            return "Sign in from Account to see the songs you've uploaded, then pull to refresh."
+        }
+        if viewModel.loadFailed { return "Check your connection and try again." }
+        return "Songs uploaded through Twins Karaoke will appear here."
+    }
+
+    private var loadingRow: some View {
+        CenteredLoadingView()
+            .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+    }
+}

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -40,7 +40,7 @@ struct UploadedSongsView: View {
                                     play(song, context: songs)
                                 }
                         }
-                        .id(song.id)
+                        .id("\(song.id):\(song.duration)")
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
                         .accessibilityHint("Starts playback.")
                         .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))

--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -41,10 +41,38 @@ class PlaylistDetailViewModel: ObservableObject {
         isLoading = true
         loadTask = Task { [weak self] in
             do {
-                let loadedSongs = try await KaraokeAPIClient.playlistSongs(id: playlistID)
+                async let remoteSongs = KaraokeAPIClient.playlistSongs(id: playlistID)
+
+                if let fallback, !fallback.isEmpty {
+                    let fallbackWithDurations = await UploadedSongDurationResolver.shared
+                        .fillingMissingDurations(in: fallback)
+                    guard !Task.isCancelled else { return }
+                    self?.applyLoadedSongs(
+                        fallbackWithDurations,
+                        playlistID: playlistID,
+                        requestFailed: false
+                    )
+                }
+
+                let loadedSongs = try await remoteSongs
                 guard !Task.isCancelled else { return }
                 self?.applyLoadedSongs(
                     loadedSongs,
+                    playlistID: playlistID,
+                    requestFailed: false
+                )
+
+                let songsWithDurations = await UploadedSongDurationResolver.shared
+                    .fillingMissingDurations(in: loadedSongs)
+                guard !Task.isCancelled else { return }
+                DebugLogger.log(
+                    "Playlist duration hydration \(playlistID): resolved="
+                        + "\(songsWithDurations.filter { $0.duration > 0 }.count), "
+                        + "missing=\(songsWithDurations.filter { $0.duration <= 0 }.count)",
+                    category: .cache
+                )
+                self?.applyLoadedSongs(
+                    songsWithDurations,
                     playlistID: playlistID,
                     requestFailed: false
                 )

--- a/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Combine
 import Foundation
 
@@ -51,12 +52,20 @@ final class UploadedSongsViewModel: ObservableObject {
         loadTask = Task { [weak self] in
             do {
                 let loadedSongs = try await KaraokeAPIClient.uploadedSongs()
+                let uniqueSongs = Self.removingDuplicateSongs(loadedSongs)
                 try Task.checkCancellation()
                 guard let self, generation == requestGeneration else { return }
 
-                songs = Self.removingDuplicateSongs(loadedSongs)
+                songs = uniqueSongs
                 hasLoaded = true
                 isLoading = false
+                rebuildDisplayedSongs()
+
+                let songsWithDurations = await Self.fillingMissingDurations(in: uniqueSongs)
+                try Task.checkCancellation()
+                guard generation == requestGeneration else { return }
+
+                songs = songsWithDurations
                 loadTask = nil
                 rebuildDisplayedSongs()
             } catch {
@@ -103,6 +112,80 @@ final class UploadedSongsViewModel: ObservableObject {
     nonisolated static func removingDuplicateSongs(_ songs: [Song]) -> [Song] {
         var seenIDs = Set<String>()
         return songs.filter { seenIDs.insert($0.id).inserted }
+    }
+
+    nonisolated static func applyingResolvedDurations(
+        _ durations: [String: Int],
+        to songs: [Song]
+    ) -> [Song] {
+        songs.map { song in
+            guard song.duration <= 0,
+                  let duration = durations[song.id],
+                  duration > 0 else {
+                return song
+            }
+            return Song(
+                id: song.id,
+                title: song.title,
+                duration: duration,
+                absolutePath: song.absolutePath,
+                cloudflareID: song.cloudflareID,
+                coverArt: song.coverArt,
+                originalArtists: song.originalArtists,
+                coverArtists: song.coverArtists,
+                userUploaded: song.userUploaded,
+                oss: song.oss
+            )
+        }
+    }
+
+    private nonisolated static func fillingMissingDurations(in songs: [Song]) async -> [Song] {
+        let songsNeedingDuration = songs.filter { $0.duration <= 0 && $0.audioURL != nil }
+        guard !songsNeedingDuration.isEmpty else { return songs }
+
+        let maximumConcurrentLookups = 4
+        var resolvedDurations: [String: Int] = [:]
+
+        for batchStart in stride(
+            from: 0,
+            to: songsNeedingDuration.count,
+            by: maximumConcurrentLookups
+        ) {
+            guard !Task.isCancelled else { return songs }
+            let batchEnd = min(
+                batchStart + maximumConcurrentLookups,
+                songsNeedingDuration.count
+            )
+            let batch = songsNeedingDuration[batchStart..<batchEnd]
+
+            await withTaskGroup(of: (String, Int?).self) { group in
+                for song in batch {
+                    group.addTask {
+                        (song.id, await resolvedDuration(for: song))
+                    }
+                }
+                for await (songID, duration) in group {
+                    if let duration {
+                        resolvedDurations[songID] = duration
+                    }
+                }
+            }
+        }
+
+        return applyingResolvedDurations(resolvedDurations, to: songs)
+    }
+
+    private nonisolated static func resolvedDuration(for song: Song) async -> Int? {
+        guard !Task.isCancelled, let audioURL = song.audioURL else { return nil }
+        do {
+            let duration = try await AVURLAsset(url: audioURL).load(.duration)
+            try Task.checkCancellation()
+            let seconds = duration.seconds
+            guard seconds.isFinite, seconds > 0 else { return nil }
+            return max(1, Int(seconds.rounded()))
+        } catch {
+            return nil
+        }
     }
 
     nonisolated static func isCancellationError(_ error: Error) -> Bool {

--- a/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
@@ -17,19 +17,24 @@ final class UploadedSongsViewModel: ObservableObject {
 
     private var hasLoaded = false
     private var loadTask: Task<Void, Never>?
+    private var requestGeneration = 0
 
     func loadIfNeeded() {
         guard !hasLoaded else { return }
-        load()
+        startLoad()
     }
 
-    func refresh() {
-        load()
+    func refresh() async {
+        startLoad()
+        let task = loadTask
+        await task?.value
     }
 
-    private func load() {
+    private func startLoad() {
         loadTask?.cancel()
         loadTask = nil
+        requestGeneration &+= 1
+        let generation = requestGeneration
         loadFailed = false
 
         guard CredentialStore.token != nil else {
@@ -42,22 +47,21 @@ final class UploadedSongsViewModel: ObservableObject {
         }
 
         requiresSignIn = false
-        isLoading = songs.isEmpty
+        isLoading = true
         loadTask = Task { [weak self] in
             do {
                 let loadedSongs = try await KaraokeAPIClient.uploadedSongs()
                 try Task.checkCancellation()
-                guard let self else { return }
+                guard let self, generation == requestGeneration else { return }
 
                 songs = Self.removingDuplicateSongs(loadedSongs)
                 hasLoaded = true
                 isLoading = false
                 loadTask = nil
                 rebuildDisplayedSongs()
-            } catch is CancellationError {
-                // A newer refresh owns the loading state.
             } catch {
-                guard let self else { return }
+                guard !Self.isCancellationError(error) else { return }
+                guard let self, generation == requestGeneration else { return }
                 DebugLogger.log(
                     "Uploaded songs fetch failed: \(error.localizedDescription)",
                     category: .network
@@ -99,6 +103,10 @@ final class UploadedSongsViewModel: ObservableObject {
     nonisolated static func removingDuplicateSongs(_ songs: [Song]) -> [Song] {
         var seenIDs = Set<String>()
         return songs.filter { seenIDs.insert($0.id).inserted }
+    }
+
+    nonisolated static func isCancellationError(_ error: Error) -> Bool {
+        error is CancellationError || (error as? URLError)?.code == .cancelled
     }
 
     deinit {

--- a/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
@@ -61,7 +61,8 @@ final class UploadedSongsViewModel: ObservableObject {
                 isLoading = false
                 rebuildDisplayedSongs()
 
-                let songsWithDurations = await Self.fillingMissingDurations(in: uniqueSongs)
+                let songsWithDurations = await UploadedSongDurationResolver.shared
+                    .fillingMissingDurations(in: uniqueSongs)
                 try Task.checkCancellation()
                 guard generation == requestGeneration else { return }
 
@@ -114,6 +115,78 @@ final class UploadedSongsViewModel: ObservableObject {
         return songs.filter { seenIDs.insert($0.id).inserted }
     }
 
+    nonisolated static func isCancellationError(_ error: Error) -> Bool {
+        error is CancellationError || (error as? URLError)?.code == .cancelled
+    }
+
+    deinit {
+        loadTask?.cancel()
+    }
+}
+
+actor UploadedSongDurationResolver {
+    static let shared = UploadedSongDurationResolver()
+
+    private var resolvedDurations: [String: Int] = [:]
+    private var lookupTasks: [String: Task<Int?, Never>] = [:]
+
+    func fillingMissingDurations(
+        in songs: [Song],
+        localAudioURLs: [String: URL] = [:]
+    ) async -> [Song] {
+        for song in songs where song.duration > 0 {
+            resolvedDurations[song.id] = song.duration
+        }
+
+        let songsNeedingDuration = songs.filter {
+            $0.duration <= 0
+                && resolvedDurations[$0.id] == nil
+                && Self.preferredAudioURL(
+                    for: $0,
+                    localAudioURLs: localAudioURLs
+                ) != nil
+        }
+        let songIDs = Set(songs.map(\.id))
+        var durationsForSongs = resolvedDurations.filter { songIDs.contains($0.key) }
+        guard !songsNeedingDuration.isEmpty else {
+            return Self.applyingResolvedDurations(durationsForSongs, to: songs)
+        }
+
+        let maximumConcurrentLookups = 4
+
+        for batchStart in stride(
+            from: 0,
+            to: songsNeedingDuration.count,
+            by: maximumConcurrentLookups
+        ) {
+            guard !Task.isCancelled else { return songs }
+            let batchEnd = min(
+                batchStart + maximumConcurrentLookups,
+                songsNeedingDuration.count
+            )
+            let batch = songsNeedingDuration[batchStart..<batchEnd]
+
+            await withTaskGroup(of: (String, Int?).self) { group in
+                for song in batch {
+                    group.addTask { [self] in
+                        let sourceURL = Self.preferredAudioURL(
+                            for: song,
+                            localAudioURLs: localAudioURLs
+                        )
+                        return (song.id, await duration(for: song, sourceURL: sourceURL))
+                    }
+                }
+                for await (songID, duration) in group {
+                    if let duration {
+                        durationsForSongs[songID] = duration
+                    }
+                }
+            }
+        }
+
+        return Self.applyingResolvedDurations(durationsForSongs, to: songs)
+    }
+
     nonisolated static func applyingResolvedDurations(
         _ durations: [String: Int],
         to songs: [Song]
@@ -139,44 +212,35 @@ final class UploadedSongsViewModel: ObservableObject {
         }
     }
 
-    private nonisolated static func fillingMissingDurations(in songs: [Song]) async -> [Song] {
-        let songsNeedingDuration = songs.filter { $0.duration <= 0 && $0.audioURL != nil }
-        guard !songsNeedingDuration.isEmpty else { return songs }
-
-        let maximumConcurrentLookups = 4
-        var resolvedDurations: [String: Int] = [:]
-
-        for batchStart in stride(
-            from: 0,
-            to: songsNeedingDuration.count,
-            by: maximumConcurrentLookups
-        ) {
-            guard !Task.isCancelled else { return songs }
-            let batchEnd = min(
-                batchStart + maximumConcurrentLookups,
-                songsNeedingDuration.count
-            )
-            let batch = songsNeedingDuration[batchStart..<batchEnd]
-
-            await withTaskGroup(of: (String, Int?).self) { group in
-                for song in batch {
-                    group.addTask {
-                        (song.id, await resolvedDuration(for: song))
-                    }
-                }
-                for await (songID, duration) in group {
-                    if let duration {
-                        resolvedDurations[songID] = duration
-                    }
-                }
-            }
-        }
-
-        return applyingResolvedDurations(resolvedDurations, to: songs)
+    nonisolated static func preferredAudioURL(
+        for song: Song,
+        localAudioURLs: [String: URL]
+    ) -> URL? {
+        localAudioURLs[song.id] ?? song.audioURL
     }
 
-    private nonisolated static func resolvedDuration(for song: Song) async -> Int? {
-        guard !Task.isCancelled, let audioURL = song.audioURL else { return nil }
+    private func duration(for song: Song, sourceURL: URL?) async -> Int? {
+        if let resolvedDuration = resolvedDurations[song.id] {
+            return resolvedDuration
+        }
+        if let lookupTask = lookupTasks[song.id] {
+            return await lookupTask.value
+        }
+
+        let lookupTask = Task {
+            await Self.loadDuration(from: sourceURL)
+        }
+        lookupTasks[song.id] = lookupTask
+        let duration = await lookupTask.value
+        lookupTasks[song.id] = nil
+        if let duration {
+            resolvedDurations[song.id] = duration
+        }
+        return duration
+    }
+
+    private nonisolated static func loadDuration(from audioURL: URL?) async -> Int? {
+        guard !Task.isCancelled, let audioURL else { return nil }
         do {
             let duration = try await AVURLAsset(url: audioURL).load(.duration)
             try Task.checkCancellation()
@@ -188,11 +252,4 @@ final class UploadedSongsViewModel: ObservableObject {
         }
     }
 
-    nonisolated static func isCancellationError(_ error: Error) -> Bool {
-        error is CancellationError || (error as? URLError)?.code == .cancelled
-    }
-
-    deinit {
-        loadTask?.cancel()
-    }
 }

--- a/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
@@ -1,0 +1,107 @@
+import Combine
+import Foundation
+
+@MainActor
+final class UploadedSongsViewModel: ObservableObject {
+    @Published private(set) var songs: [Song] = []
+    @Published private(set) var displayedSongs: [Song] = []
+    @Published private(set) var isLoading = false
+    @Published private(set) var requiresSignIn = false
+    @Published private(set) var loadFailed = false
+    @Published var sort: LibrarySongSort = .recentlyAdded {
+        didSet { rebuildDisplayedSongs() }
+    }
+    @Published var searchText = "" {
+        didSet { rebuildDisplayedSongs() }
+    }
+
+    private var hasLoaded = false
+    private var loadTask: Task<Void, Never>?
+
+    func loadIfNeeded() {
+        guard !hasLoaded else { return }
+        load()
+    }
+
+    func refresh() {
+        load()
+    }
+
+    private func load() {
+        loadTask?.cancel()
+        loadTask = nil
+        loadFailed = false
+
+        guard CredentialStore.token != nil else {
+            requiresSignIn = true
+            isLoading = false
+            hasLoaded = true
+            songs = []
+            rebuildDisplayedSongs()
+            return
+        }
+
+        requiresSignIn = false
+        isLoading = songs.isEmpty
+        loadTask = Task { [weak self] in
+            do {
+                let loadedSongs = try await KaraokeAPIClient.uploadedSongs()
+                try Task.checkCancellation()
+                guard let self else { return }
+
+                songs = Self.removingDuplicateSongs(loadedSongs)
+                hasLoaded = true
+                isLoading = false
+                loadTask = nil
+                rebuildDisplayedSongs()
+            } catch is CancellationError {
+                // A newer refresh owns the loading state.
+            } catch {
+                guard let self else { return }
+                DebugLogger.log(
+                    "Uploaded songs fetch failed: \(error.localizedDescription)",
+                    category: .network
+                )
+                hasLoaded = true
+                isLoading = false
+                loadFailed = true
+                loadTask = nil
+            }
+        }
+    }
+
+    private func rebuildDisplayedSongs() {
+        let sorted: [Song] = switch sort {
+        case .recentlyAdded:
+            songs
+        case .title:
+            songs.sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+        case .artist:
+            songs.sorted {
+                $0.displayArtist.localizedStandardCompare($1.displayArtist) == .orderedAscending
+            }
+        case .duration:
+            songs.sorted { $0.duration < $1.duration }
+        }
+
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            displayedSongs = sorted
+            return
+        }
+        displayedSongs = sorted.filter { song in
+            song.title.localizedCaseInsensitiveContains(query)
+                || song.displayArtist.localizedCaseInsensitiveContains(query)
+                || song.displayTitle.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    nonisolated static func removingDuplicateSongs(_ songs: [Song]) -> [Song] {
+        var seenIDs = Set<String>()
+        return songs.filter { seenIDs.insert($0.id).inserted }
+    }
+
+    deinit {
+        loadTask?.cancel()
+    }
+}

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -223,15 +223,11 @@ nonisolated enum KaraokeAPIClient {
 
   static func uploadedSongs(matching ids: [String]) async throws -> [Song] {
     try await uploadedSongMetadataCache.value(for: Set(ids)) {
-      try await fetchUploadedSongs()
+      try await uploadedSongs()
     }
   }
 
   static func uploadedSongs() async throws -> [Song] {
-    try await fetchUploadedSongs()
-  }
-
-  private static func fetchUploadedSongs() async throws -> [Song] {
     let data = try await data(for: uploadedSongsRequest())
     guard let songs = SongPayloadDecoder.decodeSongs(from: data) else {
       throw APIError.decodeFailed

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -141,7 +141,29 @@ nonisolated enum KaraokeAPIClient {
     if id == Playlist.favoritesID {
       return try await favoriteSongs()
     }
-    return try await playlistDetail(id: id).songListDTOs
+    let songs = try await playlistDetail(id: id).songListDTOs
+    return try await hydratePlaylistUploadedSongs(songs)
+  }
+
+  private static func hydratePlaylistUploadedSongs(_ songs: [Song]) async throws -> [Song] {
+    guard CredentialStore.token != nil else { return songs }
+    let missingDurationIDs = songs.filter { $0.duration <= 0 }.map(\.id)
+    guard !missingDurationIDs.isEmpty else { return songs }
+
+    do {
+      let uploadedMetadata = try await uploadedSongs(matching: missingDurationIDs)
+      return hydratingFavorites(
+        songs,
+        canonicalSongs: [],
+        uploadedSongs: uploadedMetadata
+      )
+    } catch {
+      try rethrowIfCancelled(error)
+      favoriteMetadataLogger.error(
+        "Playlist uploaded metadata fetch failed: \(String(describing: error), privacy: .public)"
+      )
+      return songs
+    }
   }
 
   static func playlistSongCount(id: String) async throws -> Int? {

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -227,6 +227,10 @@ nonisolated enum KaraokeAPIClient {
     }
   }
 
+  static func uploadedSongs() async throws -> [Song] {
+    try await fetchUploadedSongs()
+  }
+
   private static func fetchUploadedSongs() async throws -> [Song] {
     let data = try await data(for: uploadedSongsRequest())
     guard let songs = SongPayloadDecoder.decodeSongs(from: data) else {

--- a/TwinskaraokeTests/UploadedSongsViewModelTests.swift
+++ b/TwinskaraokeTests/UploadedSongsViewModelTests.swift
@@ -23,11 +23,27 @@ struct UploadedSongsViewModelTests {
         #expect(!UploadedSongsViewModel.isCancellationError(URLError(.timedOut)))
     }
 
-    private func song(id: String, title: String) -> Song {
+    @Test("Resolved durations fill only missing values")
+    func resolvedDurationsFillOnlyMissingValues() {
+        let missingDuration = song(id: "missing", title: "Missing", duration: 0)
+        let existingDuration = song(id: "existing", title: "Existing", duration: 90)
+
+        let songs = UploadedSongsViewModel.applyingResolvedDurations(
+            ["missing": 214, "existing": 999],
+            to: [missingDuration, existingDuration]
+        )
+
+        #expect(songs.map(\.id) == ["missing", "existing"])
+        #expect(songs.map(\.duration) == [214, 90])
+        #expect(songs[0].absolutePath == missingDuration.absolutePath)
+        #expect(songs[0].userUploaded == true)
+    }
+
+    private func song(id: String, title: String, duration: Int = 120) -> Song {
         Song(
             id: id,
             title: title,
-            duration: 120,
+            duration: duration,
             absolutePath: "uploads/\(id).m4a",
             cloudflareID: nil,
             coverArt: nil,

--- a/TwinskaraokeTests/UploadedSongsViewModelTests.swift
+++ b/TwinskaraokeTests/UploadedSongsViewModelTests.swift
@@ -28,7 +28,7 @@ struct UploadedSongsViewModelTests {
         let missingDuration = song(id: "missing", title: "Missing", duration: 0)
         let existingDuration = song(id: "existing", title: "Existing", duration: 90)
 
-        let songs = UploadedSongsViewModel.applyingResolvedDurations(
+        let songs = UploadedSongDurationResolver.applyingResolvedDurations(
             ["missing": 214, "existing": 999],
             to: [missingDuration, existingDuration]
         )
@@ -39,12 +39,47 @@ struct UploadedSongsViewModelTests {
         #expect(songs[0].userUploaded == true)
     }
 
-    private func song(id: String, title: String, duration: Int = 120) -> Song {
+    @Test("Cached durations apply to sparse playlist songs")
+    func cachedDurationsApplyToSparsePlaylistSongs() async {
+        let resolver = UploadedSongDurationResolver()
+        let completeSong = song(id: "upload", title: "Upload", duration: 214)
+        _ = await resolver.fillingMissingDurations(in: [completeSong])
+
+        let sparsePlaylistSong = song(
+            id: "upload",
+            title: "Upload",
+            duration: 0,
+            includesAudioPath: false
+        )
+        let songs = await resolver.fillingMissingDurations(in: [sparsePlaylistSong])
+
+        #expect(songs.first?.duration == 214)
+    }
+
+    @Test("Local downloaded audio is preferred for duration lookup")
+    func localDownloadedAudioIsPreferredForDurationLookup() {
+        let uploadedSong = song(id: "upload", title: "Upload", duration: 0)
+        let localURL = URL(fileURLWithPath: "/tmp/upload.m4a")
+
+        let sourceURL = UploadedSongDurationResolver.preferredAudioURL(
+            for: uploadedSong,
+            localAudioURLs: [uploadedSong.id: localURL]
+        )
+
+        #expect(sourceURL == localURL)
+    }
+
+    private func song(
+        id: String,
+        title: String,
+        duration: Int = 120,
+        includesAudioPath: Bool = true
+    ) -> Song {
         Song(
             id: id,
             title: title,
             duration: duration,
-            absolutePath: "uploads/\(id).m4a",
+            absolutePath: includesAudioPath ? "uploads/\(id).m4a" : nil,
             cloudflareID: nil,
             coverArt: nil,
             originalArtists: nil,

--- a/TwinskaraokeTests/UploadedSongsViewModelTests.swift
+++ b/TwinskaraokeTests/UploadedSongsViewModelTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Uploaded songs")
+struct UploadedSongsViewModelTests {
+    @Test("Duplicate uploaded songs retain API order")
+    func duplicateSongsRetainAPIOrder() {
+        let first = song(id: "first", title: "First")
+        let duplicate = song(id: "first", title: "Duplicate")
+        let second = song(id: "second", title: "Second")
+
+        let songs = UploadedSongsViewModel.removingDuplicateSongs([first, duplicate, second])
+
+        #expect(songs.map(\.id) == ["first", "second"])
+        #expect(songs.first?.title == "First")
+    }
+
+    private func song(id: String, title: String) -> Song {
+        Song(
+            id: id,
+            title: title,
+            duration: 120,
+            absolutePath: "uploads/\(id).m4a",
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: nil,
+            userUploaded: true
+        )
+    }
+}

--- a/TwinskaraokeTests/UploadedSongsViewModelTests.swift
+++ b/TwinskaraokeTests/UploadedSongsViewModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Twinskaraoke
 
@@ -13,6 +14,13 @@ struct UploadedSongsViewModelTests {
 
         #expect(songs.map(\.id) == ["first", "second"])
         #expect(songs.first?.title == "First")
+    }
+
+    @Test("Task and URL cancellations use the cancellation path")
+    func cancellationErrorsUseCancellationPath() {
+        #expect(UploadedSongsViewModel.isCancellationError(CancellationError()))
+        #expect(UploadedSongsViewModel.isCancellationError(URLError(.cancelled)))
+        #expect(!UploadedSongsViewModel.isCancellationError(URLError(.timedOut)))
     }
 
     private func song(id: String, title: String) -> Song {


### PR DESCRIPTION
## Summary

- add an Uploaded entry directly below Downloaded in Library
- load the signed-in user's uploaded songs from the authenticated uploads route
- support search, sorting, play, shuffle, artwork prefetching, and standard song actions
- provide loading, empty, sign-in, retry, and pull-to-refresh states
- preserve API order while removing duplicate song IDs

## Why

Uploaded songs were accessible through playlists and favorites but had no dedicated destination in the app. This gives them a predictable home in Library and uses their canonical metadata for artwork and playback.

## Validation

- Release simulator build
- 62 unit tests across 7 suites
- live device verification of the Uploaded screen, artwork, and playback

## Summary by Sourcery

Add a dedicated Uploaded songs section to the Library that surfaces a signed-in user’s uploaded tracks with full browsing and playback support.

New Features:
- Introduce an Uploaded entry in the Library navigation that opens an Uploaded songs screen.
- Provide an Uploaded songs view that supports search, sorting, play, shuffle, artwork prefetching, pull-to-refresh, and standard song interactions.

Enhancements:
- Expose a high-level KaraokeAPIClient.uploadedSongs API for fetching a user’s uploaded tracks while de-duplicating by song ID in a stable order.

Tests:
- Add unit coverage for the duplicate-upload handling logic to ensure API order is preserved when removing duplicate song IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Uploaded” section to the Library with a dedicated Uploaded Songs screen.
  * Users can browse, search, sort, play, shuffle, and refresh uploaded songs, with clear loading, empty, error, and sign-in-required states.
* **Bug Fixes**
  * Improved song duration handling so newly resolved timings reflect correctly in the UI for uploaded, downloaded, and playlist songs.
* **Tests**
  * Expanded Uploaded Songs view model tests to cover duplicates, cancellation, duration resolution, and source preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->