### PR TITLE
Fix missing mini player bar title and artwork

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -523,14 +523,15 @@ private struct PopupContent: View {
     var body: some View {
         FullScreenPlayerView()
             .environmentObject(AudioPlayerManager.shared)
-            .background {
-                PopupMetadataPreferences(
+            // The popup bar only picks up title/image modifiers applied directly to the
+            // popup content view; hosting them in a background child leaves the bar blank.
+            .modifier(
+                PopupTitleModifier(
                     title: popupState.title,
-                    subtitle: popupState.subtitle,
-                    artwork: popupState.artwork
+                    subtitle: popupState.subtitle
                 )
-                .equatable()
-            }
+            )
+            .modifier(PopupImageModifier(artwork: popupState.artwork))
             .popupBarButtons {
                 PopupBarTrailingItems(
                     isPlaying: popupState.isPlaying,
@@ -552,28 +553,21 @@ private struct PopupContent: View {
     }
 }
 
-private struct PopupMetadataPreferences: View, Equatable {
+private struct PopupTitleModifier: ViewModifier, Equatable {
     let title: String
     let subtitle: String
-    let artwork: UIImage?
 
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.title == rhs.title
-            && lhs.subtitle == rhs.subtitle
-            && lhs.artwork === rhs.artwork
-    }
-
-    var body: some View {
-        Color.clear
-            .frame(width: 1, height: 1)
-            .accessibilityHidden(true)
-            .popupTitle(verbatim: title, subtitle: subtitle)
-            .modifier(PopupMetadataImageModifier(artwork: artwork))
+    func body(content: Content) -> some View {
+        content.popupTitle(verbatim: title, subtitle: subtitle)
     }
 }
 
-private struct PopupMetadataImageModifier: ViewModifier {
+private struct PopupImageModifier: ViewModifier, Equatable {
     let artwork: UIImage?
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.artwork === rhs.artwork
+    }
 
     func body(content: Content) -> some View {
         if let artwork {

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -995,9 +995,10 @@ struct FullScreenPlayerView: View {
         guard let url else { return }
         coverArtSaveStatus = .saving
         URLSession.shared.dataTask(with: url) { data, _, error in
-            DispatchQueue.main.async {
-                #if canImport(UIKit)
-                    if let data, let image = UIImage(data: data) {
+            #if canImport(UIKit)
+                // Decode off-main; a full-HD decode on the main queue can hitch the player UI.
+                if let data, let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
                         ImageSaver.shared.save(image: image) { result in
                             DispatchQueue.main.async {
                                 switch result {
@@ -1009,9 +1010,11 @@ struct FullScreenPlayerView: View {
                                 resetCoverArtSaveStatusLater()
                             }
                         }
-                        return
                     }
-                #endif
+                    return
+                }
+            #endif
+            DispatchQueue.main.async {
                 coverArtSaveStatus = .failed(error?.localizedDescription ?? "Couldn't save")
                 resetCoverArtSaveStatusLater()
             }
@@ -1071,6 +1074,8 @@ struct FullScreenPlayerView: View {
                   let artist = coverArt["artist"] as? [String: Any]
             else { return }
             DispatchQueue.main.async {
+                // A slow response for a previous song must not label the current one.
+                guard audioManager.currentSong?.id == songID else { return }
                 coverArtArtistName = artist["name"] as? String
                 coverArtArtistLink = artist["socialLink"] as? String
             }

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -13325,6 +13325,9 @@
     "Play random songs" : {
 
     },
+    "Play uploaded songs" : {
+
+    },
     "Playback" : {
       "localizations" : {
         "de" : {
@@ -17267,6 +17270,9 @@
         }
       }
     },
+    "Search Uploads" : {
+
+    },
     "Searching songs" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -18419,6 +18425,9 @@
     "Shuffle random songs" : {
 
     },
+    "Shuffle uploaded songs" : {
+
+    },
     "Sign In" : {
       "localizations" : {
         "de" : {
@@ -19518,6 +19527,9 @@
           }
         }
       }
+    },
+    "Sort Uploaded Songs" : {
+
     },
     "Source Code" : {
       "localizations" : {
@@ -21523,6 +21535,9 @@
           }
         }
       }
+    },
+    "Uploaded" : {
+
     },
     "Use the playback controls below." : {
       "localizations" : {


### PR DESCRIPTION
## Problem
Since e86e101 ("Improve UI responsiveness and camera stability"), the floating mini player bar rendered without the song title, artist, and cover artwork. The play/next buttons still worked.

## Cause
That commit moved the `popupTitle`/`popupImage` modifiers off the popup content view onto a hidden 1x1 view inside a `.background { }` wrapper. LNPopupUI only picks up these modifiers when they are applied directly to the popup content view, so the bar lost its metadata. The `popupBarButtons` modifier stayed attached directly, which is why the buttons kept working.

## Fix
- Restore direct `popupTitle`/`popupImage` application via equatable view modifiers, preserving the original optimization (popup content is not re-evaluated when metadata is unchanged).
- Harden the full-screen player cover art paths: guard the cover-art artist credit lookup against stale responses after fast song skips, and decode the full-HD image off the main queue before saving to Photos.
- Include newly extracted uploaded-library localization keys.

## Testing
- Verified on a physical iPhone (iOS 26): mini player bar shows cover, title, and artist again; expanding/collapsing and bar buttons work.
- Full unit test suite passes; app builds warning-free.

## Summary by Sourcery

Restore popup metadata modifiers on the mini player content view so the floating bar shows title and artwork again, and harden full-screen cover art handling and saving.

Bug Fixes:
- Fix mini player bar missing song title, subtitle, and artwork by reattaching popup metadata directly to the popup content view.
- Prevent stale cover art artist responses from incorrectly labeling the currently playing song.
- Avoid UI hitches when saving full-HD cover art by decoding the image off the main thread before writing to Photos.

Chores:
- Add newly extracted localization keys for uploaded-library strings.