### PR TITLE
Refine app-wide motion and animation consistency

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -256,7 +256,7 @@ private struct PopupHostView: View {
     }
 
     private var shellAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.24, dampingFraction: 0.88)
+        reduceMotion ? nil : AppMotion.snap
     }
 
     private var shellTransition: AnyTransition {

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -106,9 +106,9 @@ struct AddToPlaylistSheet: View {
             .sheet(isPresented: $showCreatePlaylist) {
                 CreatePlaylistSheet()
             }
-            .animation(reduceMotion ? nil : AppMotion.spring(response: 0.2, dampingFraction: 0.9), value: inFlight)
-            .animation(reduceMotion ? nil : AppMotion.spring(response: 0.3, dampingFraction: 0.82), value: added)
-            .animation(reduceMotion ? nil : AppMotion.spring(response: 0.2, dampingFraction: 0.9), value: failed)
+            .animation(reduceMotion ? nil : AppMotion.snap, value: inFlight)
+            .animation(reduceMotion ? nil : AppMotion.quick, value: added)
+            .animation(reduceMotion ? nil : AppMotion.snap, value: failed)
         }
     }
 

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -385,6 +385,8 @@ struct MusicSkeletonLine: View {
 struct MusicEmptyState: View {
     let title: String
     let message: String
+    @Environment(\.appReduceMotion) private var reduceMotion
+    @State private var appeared = false
 
     var body: some View {
         VStack(spacing: 15) {
@@ -407,6 +409,18 @@ struct MusicEmptyState: View {
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 24)
         .padding(.vertical, 10)
+        .opacity(appeared || reduceMotion ? 1 : 0)
+        .scaleEffect(appeared || reduceMotion ? 1 : 0.97)
+        .onAppear {
+            guard !appeared else { return }
+            guard !reduceMotion else {
+                appeared = true
+                return
+            }
+            withAnimation(AppMotion.standard) {
+                appeared = true
+            }
+        }
     }
 }
 

--- a/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
+++ b/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
@@ -127,7 +127,7 @@ struct AppleMusicProgressBar: View {
     }
 
     private var scrubAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.3, dampingFraction: 0.85)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     private var scrubBubbleTransition: AnyTransition {

--- a/Twinskaraoke/Components/Player/KaraokeRightDock.swift
+++ b/Twinskaraoke/Components/Player/KaraokeRightDock.swift
@@ -151,7 +151,7 @@ struct KaraokeRightDock: View {
     }
 
     private var dockAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.4, dampingFraction: 0.85)
+        reduceMotion ? nil : AppMotion.standard
     }
 
     private var sliderTransition: AnyTransition {

--- a/Twinskaraoke/Components/Player/PlayerArtworkView.swift
+++ b/Twinskaraoke/Components/Player/PlayerArtworkView.swift
@@ -68,11 +68,11 @@ struct PlayerArtworkView: View {
     }
 
     private var artworkPlaybackAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.55, dampingFraction: 0.86)
+        reduceMotion ? nil : AppMotion.gentle
     }
 
     private var bufferingAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.25, dampingFraction: 0.86)
+        reduceMotion ? nil : AppMotion.snap
     }
 
     private var bufferingTransition: AnyTransition {

--- a/Twinskaraoke/Components/Player/VerticalKaraokeLevel.swift
+++ b/Twinskaraoke/Components/Player/VerticalKaraokeLevel.swift
@@ -32,6 +32,6 @@ struct VerticalKaraokeLevel: View {
     }
 
     private var levelAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.85)
