### PR TITLE
Run the iOS app in Release configuration

### DIFF
--- a/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke.xcscheme
+++ b/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -55,7 +55,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/TwinskaraokeWatchApp.xcscheme
+++ b/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/TwinskaraokeWatchApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
## Change
Switch the shared iOS scheme's **Run** action from Debug to Release, and pick up Xcode's scheme upgrade marker (2640 → 2660) on both schemes.

## Why
Day-to-day device builds now carry full compiler optimizations, matching what App Store users actually experience. During recent animation/scroll smoothness work, Debug builds (no optimizations + active debug logging) were noticeably misrepresenting the app's real performance.

Notes:
- The **Test** action stays on Debug, so unit/UI test workflows are unchanged.
- Debug logging is disabled in Release by default; it can still be enabled at runtime via the developer menu toggle when logs are needed.
- Contributors who prefer debugging with full symbols can locally set the Run configuration back to Debug in the scheme editor (Product → Scheme → Edit Scheme → Run).

## Testing
- Verified Release build installs and runs correctly on a physical iPhone (iOS 26); performance review of the merged motion work was done on this configuration.

## Summary by Sourcery

Update iOS and watchOS Xcode schemes to run the app in Release configuration and align with the latest Xcode scheme format version.

Build:
- Switch the shared iOS scheme Run action from Debug to Release to use optimized builds for day-to-day device runs.
- Update Xcode scheme metadata versions for the iOS and watch app schemes to the latest format.