### PR TITLE
Defer artwork state writes out of view updates

### DIFF
--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -70,7 +70,7 @@ struct RemoteArtworkImage: View {
                         .frame(width: displaySize.width, height: displaySize.height)
                         .clipped()
                         .onAppear {
-                            markRendered(url)
+                            deferMarkRendered(url)
                         }
                 } placeholder: {
                     Color.clear
@@ -79,8 +79,10 @@ struct RemoteArtworkImage: View {
                     markFinishedAfterFailure(for: url, error: error)
                 }
                 .onSuccess { _, _, cacheType in
-                    ArtworkLoadMetrics.shared.record(cacheType: cacheType)
-                    markRendered(url)
+                    // Memory-cache hits complete synchronously while SwiftUI is still
+                    // evaluating this view; writing @State here trips "Modifying state
+                    // during view update". Defer the write to the next runloop turn.
+                    deferMarkRendered(url, cacheType: cacheType)
                 }
                 .transition(
                     shouldAnimateLoad
@@ -88,6 +90,15 @@ struct RemoteArtworkImage: View {
                         : .identity
                 )
             }
+        }
+    }
+
+    private func deferMarkRendered(_ loadedURL: URL, cacheType: SDImageCacheType? = nil) {
+        DispatchQueue.main.async {
+            if let cacheType {
+                ArtworkLoadMetrics.shared.record(cacheType: cacheType)
+            }
+            markRendered(loadedURL)
         }
     }
 


### PR DESCRIPTION
## Problem
Live-debug console output showed constant bursts of `Modifying state during view update, this will cause undefined behavior.` while scrolling lists and switching songs — up to hundreds per minute during normal browsing.

## Cause
SDWebImage delivers memory-cache hits synchronously, so `WebImage`'s `onSuccess` (and the rendered-state bookkeeping in `RemoteArtworkImage`) ran while SwiftUI was still evaluating the view and wrote `@State` mid-update. The burst sizes matched visible row counts and the artwork surfaces rebuilt on song change (log showed `memory=150` cache hits during the largest storm).

## Fix
Defer the render bookkeeping (`markRendered` and the cache metrics recording) to the next runloop turn via a single `deferMarkRendered` helper used by both the `onSuccess` callback and the image `onAppear` path.

## Testing
- Verified on a physical iPhone (iOS 26): browsing, scrolling, and rapid song switching no longer emit the warning.
- App builds warning-free; unit test suite passes.

## Summary by Sourcery

Defer artwork rendering state updates and cache metric recording to avoid modifying SwiftUI view state during view evaluation.

Bug Fixes:
- Prevent SwiftUI warnings and potential undefined behavior caused by updating artwork render state during view updates.

Enhancements:
- Centralize deferred artwork render bookkeeping in a helper that records cache metrics and marks images as rendered after the next runloop turn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote artwork image loading stability by deferring rendering state updates.
  * Prevented potential view evaluation issues while recording image cache metrics and marking artwork as rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->