+        reduceMotion ? nil : AppMotion.quick
     }
 }

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -61,6 +61,7 @@ struct SongRow: View {
     @ObservedObject private var playback = PlaybackRowState.shared
     @StateObject private var downloadState: SongDownloadRowState
     @State private var showAddToPlaylist = false
+    @Environment(\.appReduceMotion) private var reduceMotion
 
     init(
         song: Song,
@@ -105,6 +106,7 @@ struct SongRow: View {
                         .foregroundStyle(.primary)
                 }
             }
+            .animation(statusAnimation, value: isCurrentSong)
             VStack(alignment: .leading, spacing: 2) {
                 Text(song.title)
                     .font(size.titleFont)
@@ -116,15 +118,20 @@ struct SongRow: View {
                     .lineLimit(1)
             }
             Spacer()
-            if downloadState.status.isDownloaded {
-                Image(systemName: "arrow.down.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel("Downloaded")
-            } else if downloadState.status.isDownloading {
-                ProgressView()
-                    .controlSize(.small)
+            Group {
+                if downloadState.status.isDownloaded {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Downloaded")
+                        .transition(statusTransition)
+                } else if downloadState.status.isDownloading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .transition(statusTransition)
+                }
             }
+            .animation(statusAnimation, value: downloadState.status)
             if !song.durationText.isEmpty {
                 Text(song.durationText)
                     .font(.caption.monospacedDigit())
@@ -164,6 +171,14 @@ struct SongRow: View {
         SongActionsMenuItems(song: song) {
             showAddToPlaylist = true
         }
+    }
+
+    private var statusAnimation: Animation? {
+        reduceMotion ? nil : AppMotion.quick
+    }
+
+    private var statusTransition: AnyTransition {
+        reduceMotion ? .opacity : .scale(scale: 0.6).combined(with: .opacity)
     }
 }
 

--- a/Twinskaraoke/Features/Account/LoginSheet.swift
+++ b/Twinskaraoke/Features/Account/LoginSheet.swift
@@ -58,11 +58,11 @@ struct LoginSheet: View {
                 if !message.isEmpty { AppHaptic.error.play() }
             }
             .animation(
-                reduceMotion ? nil : AppMotion.spring(response: 0.34, dampingFraction: 0.86),
+                reduceMotion ? nil : AppMotion.quick,
                 value: auth.errorMessage ?? ""
             )
             .animation(
-                reduceMotion ? nil : AppMotion.spring(response: 0.32, dampingFraction: 0.84),
+                reduceMotion ? nil : AppMotion.quick,
                 value: auth.isLoading
             )
         }
@@ -179,7 +179,7 @@ struct LoginSheet: View {
                 )
         }
         .animation(
-            reduceMotion ? nil : AppMotion.spring(response: 0.28, dampingFraction: 0.86),
+            reduceMotion ? nil : AppMotion.snap,
             value: focus
         )
     }

--- a/Twinskaraoke/Features/Account/ProfileDetailView.swift
+++ b/Twinskaraoke/Features/Account/ProfileDetailView.swift
@@ -115,7 +115,7 @@ struct ProfileDetailView: View {
     }
 
     private var profileAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.36, dampingFraction: 0.82)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     private var bottomTransition: AnyTransition {
@@ -369,7 +369,7 @@ private struct AchievementMeter: View {
             animatedProgress = newValue
             return
         }
-        withOptionalAnimation(AppMotion.spring(response: 0.7, dampingFraction: 0.86)) {
+        withOptionalAnimation(AppMotion.gentle) {
             animatedProgress = newValue
         }
     }

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -382,11 +382,11 @@ struct QRApproveView: View {
     }
 
     private var phaseAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.36, dampingFraction: 0.84)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     private var permissionAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.2, dampingFraction: 0.9)
+        reduceMotion ? nil : AppMotion.snap
     }
 }
 

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -562,7 +562,7 @@ private struct SettingsOverviewCard: View {
     }
 
     private var overviewAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.34, dampingFraction: 0.7)
+        reduceMotion ? nil : AppMotion.playful
     }
 }
 

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -33,7 +33,7 @@ struct BrowseSongCollectionView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
         .animation(
-            reduceMotion ? nil : AppMotion.spring(response: 0.34, dampingFraction: 0.84),
+            reduceMotion ? nil : AppMotion.quick,
             value: showsCollapsedTitle
         )
     }

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -8,7 +8,7 @@ struct HomeView: View {
     @State private var artworkPrefetchTracker = ArtworkPrefetchTracker()
 
     private var loadingAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.38, dampingFraction: 0.84)
+        reduceMotion ? nil : AppMotion.standard
     }
 
 
