### PR TITLE
Fix audio playback and separation edge cases

### DIFF
--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -28,9 +28,7 @@ extension AVAudioTime {
 
 @MainActor
 final class SimpleAudioPlayer {
-    // AVAudioPlayerNode.stop() is thread-safe and is also used during
-    // nonisolated owner teardown.
-    nonisolated(unsafe) let playerNode = AVAudioPlayerNode()
+    let playerNode = AVAudioPlayerNode()
     let sourceMixer = AVAudioMixerNode()
     var completionHandler: (() -> Void)?
 
@@ -98,8 +96,14 @@ final class SimpleAudioPlayer {
         seekOffset = max(0, seconds)
         pausedPosition = nil
 
-        if let file = loadedFile {
-            scheduleFileSegment(file, at: time)
+        let generation = scheduleGeneration
+        guard let file = loadedFile, scheduleFileSegment(file, at: time) else {
+            // Preserve the asynchronous shape of a natural node completion.
+            // A later stop/load invalidates this generation before delivery.
+            Task { @MainActor [weak self] in
+                self?.deliverCompletion(for: generation)
+            }
+            return
         }
 
         if let time {
@@ -129,11 +133,12 @@ final class SimpleAudioPlayer {
         playerNode.stop()
     }
 
-    private func scheduleFileSegment(_ file: AVAudioFile, at time: AVAudioTime?) {
+    @discardableResult
+    private func scheduleFileSegment(_ file: AVAudioFile, at time: AVAudioTime?) -> Bool {
         let sampleRate = file.fileFormat.sampleRate
         let startFrame = AVAudioFramePosition(seekOffset * sampleRate)
         let remaining = AVAudioFrameCount(max(0, file.length - startFrame))
-        guard remaining > 0 else { return }
+        guard remaining > 0 else { return false }
         let generation = scheduleGeneration
         playerNode.scheduleSegment(
             file, startingFrame: startFrame, frameCount: remaining, at: time,
@@ -143,6 +148,7 @@ final class SimpleAudioPlayer {
                 self?.deliverCompletion(for: generation)
             }
         }
+        return true
     }
 
     private func deliverCompletion(for generation: UInt64) {
@@ -324,7 +330,7 @@ final class AVEnginePlayback {
         }
     }
 
-    deinit {
+    isolated deinit {
         if let engineConfigObserver {
             NotificationCenter.default.removeObserver(engineConfigObserver)
         }

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -40,6 +40,31 @@ nonisolated struct CachedStems {
     }
 }
 
+struct SeparationJobOwnership {
+    private(set) var activeID: UUID?
+
+    @discardableResult
+    mutating func begin(id: UUID = UUID()) -> UUID {
+        activeID = id
+        return id
+    }
+
+    mutating func cancelCurrent() {
+        activeID = nil
+    }
+
+    func owns(_ id: UUID) -> Bool {
+        activeID == id
+    }
+
+    @discardableResult
+    mutating func finish(_ id: UUID) -> Bool {
+        guard activeID == id else { return false }
+        activeID = nil
+        return true
+    }
+}
+
 @MainActor
 final class VocalSeparator: ObservableObject {
     static let shared = VocalSeparator()
@@ -59,12 +84,24 @@ final class VocalSeparator: ObservableObject {
     private var activeTaskKind: SeparationTaskKind?
     private var backgroundAnalysisTask: Task<Void, Never>?
     private var realtimeCleanupTask: Task<Void, Never>?
+    private var jobOwnership = SeparationJobOwnership()
 
     private nonisolated static var realtimeTempDir: URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("RealtimeStems", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
+    }
+
+    nonisolated static func separationOutputURLs(
+        in directory: URL, songID: String, jobID: UUID
+    ) -> (vocals: URL, instruments: URL) {
+        let storageKey = SongStorageKey.component(for: songID)
+        let prefix = "\(storageKey).\(jobID.uuidString)"
+        return (
+            directory.appendingPathComponent("\(prefix).vocals.wav"),
+            directory.appendingPathComponent("\(prefix).instruments.wav")
+        )
     }
 
     private init() {
@@ -157,39 +194,48 @@ final class VocalSeparator: ObservableObject {
             activeTaskKind = nil
             processingSongID = nil
             progressFraction = 0
+            jobOwnership.cancelCurrent()
         }
         try Task.checkCancellation()
         guard #available(iOS 18.0, *) else { throw VocalSeparatorError.unavailable }
         DebugLogger.log("Starting full separation for \(songID)", category: .separation)
         processingSongID = songID
         activeTaskKind = initiatedByBackground ? .background : .foreground
+        let jobID = jobOwnership.begin()
         _ = AudioCacheStore.ensureSongDirectory(for: songID)
         let songFiles = AudioCacheStore.files(for: songID)
         let vocalsURL = songFiles.vocals
         let instrumentsURL = songFiles.instruments
+        let staging = Self.separationOutputURLs(
+            in: vocalsURL.deletingLastPathComponent(),
+            songID: songID,
+            jobID: jobID
+        )
         let modelRef = modelURL
         let task = Task<URL, Error>.detached(priority: .utility) {
             do {
                 try await Self.runSeparation2(
                     modelURL: modelRef,
-                    songID: songID,
+                    jobID: jobID,
                     sourceURL: sourceURL,
-                    vocalsOutputURL: vocalsURL,
-                    instrumentsOutputURL: instrumentsURL
+                    vocalsOutputURL: staging.vocals,
+                    instrumentsOutputURL: staging.instruments
                 ) { fraction in
-                    await VocalSeparator.shared.updateProgress(songID: songID, fraction: fraction)
-                }
-                AudioCacheStore.clearMainOffset(for: songID)
-                await VocalSeparator.shared.finishJob(songID: songID)
-                await MainActor.run {
-                    NotificationCenter.default.post(
-                        name: .vocalSeparatorDidCacheStems,
-                        object: songID
+                    await VocalSeparator.shared.updateProgress(
+                        jobID: jobID, songID: songID, fraction: fraction
                     )
                 }
+                try Task.checkCancellation()
+                try await VocalSeparator.shared.publishCompletedFullJob(
+                    jobID: jobID,
+                    songID: songID,
+                    staging: staging,
+                    destinations: (vocalsURL, instrumentsURL)
+                )
                 return vocalsURL
             } catch {
-                await VocalSeparator.shared.finishJob(songID: songID)
+                Self.cleanupTmpFiles([staging.vocals, staging.instruments])
+                await VocalSeparator.shared.finishJob(jobID: jobID)
                 throw error
             }
         }
@@ -214,6 +260,7 @@ final class VocalSeparator: ObservableObject {
             activeTaskKind = nil
             processingSongID = nil
             progressFraction = 0
+            jobOwnership.cancelCurrent()
         }
 
         try Task.checkCancellation()
@@ -227,74 +274,78 @@ final class VocalSeparator: ObservableObject {
 
         processingSongID = songID
         activeTaskKind = .foreground
-        let storageKey = SongStorageKey.component(for: songID)
-        let vocalsURL = Self.realtimeTempDir.appendingPathComponent("\(storageKey).vocals.wav")
-        let instrumentsURL = Self.realtimeTempDir.appendingPathComponent("\(storageKey).instruments.wav")
+        let jobID = jobOwnership.begin()
+        let outputs = Self.separationOutputURLs(
+            in: Self.realtimeTempDir,
+            songID: songID,
+            jobID: jobID
+        )
+        let vocalsURL = outputs.vocals
+        let instrumentsURL = outputs.instruments
         let modelRef = modelURL
 
         let task = Task<URL, Error>.detached(priority: .utility) {
-            do {
-                let trimmedSource: URL
-                let trimmedTemp: URL?
-                if normalizedStart > 1.0 {
-                    let tmp = FileManager.default.temporaryDirectory
-                        .appendingPathComponent("\(storageKey).rt.trim.m4a")
-                    try await Self.trim(source: sourceURL, from: normalizedStart, to: tmp)
-                    trimmedSource = tmp
-                    trimmedTemp = tmp
-                } else {
-                    trimmedSource = sourceURL
-                    trimmedTemp = nil
-                }
-                defer {
-                    if let trimmedTemp {
-                        try? FileManager.default.removeItem(at: trimmedTemp)
-                    }
-                }
-                try await Self.runSeparation2(
-                    modelURL: modelRef,
-                    songID: songID,
-                    sourceURL: trimmedSource,
-                    vocalsOutputURL: vocalsURL,
-                    instrumentsOutputURL: instrumentsURL
-                ) { fraction in
-                    await VocalSeparator.shared.updateProgress(songID: songID, fraction: fraction)
-                }
-                await VocalSeparator.shared.finishJob(songID: songID)
-                return vocalsURL
-            } catch {
-                await VocalSeparator.shared.finishJob(songID: songID)
-                throw error
+            let trimmedSource: URL
+            let trimmedTemp: URL?
+            if normalizedStart > 1.0 {
+                let tmp = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("\(jobID.uuidString).rt.trim.m4a")
+                try await Self.trim(source: sourceURL, from: normalizedStart, to: tmp)
+                trimmedSource = tmp
+                trimmedTemp = tmp
+            } else {
+                trimmedSource = sourceURL
+                trimmedTemp = nil
             }
+            defer {
+                if let trimmedTemp {
+                    try? FileManager.default.removeItem(at: trimmedTemp)
+                }
+            }
+            try await Self.runSeparation2(
+                modelURL: modelRef,
+                jobID: jobID,
+                sourceURL: trimmedSource,
+                vocalsOutputURL: vocalsURL,
+                instrumentsOutputURL: instrumentsURL
+            ) { fraction in
+                await VocalSeparator.shared.updateProgress(
+                    jobID: jobID, songID: songID, fraction: fraction
+                )
+            }
+            return vocalsURL
         }
         activeTask = task
         do {
             _ = try await task.value
             try Task.checkCancellation()
+            guard jobOwnership.owns(jobID) else {
+                throw VocalSeparatorError.cancelled
+            }
+            guard FileManager.default.fileExists(atPath: vocalsURL.path),
+                  FileManager.default.fileExists(atPath: instrumentsURL.path)
+            else {
+                throw VocalSeparatorError.unavailable
+            }
+            try Task.checkCancellation()
+            finishJob(jobID: jobID)
+
+            DebugLogger.log(
+                "Real-time separation complete for \(songID), offset=\(normalizedStart)",
+                category: .separation
+            )
+            let offset = normalizedStart > 1.0 ? normalizedStart : 0
+            return CachedStems(
+                vocals: vocalsURL,
+                instruments: instrumentsURL,
+                startOffset: offset,
+                isTemporary: true
+            )
         } catch {
             Self.cleanupTmpFiles([vocalsURL, instrumentsURL])
+            finishJob(jobID: jobID)
             throw error
         }
-
-        guard FileManager.default.fileExists(atPath: vocalsURL.path),
-              FileManager.default.fileExists(atPath: instrumentsURL.path)
-        else {
-            Self.cleanupTmpFiles([vocalsURL, instrumentsURL])
-            throw VocalSeparatorError.unavailable
-        }
-        try Task.checkCancellation()
-
-        DebugLogger.log(
-            "Real-time separation complete for \(songID), offset=\(normalizedStart)",
-            category: .separation
-        )
-        let offset = normalizedStart > 1.0 ? normalizedStart : 0
-        return CachedStems(
-            vocals: vocalsURL,
-            instruments: instrumentsURL,
-            startOffset: offset,
-            isTemporary: true
-        )
     }
 
     func analyzeInBackground(songID: String, sourceURL: URL) {
@@ -343,6 +394,7 @@ final class VocalSeparator: ObservableObject {
             activeTaskKind = nil
             processingSongID = nil
             progressFraction = 0
+            jobOwnership.cancelCurrent()
             old?.cancel()
         }
         isBackgroundAnalyzing = false
@@ -358,6 +410,7 @@ final class VocalSeparator: ObservableObject {
         activeTaskKind = nil
         processingSongID = nil
         progressFraction = 0
+        jobOwnership.cancelCurrent()
         old?.cancel()
         if hadWork {
             DebugLogger.log("Separation cancelled", category: .separation)
@@ -420,17 +473,41 @@ final class VocalSeparator: ObservableObject {
         return duration
     }
 
-    private func updateProgress(songID: String, fraction: Float) {
-        if processingSongID == songID { progressFraction = fraction }
+    private func updateProgress(jobID: UUID, songID: String, fraction: Float) {
+        if jobOwnership.owns(jobID), processingSongID == songID {
+            progressFraction = fraction
+        }
     }
 
-    fileprivate func finishJob(songID: String) {
-        if processingSongID == songID {
-            processingSongID = nil
-            progressFraction = 0
-            activeTask = nil
-            activeTaskKind = nil
+    private func finishJob(jobID: UUID) {
+        guard jobOwnership.finish(jobID) else { return }
+        processingSongID = nil
+        progressFraction = 0
+        activeTask = nil
+        activeTaskKind = nil
+    }
+
+    private func publishCompletedFullJob(
+        jobID: UUID,
+        songID: String,
+        staging: (vocals: URL, instruments: URL),
+        destinations: (vocals: URL, instruments: URL)
+    ) throws {
+        guard jobOwnership.owns(jobID) else {
+            throw VocalSeparatorError.cancelled
         }
+        try Self.publishStemFiles(
+            vocalsSource: staging.vocals,
+            instrumentsSource: staging.instruments,
+            vocalsDestination: destinations.vocals,
+            instrumentsDestination: destinations.instruments
+        )
+        AudioCacheStore.clearMainOffset(for: songID)
+        finishJob(jobID: jobID)
+        NotificationCenter.default.post(
+            name: .vocalSeparatorDidCacheStems,
+            object: songID
+        )
     }
 
     private static func trim(source: URL, from startSeconds: TimeInterval, to output: URL)
@@ -461,7 +538,7 @@ final class VocalSeparator: ObservableObject {
     @available(iOS 18.0, *)
     private static func runSeparation2(
         modelURL: URL,
-        songID: String,
+        jobID: UUID,
         sourceURL: URL,
         vocalsOutputURL: URL,
         instrumentsOutputURL: URL,
@@ -469,11 +546,12 @@ final class VocalSeparator: ObservableObject {
     ) async throws {
         let separator = try AudioSeparator2(modelURL: modelURL)
         let tmpDir = FileManager.default.temporaryDirectory
-        let storageKey = SongStorageKey.component(for: songID)
-        let tmpVocals = tmpDir.appendingPathComponent("\(storageKey).vocals.wav")
-        let tmpInstruments = tmpDir.appendingPathComponent("\(storageKey).instruments.wav")
-        try? FileManager.default.removeItem(at: tmpVocals)
-        try? FileManager.default.removeItem(at: tmpInstruments)
+            .appendingPathComponent("SeparationJobs", isDirectory: true)
+            .appendingPathComponent(jobID.uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpVocals = tmpDir.appendingPathComponent("vocals.wav")
+        let tmpInstruments = tmpDir.appendingPathComponent("instruments.wav")
         let stems = Stems2(vocals: tmpVocals, accompaniment: tmpInstruments)
         do {
             for try await prog in separator.separate(from: sourceURL, to: stems) {
@@ -519,7 +597,29 @@ final class VocalSeparator: ObservableObject {
         }
     }
 
-    private static func cleanupTmpFiles(_ urls: [URL]) {
+    private nonisolated static func publishStemFiles(
+        vocalsSource: URL,
+        instrumentsSource: URL,
+        vocalsDestination: URL,
+        instrumentsDestination: URL
+    ) throws {
+        let moves = [
+            (vocalsSource, vocalsDestination),
+            (instrumentsSource, instrumentsDestination),
+        ]
+        do {
+            for (source, destination) in moves {
+                try? FileManager.default.removeItem(at: destination)
+                try FileManager.default.moveItem(at: source, to: destination)
+            }
+        } catch {
+            cleanupTmpFiles(moves.map(\.0))
+            cleanupTmpFiles(moves.map(\.1))
+            throw error
+        }
+    }
+
+    private nonisolated static func cleanupTmpFiles(_ urls: [URL]) {
         for url in urls {
             try? FileManager.default.removeItem(at: url)
         }

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -603,21 +603,66 @@ final class VocalSeparator: ObservableObject {
         vocalsDestination: URL,
         instrumentsDestination: URL
     ) throws {
+        let fileManager = FileManager.default
         let moves = [
             (vocalsSource, vocalsDestination),
             (instrumentsSource, instrumentsDestination),
         ]
+        let transactionID = UUID().uuidString
+        var backups: [(destination: URL, backup: URL)] = []
+        var publishedDestinations: [URL] = []
+
         do {
+            // Move any existing pair aside first. Both replacements are then
+            // published as one transaction and the old pair can be restored if
+            // either move fails.
+            for (_, destination) in moves
+            where fileManager.fileExists(atPath: destination.path) {
+                let backup = destination.deletingLastPathComponent()
+                    .appendingPathComponent(
+                        ".\(destination.lastPathComponent).\(transactionID).backup"
+                    )
+                try fileManager.moveItem(at: destination, to: backup)
+                backups.append((destination, backup))
+            }
+
             for (source, destination) in moves {
-                try? FileManager.default.removeItem(at: destination)
-                try FileManager.default.moveItem(at: source, to: destination)
+                try fileManager.moveItem(at: source, to: destination)
+                publishedDestinations.append(destination)
+            }
+
+            for (_, backup) in backups {
+                try? fileManager.removeItem(at: backup)
             }
         } catch {
+            for destination in publishedDestinations.reversed() {
+                try? fileManager.removeItem(at: destination)
+            }
+            for (destination, backup) in backups.reversed()
+            where fileManager.fileExists(atPath: backup.path) {
+                try? fileManager.removeItem(at: destination)
+                try? fileManager.moveItem(at: backup, to: destination)
+            }
             cleanupTmpFiles(moves.map(\.0))
-            cleanupTmpFiles(moves.map(\.1))
             throw error
         }
     }
+
+    #if DEBUG
+        nonisolated static func publishStemFilesForTesting(
+            vocalsSource: URL,
+            instrumentsSource: URL,
+            vocalsDestination: URL,
+            instrumentsDestination: URL
+        ) throws {
+            try publishStemFiles(
+                vocalsSource: vocalsSource,
+                instrumentsSource: instrumentsSource,
+                vocalsDestination: vocalsDestination,
+                instrumentsDestination: instrumentsDestination
+            )
+        }
+    #endif
 
     private nonisolated static func cleanupTmpFiles(_ urls: [URL]) {
         for url in urls {

--- a/TwinskaraokeTests/AVEnginePlaybackRegressionTests.swift
+++ b/TwinskaraokeTests/AVEnginePlaybackRegressionTests.swift
@@ -38,6 +38,23 @@ struct AVEnginePlaybackRegressionTests {
         #expect(abs(player.duration - 2) < 0.01)
     }
 
+    @Test("Starting at end of file reports completion without phantom playback")
+    func endOfFileStartCompletes() async throws {
+        let sourceURL = try makeSilentWaveFile(duration: 2, sampleRate: 48_000)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let player = SimpleAudioPlayer()
+        try player.load(file: AVAudioFile(forReading: sourceURL))
+
+        var completionCount = 0
+        player.completionHandler = { completionCount += 1 }
+        player.play(from: player.duration)
+        await Task.yield()
+
+        #expect(!player.isPlaying)
+        #expect(completionCount == 1)
+    }
+
     private func makeSilentWaveFile(duration: TimeInterval, sampleRate: Double) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("playback-regression-\(UUID().uuidString).wav")

--- a/TwinskaraokeTests/VocalSeparatorRegressionTests.swift
+++ b/TwinskaraokeTests/VocalSeparatorRegressionTests.swift
@@ -51,4 +51,36 @@ struct VocalSeparatorRegressionTests {
         #expect(FileManager.default.fileExists(atPath: replacement.vocals.path))
         #expect(FileManager.default.fileExists(atPath: replacement.instruments.path))
     }
+
+    @Test("Failed publication restores the previous stem pair")
+    func failedPublicationRestoresPreviousStems() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stem-publication-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let previousVocals = directory.appendingPathComponent("vocals.wav")
+        let previousInstruments = directory.appendingPathComponent("instruments.wav")
+        let stagedVocals = directory.appendingPathComponent("staged-vocals.wav")
+        let missingStagedInstruments = directory.appendingPathComponent("missing-instruments.wav")
+        let previousVocalsData = Data("previous vocals".utf8)
+        let previousInstrumentsData = Data("previous instruments".utf8)
+
+        try previousVocalsData.write(to: previousVocals)
+        try previousInstrumentsData.write(to: previousInstruments)
+        try Data("replacement vocals".utf8).write(to: stagedVocals)
+
+        do {
+            try VocalSeparator.publishStemFilesForTesting(
+                vocalsSource: stagedVocals,
+                instrumentsSource: missingStagedInstruments,
+                vocalsDestination: previousVocals,
+                instrumentsDestination: previousInstruments
+            )
+            Issue.record("Expected publication to fail when the second staged stem is missing")
+        } catch {}
+
+        #expect(try Data(contentsOf: previousVocals) == previousVocalsData)
+        #expect(try Data(contentsOf: previousInstruments) == previousInstrumentsData)
+    }
 }

--- a/TwinskaraokeTests/VocalSeparatorRegressionTests.swift
+++ b/TwinskaraokeTests/VocalSeparatorRegressionTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Vocal separator regressions", .serialized)
+struct VocalSeparatorRegressionTests {
+    @Test("A stale job cannot finish or clear its replacement")
+    func staleJobCannotFinishReplacement() {
+        var ownership = SeparationJobOwnership()
+        let staleID = UUID()
+        let replacementID = UUID()
+
+        ownership.begin(id: staleID)
+        ownership.begin(id: replacementID)
+
+        let staleFinished = ownership.finish(staleID)
+        #expect(!staleFinished)
+        #expect(ownership.owns(replacementID))
+        let replacementFinished = ownership.finish(replacementID)
+        #expect(replacementFinished)
+        #expect(ownership.activeID == nil)
+    }
+
+    @Test("Stale cleanup cannot delete replacement output files")
+    func staleCleanupCannotDeleteReplacementOutputs() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("separation-ownership-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let stale = VocalSeparator.separationOutputURLs(
+            in: directory,
+            songID: "same-song",
+            jobID: UUID()
+        )
+        let replacement = VocalSeparator.separationOutputURLs(
+            in: directory,
+            songID: "same-song",
+            jobID: UUID()
+        )
+
+        for url in [stale.vocals, stale.instruments, replacement.vocals, replacement.instruments] {
+            try Data([0x52, 0x49, 0x46, 0x46]).write(to: url)
+        }
+        for url in [stale.vocals, stale.instruments] {
+            try FileManager.default.removeItem(at: url)
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: stale.vocals.path))
+        #expect(!FileManager.default.fileExists(atPath: stale.instruments.path))
+        #expect(FileManager.default.fileExists(atPath: replacement.vocals.path))
+        #expect(FileManager.default.fileExists(atPath: replacement.instruments.path))
+    }
+}


### PR DESCRIPTION
## Summary

- avoid starting an `AVAudioPlayerNode` when no frames remain and report completion through the existing schedule generation
- isolate audio-node teardown to the main actor instead of relying on undocumented thread-safety assumptions
- give each vocal-separation job unique ownership and staging paths so stale cancellation or cleanup cannot affect a replacement job
- add regression coverage for end-of-file playback and same-song separation replacement

## Root cause

This follows up on #58. Playback starting at or beyond the end of a file could enter a playing state without scheduled audio or a completion callback. Separation jobs also reused song-derived temporary and output paths while cancellation completed asynchronously, allowing stale work to remove or publish files belonging to a newer request.

## Validation

- Debug iOS Simulator build
- Release iOS Simulator build
- complete `TwinskaraokeTests` unit-test target

## Summary by Sourcery

Ensure audio playback completion is correctly reported at end-of-file and make vocal separation jobs uniquely owned and isolated to prevent stale tasks from affecting newer ones.

New Features:
- Add unique job ownership tracking for vocal separation tasks to distinguish active and stale jobs.
- Introduce per-job temporary and output paths for vocal separation results to avoid collisions between multiple requests.

Bug Fixes:
- Prevent starting audio playback when seeking to or beyond the end of a file and still deliver a completion callback without entering a playing state.
- Guard vocal separation progress, completion, and file publication so that cancelled or replaced jobs cannot clear or overwrite outputs for newer jobs.

Enhancements:
- Constrain audio-node teardown and playback engine deinitialization to the main actor for safer AVAudioEngine lifecycle management.
- Encapsulate stem file publishing and temporary file cleanup to centralize error handling and resource management in the separation pipeline.

Tests:
- Add regression tests covering end-of-file audio playback completion behaviour.
- Add regression tests ensuring separation job ownership prevents stale jobs from finishing or deleting replacement output files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback handling when starting at the end of a file, preventing phantom playback and ensuring completion is reported once.
  * Prevented outdated vocal-separation jobs from overwriting or cleaning up results from newer jobs.
  * Added safer publication of separated vocal and instrumental files, preserving existing files if an update fails.

* **Tests**
  * Added regression coverage for playback completion, job ownership, temporary-file cleanup, and failed result publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->