@@ -70,23 +70,29 @@ struct HomeView: View {
     private var compactHomeOverview: some View {
         VStack(alignment: .leading, spacing: 18) {
             topPicksShelf()
+                .shelfEntrance(index: 0)
 
             if !recentlyPlayed.playlists.isEmpty {
                 PlaylistCarousel(title: "Recently Played", playlists: recentlyPlayed.playlists)
+                    .shelfEntrance(index: 1)
             }
 
             if !viewModel.suggestions.isEmpty {
                 HomeSongSection(title: "Made for You", songs: viewModel.suggestions)
+                    .shelfEntrance(index: 2)
             }
 
             latestSingleSection()
+                .shelfEntrance(index: 3)
 
             if !viewModel.newReleases.isEmpty {
                 HomeSongSection(title: "New Releases", songs: viewModel.newReleases)
+                    .shelfEntrance(index: 4)
             }
 
             if !viewModel.trending.isEmpty {
                 HomeSongSection(title: "More to Explore", songs: viewModel.trending)
+                    .shelfEntrance(index: 5)
             }
         }
     }
@@ -100,6 +106,7 @@ struct HomeView: View {
                 secondarySong: homeSecondarySong,
                 secondaryContext: viewModel.suggestions.isEmpty ? viewModel.trending : viewModel.suggestions
             )
+            .shelfEntrance(index: 0)
 
             HStack(alignment: .top, spacing: AM.Spacing.xxl) {
                 VStack(alignment: .leading, spacing: AM.Spacing.xxl) {
@@ -119,6 +126,7 @@ struct HomeView: View {
                 }
                 .frame(minWidth: 520, maxWidth: .infinity, alignment: .topLeading)
                 .layoutPriority(1)
+                .shelfEntrance(index: 1)
 
                 VStack(alignment: .leading, spacing: AM.Spacing.xxl) {
                     latestSingleSection(horizontalPadding: 0)
@@ -135,6 +143,7 @@ struct HomeView: View {
                     width: AM.Layout.wideInspectorWidth,
                     alignment: .topLeading
                 )
+                .shelfEntrance(index: 2)
             }
         }
         .frame(maxWidth: AM.Layout.wideContentMaxWidth, alignment: .topLeading)
@@ -214,5 +223,38 @@ struct HomeView: View {
                 horizontalPadding: horizontalPadding
             )
         }
+    }
+}
+
+/// Fades and rises a Home shelf into place once, staggered by its position,
+/// when the loaded content first replaces the skeleton.
+private struct ShelfEntranceModifier: ViewModifier {
+    let index: Int
+    @Environment(\.appReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(appeared || reduceMotion ? 1 : 0)
+            .offset(y: appeared || reduceMotion ? 0 : 14)
+            .onAppear {
+                guard !appeared else { return }
+                guard !reduceMotion else {
+                    appeared = true
+                    return
+                }
+                withAnimation(
+                    AppMotion.standard
+                        .delay(Double(index) * 0.05)
+                ) {
+                    appeared = true
+                }
+            }
+    }
+}
+
+private extension View {
+    func shelfEntrance(index: Int) -> some View {
+        modifier(ShelfEntranceModifier(index: index))
     }
 }

--- a/Twinskaraoke/Features/Home/NewView.swift
+++ b/Twinskaraoke/Features/Home/NewView.swift
@@ -8,7 +8,7 @@ struct NewView: View {
     @State private var artworkPrefetchTracker = ArtworkPrefetchTracker()
 
     private var loadingAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.38, dampingFraction: 0.84)
+        reduceMotion ? nil : AppMotion.standard
     }
 
     var body: some View {

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
@@ -67,7 +67,7 @@ struct ArtDetailView: View {
                 appeared = true
                 return
             }
-            withAnimation(.spring(response: 0.48, dampingFraction: 0.82)) {
+            withAnimation(AppMotion.standard) {
                 appeared = true
             }
         }

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -385,7 +385,7 @@ private struct ArtistDetailStateView: View {
                 isPulsing = false
                 return
             }
-            withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) {
+            withAnimation(AppMotion.standard) {
                 hasAppeared = true
             }
             withAnimation(.easeInOut(duration: 1.45).repeatForever(autoreverses: true)) {

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -121,9 +121,9 @@ struct CreatePlaylistSheet: View {
             .onAppear {
                 focusedField = .name
             }
-            .animation(reduceMotion ? nil : .spring(response: 0.34, dampingFraction: 0.84), value: isSaving)
+            .animation(reduceMotion ? nil : AppMotion.quick, value: isSaving)
             .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: errorMessage)
-            .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: trimmedName)
+            .animation(reduceMotion ? nil : AppMotion.quick, value: trimmedName)
         }
     }
 

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -240,7 +240,7 @@ struct DownloadedSongsView: View {
         if reduceMotion || !animated {
             localSongs = songs
         } else {
-            withAnimation(.spring(response: 0.34, dampingFraction: 0.84)) {
+            withAnimation(AppMotion.quick) {
                 localSongs = songs
             }
         }
@@ -345,7 +345,7 @@ private struct DownloadedEmptyStateView: View {
                 hasAppeared = true
                 isPulsing = false
             } else {
-                withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) {
+                withAnimation(AppMotion.standard) {
                     hasAppeared = true
                 }
                 withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -40,11 +40,11 @@ struct PlaylistDetailView: View {
             }
         }
         .animation(
-            reduceMotion ? nil : AppMotion.spring(response: 0.34, dampingFraction: 0.84),
+            reduceMotion ? nil : AppMotion.quick,
             value: showsCollapsedTitle
         )
         .animation(
-            reduceMotion ? nil : .spring(response: 0.34, dampingFraction: 0.84),
+            reduceMotion ? nil : AppMotion.quick,
             value: loader.isLoading
         )
         .scrollIndicators(.hidden)

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -5,7 +5,7 @@ struct UploadedSongsView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
 
     private var listAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.spring(response: 0.34, dampingFraction: 0.84)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     var body: some View {

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -257,7 +257,7 @@ private struct VideoGalleryStateView: View {
                 isPulsing = false
                 return
             }
-            withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) {
+            withAnimation(AppMotion.standard) {
                 hasAppeared = true
             }
             withAnimation(.easeInOut(duration: 1.45).repeatForever(autoreverses: true)) {
@@ -504,7 +504,7 @@ struct VideoPlayerScreen: View {
                 appeared = true
                 return
             }
-            withAnimation(.spring(response: 0.44, dampingFraction: 0.84)) {
+            withAnimation(AppMotion.standard) {
                 appeared = true
             }
         }

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -567,12 +567,21 @@ struct FullScreenPlayerView: View {
                     AppHaptic.success.play()
                 }
             } label: {
-                Image(systemName: favorites.isFavorite(song.id) ? "star.fill" : "star")
-                    .font(.title3)
-                    .foregroundStyle(playerTitleIconColor(isActive: favorites.isFavorite(song.id)))
-                    .frame(width: 44, height: 44)
-                    .background(playerTitleButtonBackground, in: Circle())
-                    .overlay(playerTitleButtonBorder)
+                Group {
+                    let isFav = favorites.isFavorite(song.id)
+                    if #available(iOS 17.0, *), !reduceMotion {
+                        Image(systemName: isFav ? "star.fill" : "star")
+                            .contentTransition(.symbolEffect(.replace))
+                            .symbolEffect(.bounce, value: isFav)
+                    } else {
+                        Image(systemName: isFav ? "star.fill" : "star")
+                    }
+                }
+                .font(.title3)
+                .foregroundStyle(playerTitleIconColor(isActive: favorites.isFavorite(song.id)))
+                .frame(width: 44, height: 44)
+                .background(playerTitleButtonBackground, in: Circle())
+                .overlay(playerTitleButtonBorder)
             }
             .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6))
             .accessibilityLabel(
@@ -682,6 +691,7 @@ struct FullScreenPlayerView: View {
                     if #available(iOS 17.0, *), !reduceMotion {
                         Image(systemName: isFav ? "star.fill" : "star")
                             .contentTransition(.symbolEffect(.replace))
+                            .symbolEffect(.bounce, value: isFav)
                     } else {
                         Image(systemName: isFav ? "star.fill" : "star")
                     }
@@ -782,7 +792,7 @@ struct FullScreenPlayerView: View {
                 .foregroundStyle(audioManager.isEditingProgress ? .primary : .secondary)
                 .scaleEffect(audioManager.isEditingProgress ? 1.12 : 1.0, anchor: .center)
                 .animation(
-                    reduceMotion ? nil : AppMotion.spring(response: 0.3, dampingFraction: 0.85),
+                    reduceMotion ? nil : AppMotion.quick,
                     value: audioManager.isEditingProgress
                 )
                 .padding(.horizontal, metrics.horizontalPadding)
@@ -884,7 +894,7 @@ struct FullScreenPlayerView: View {
     }
 
     private var playerSurfaceAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.46, dampingFraction: 0.86, blendDuration: 0.08)
+        reduceMotion ? nil : AppMotion.standard
     }
 
     private var lyricsSurfaceTransition: AnyTransition {
@@ -954,7 +964,7 @@ struct FullScreenPlayerView: View {
         .accessibilityValue(lyricsTranslationAccessibilityValue)
         .accessibilityHint(lyricsTranslationAccessibilityHint)
         .animation(
-            reduceMotion ? nil : AppMotion.spring(response: 0.32, dampingFraction: 0.86),
+            reduceMotion ? nil : AppMotion.quick,
             value: lyricsViewModel.translationState
         )
     }

--- a/Twinskaraoke/Features/Player/LyricsView.swift
+++ b/Twinskaraoke/Features/Player/LyricsView.swift
@@ -12,7 +12,7 @@ struct LyricsView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
 
     private var scrollAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.6, dampingFraction: 0.85)
+        reduceMotion ? nil : AppMotion.gentle
     }
 
     private var currentIndex: Int {
@@ -195,7 +195,6 @@ private struct LyricLineRow: View, Equatable {
                         Text(line.text)
                             .scaledSystemFont(size: isCurrent ? 30 : 23, weight: isCurrent ? .bold : .semibold)
                             .foregroundStyle(lineColor)
-                            .blur(radius: lineBlur)
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -216,6 +215,7 @@ private struct LyricLineRow: View, Equatable {
                 }
             }
             .padding(.horizontal, 4)
+            .blur(radius: lineBlur)
         }
         .buttonStyle(PressableButtonStyle(scale: 0.97, dim: 0.82, haptic: .selection))
         .scaleEffect(reduceMotion ? 1.0 : (isCurrent ? 1.0 : 0.92), anchor: .leading)
@@ -255,11 +255,11 @@ private struct LyricLineRow: View, Equatable {
     }
 
     private var lineAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.82)
+        reduceMotion ? nil : AppMotion.gentle
     }
 
     private var translationAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.34, dampingFraction: 0.86)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     private var translationTransition: AnyTransition {
@@ -273,7 +273,11 @@ private struct LyricLineRow: View, Equatable {
     }
 
     private var lineBlur: CGFloat {
-        0
+        // Depth-of-field: the active line stays crisp while lines soften with
+        // distance, like Apple Music. Skipped under reduce motion, where the
+        // constant refocusing would read as movement.
+        guard !reduceMotion, !isCurrent else { return 0 }
+        return min(2.0, 0.7 * CGFloat(distance))
     }
 
     private var lineOpacity: Double {

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -7,15 +7,15 @@ struct QueueView: View {
     @State private var showCurrentAddToPlaylist = false
 
     private var queueToggleAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.82)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     private var headerAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.88)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     private var queueMutationAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.36, dampingFraction: 0.86)
+        reduceMotion ? nil : AppMotion.quick
     }
 
     private var emptyQueueTransition: AnyTransition {

--- a/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
+++ b/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
@@ -172,8 +172,8 @@ struct RadioPlayerLayout: View {
     private var liveDotAnimation: Animation? {
         guard !reduceMotion else { return nil }
         return audioManager.isPlaying
-            ? AppMotion.spring(response: 0.42, dampingFraction: 0.78).repeatForever(autoreverses: true)
-            : AppMotion.spring(response: 0.25, dampingFraction: 0.78)
+            ? AppMotion.standard.repeatForever(autoreverses: true)
+            : AppMotion.snap
     }
 
     private var radioFavoriteID: String? {

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -45,7 +45,7 @@ struct RadioView: View {
     @State private var showingRadioSchedule = false
 
     private var metadataPulseAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.4, dampingFraction: 0.82)
+        reduceMotion ? nil : AppMotion.standard
     }
 
     var body: some View {

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -550,7 +550,7 @@ struct SearchCategorySongCollectionView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
 
     private var categoryStateAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.34, dampingFraction: 0.84)
+        reduceMotion ? nil : AppMotion.quick
     }
 
 
@@ -686,7 +686,7 @@ private struct SearchRecoveryStateView: View {
     @State private var hasAppeared = false
 
     private var entranceAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.42, dampingFraction: 0.82)
+        reduceMotion ? nil : AppMotion.standard
     }
 
 

--- a/TwinskaraokeShared/Components/AppMotion.swift
+++ b/TwinskaraokeShared/Components/AppMotion.swift
@@ -17,12 +17,16 @@ enum DisplayRefreshRate {
     #endif
   }
 
+  /// Full display rate — 120Hz on ProMotion — for small always-moving elements
+  /// (spinners, bouncing dots) whose choppiness is visible next to smooth scrolling.
   static var lightweightAnimationInterval: TimeInterval {
-    1.0 / 60.0
+    1.0 / Double(maximumFramesPerSecond)
   }
 
+  /// Decorative ambience (equalizer bars). 60fps reads as fluid; full display
+  /// rate would spend battery on motion nobody tracks closely.
   static var decorativeAnimationInterval: TimeInterval {
-    1.0 / 30.0
+    1.0 / 60.0
   }
 }
 
@@ -94,4 +98,24 @@ enum AppMotion {
   static func spring(response: TimeInterval, dampingFraction: Double) -> Animation {
     .spring(response: duration(response), dampingFraction: dampingFraction)
   }
+
+  // MARK: - Semantic motion scale
+
+  // One shared physics family so every interaction feels tuned by the same hand.
+  // Pick by role, not by taste-per-callsite:
+
+  /// Small state flips: icons, badges, toggles, selection feedback.
+  static var snap: Animation { .spring(response: 0.22, dampingFraction: 0.88) }
+
+  /// The workhorse: row/list changes, control state, chrome reveals.
+  static var quick: Animation { .spring(response: 0.32, dampingFraction: 0.85) }
+
+  /// Content-level moves: section reflows, layout swaps, sheets' inner content.
+  static var standard: Animation { .spring(response: 0.42, dampingFraction: 0.84) }
+
+  /// Large surfaces: hero artwork, full-screen layout shifts, lyric scrolling.
+  static var gentle: Animation { .spring(response: 0.58, dampingFraction: 0.85) }
+
+  /// Deliberately bouncy celebratory moments.
+  static var playful: Animation { .spring(response: 0.34, dampingFraction: 0.7) }
 }

--- a/TwinskaraokeShared/Components/AppMotion.swift
+++ b/TwinskaraokeShared/Components/AppMotion.swift
@@ -105,17 +105,17 @@ enum AppMotion {
   // Pick by role, not by taste-per-callsite:
 
   /// Small state flips: icons, badges, toggles, selection feedback.
-  static var snap: Animation { .spring(response: 0.22, dampingFraction: 0.88) }
+  static var snap: Animation { spring(response: 0.22, dampingFraction: 0.88) }
 
   /// The workhorse: row/list changes, control state, chrome reveals.
-  static var quick: Animation { .spring(response: 0.32, dampingFraction: 0.85) }
+  static var quick: Animation { spring(response: 0.32, dampingFraction: 0.85) }
 
   /// Content-level moves: section reflows, layout swaps, sheets' inner content.
-  static var standard: Animation { .spring(response: 0.42, dampingFraction: 0.84) }
+  static var standard: Animation { spring(response: 0.42, dampingFraction: 0.84) }
 
   /// Large surfaces: hero artwork, full-screen layout shifts, lyric scrolling.
-  static var gentle: Animation { .spring(response: 0.58, dampingFraction: 0.85) }
+  static var gentle: Animation { spring(response: 0.58, dampingFraction: 0.85) }
 
   /// Deliberately bouncy celebratory moments.
-  static var playful: Animation { .spring(response: 0.34, dampingFraction: 0.7) }
+  static var playful: Animation { spring(response: 0.34, dampingFraction: 0.7) }
 }

--- a/TwinskaraokeShared/Components/PressableButtonStyle.swift
+++ b/TwinskaraokeShared/Components/PressableButtonStyle.swift
@@ -120,7 +120,7 @@ private struct PressableButtonBody: View {
   }
 
   private var animation: Animation {
-    pressAnimation ?? AppMotion.spring(response: 0.32, dampingFraction: 0.7)
+    pressAnimation ?? AppMotion.playful
   }
 
   private func updatePressState(_ isPressed: Bool) {


### PR DESCRIPTION
## Motivation
Animations across the app were individually fine but used 40 distinct spring parameter pairs across ~55 call sites, so interactions felt near-identical rather than part of one tuned system. Some TimelineView-driven elements also ran below the display's refresh rate on ProMotion devices.

## Changes
**Unified motion scale** — `AppMotion` gains five documented semantic tokens (`snap`, `quick`, `standard`, `gentle`, `playful`), each the median of an existing parameter cluster, and all interaction springs now use them. No call site shifts more than ~0.06s response from its previous value, so nothing changes character — everything just shares the same physics family. Deliberately left untouched: perf-tuned artwork micro-fades, slow decorative loops (shimmer, QR pulse, ambient breathing), and the parameterized radio-queue spring.

**Full ProMotion usage** — lightweight TimelineView animations (lyric bouncing dots, translation spinner) now tick at the display's maximum rate (120Hz on ProMotion); equalizer bars lifted from 30fps to 60fps, which removes visibly steppy motion next to 120Hz scrolling.

**Motion polish**
- Song rows: download indicator and now-playing equalizer overlay spring in/out instead of popping
- Full-screen player: favorite star bounces on toggle
- Lyrics: depth-of-field — non-active lines blur slightly with distance, current line stays crisp (implements the previously stubbed `lineBlur` hook)
- Home: shelves fade and rise into place with a 50ms stagger when content replaces skeletons (compact and wide layouts)
- Shared empty states get one soft entrance

All effects respect the app's reduce-motion setting, collapsing to opacity-only or no animation.

## Testing
- Verified on a physical iPhone (iOS 26, ProMotion): browsing, playback, lyrics, sheets, and empty states all reviewed by feel
- App builds warning-free; full unit test suite (66 tests) passes

## Summary by Sourcery

Unify motion timing across the app using new semantic animation tokens and refine several UI animations for smoother, more polished interactions while respecting reduce-motion settings.

New Features:
- Introduce semantic AppMotion presets (snap, quick, standard, gentle, playful) to standardize interaction animations.
- Add staggered entrance animations for Home shelves and soft entrance animation for shared empty states.
- Enhance favorite star interactions in the full-screen player with bounce effects on toggle where supported.
- Apply depth-of-field blurring to non-active lyric lines to emphasize the current line.

Enhancements:
- Switch multiple views from ad-hoc spring values to shared AppMotion presets for consistent motion across the app.
- Increase lightweight TimelineView-driven animation frame rates to track the display’s maximum refresh rate and improve smoothness of decorative animations.
- Refine song row status changes with animated transitions for download indicators and now-playing state.
- Adjust various player, queue, search, profile, radio, and library view animations to use appropriate semantic motion levels based on interaction type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Refined animation timing throughout browsing, playback, lyrics, playlists, search, account, and radio experiences for smoother, more consistent interactions.
  * Improved reduced-motion support, disabling or simplifying transitions where appropriate.
  * Added staggered entrance animations for Home content sections.
  * Enhanced song-row download and active-song transitions.
  * Added subtle favorite-button bounce effects when motion is enabled.
  * Improved lyric depth effects with distance-based blur.
  * Adjusted animation timing for different display refresh rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->