### PR TITLE
Add pull-down playlist search

### DIFF
--- a/Twinskaraoke/Components/Shared/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/Shared/ScrollOptimization.swift
@@ -22,11 +22,12 @@ extension View {
         baseSize: CGFloat,
         restingOffset: CGFloat = 0,
         fadesWhenCollapsed: Bool = false,
-        reduceMotion: Bool
+        reduceMotion: Bool,
+        pullDownOverride: CGFloat? = nil
     ) -> some View {
         visualEffect { content, proxy in
             let rawOffset = proxy.frame(in: .scrollView(axis: .vertical)).minY - restingOffset
-            let pullDown = reduceMotion ? 0 : max(0, rawOffset)
+            let pullDown = reduceMotion ? 0 : (pullDownOverride ?? max(0, rawOffset))
             let collapse = reduceMotion ? 0 : max(0, -rawOffset)
             let scale = max(
                 140 / max(baseSize, 1),

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -2,6 +2,8 @@ import Combine
 import SwiftUI
 
 struct PlaylistDetailView: View {
+    private static let searchFieldHeight: CGFloat = 40
+
     let playlist: Playlist
     @Environment(\.appReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -10,6 +12,14 @@ struct PlaylistDetailView: View {
     @ObservedObject private var fallbackArt = FallbackArtProvider.shared
     @State private var showsCollapsedTitle = false
     @State private var searchText = ""
+    @State private var isSearchVisible = false
+    @State private var isSearchModeActive = false
+    @State private var artworkPullOverride: CGFloat = 0
+    @State private var isArtworkPullOverridden = false
+    @State private var canAutoHideSearch = false
+    @State private var isActivelyPulling = false
+    @State private var searchRevealState = PlaylistSearchRevealState()
+    @FocusState private var isSearchFocused: Bool
     private func usesWideOverview(availableWidth: CGFloat) -> Bool {
         AM.Layout.usesWideCanvas(
             horizontalSizeClass: horizontalSizeClass,
@@ -24,7 +34,7 @@ struct PlaylistDetailView: View {
         let isSearching = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         GeometryReader { geo in
             ScrollView {
-                playlistOverview(
+                playlistScrollContent(
                     songs: songs,
                     displayedSongs: displayedSongs,
                     isSearching: isSearching,
@@ -33,10 +43,25 @@ struct PlaylistDetailView: View {
                     .padding(.bottom, 16)
             }
             .smoothScrolling()
+            .scrollDismissesKeyboard(.interactively)
             .bottomChromeScrollTracking()
             .collapsedNavigationTitle($showsCollapsedTitle)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.contentOffset.y + geometry.contentInsets.top
+            } action: { _, scrollOffset in
+                updateSearchInteraction(scrollOffset: scrollOffset)
+            }
+            .onScrollPhaseChange { _, phase in
+                let wasActivelyPulling = isActivelyPulling
+                isActivelyPulling = phase == .tracking || phase == .interacting
+                if wasActivelyPulling, !isActivelyPulling, isArtworkPullOverridden {
+                    withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.24)) {
+                        artworkPullOverride = 0
+                    }
+                }
+            }
         }
-        .navigationTitle(showsCollapsedTitle ? playlist.name : "")
+        .navigationTitle(showsCollapsedTitle && !isSearchModeActive ? playlist.name : "")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
         .toolbar {
@@ -48,11 +73,16 @@ struct PlaylistDetailView: View {
                 )
             }
         }
-        .searchable(
-            text: $searchText,
-            placement: .navigationBarDrawer(displayMode: .automatic),
-            prompt: "Find in Playlist"
-        )
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if isSearchVisible {
+                playlistSearchField
+                    .transition(
+                        reduceMotion
+                            ? .opacity
+                            : .move(edge: .top).combined(with: .opacity)
+                    )
+            }
+        }
         .animation(
             reduceMotion ? nil : AppMotion.quick,
             value: showsCollapsedTitle
@@ -60,6 +90,10 @@ struct PlaylistDetailView: View {
         .animation(
             reduceMotion ? nil : AppMotion.quick,
             value: loader.isLoading
+        )
+        .animation(
+            reduceMotion ? nil : AppMotion.quick,
+            value: isSearchModeActive
         )
         .scrollIndicators(.hidden)
         .musicScreenBackground()
@@ -75,9 +109,152 @@ struct PlaylistDetailView: View {
             guard playlist.isFavorites else { return }
             loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
         }
+        .onChange(of: isSearchFocused) { _, isFocused in
+            guard isFocused, !isSearchModeActive else { return }
+            isArtworkPullOverridden = false
+            withAnimation(reduceMotion ? nil : AppMotion.quick) {
+                isSearchModeActive = true
+            }
+        }
         .onDisappear {
             ArtworkPrefetcher.shared.cancel(reason: "playlist cover \(playlist.id)")
             ArtworkPrefetcher.shared.cancel(reason: "playlist songs \(playlist.id)")
+        }
+    }
+
+    @ViewBuilder
+    private func playlistScrollContent(
+        songs: [Song],
+        displayedSongs: [Song],
+        isSearching: Bool,
+        width: CGFloat
+    ) -> some View {
+        if isSearchModeActive {
+            playlistSongsContent(
+                songs: songs,
+                displayedSongs: displayedSongs,
+                isSearching: isSearching,
+                showsActionButtons: false
+            )
+            .padding(.top, AM.Spacing.xs)
+            .transition(
+                reduceMotion
+                    ? .opacity
+                    : .opacity.combined(with: .move(edge: .bottom))
+            )
+            .accessibilityIdentifier("PlaylistDetail.SearchResults")
+        } else {
+            playlistOverview(
+                songs: songs,
+                displayedSongs: displayedSongs,
+                isSearching: isSearching,
+                width: width
+            )
+            .transition(
+                reduceMotion
+                    ? .opacity
+                    : .opacity.combined(with: .scale(scale: 0.98))
+            )
+        }
+    }
+
+    private var playlistSearchField: some View {
+        HStack(spacing: AM.Spacing.s) {
+            HStack(spacing: AM.Spacing.s) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Find in Playlist", text: $searchText)
+                    .focused($isSearchFocused)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.search)
+                    .accessibilityIdentifier("PlaylistDetail.searchField")
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.tertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear Search")
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: Self.searchFieldHeight)
+            .background(.thinMaterial, in: Capsule())
+
+            if isSearchModeActive {
+                Button("Cancel") {
+                    dismissSearch()
+                }
+                .foregroundStyle(Color.appAccent)
+                .buttonStyle(.plain)
+                .transition(.opacity.combined(with: .move(edge: .trailing)))
+            }
+        }
+        .padding(.horizontal, AM.Spacing.screenMargin)
+        .padding(.top, AM.Spacing.s)
+        .padding(.bottom, AM.Spacing.m)
+        .animation(reduceMotion ? nil : AppMotion.quick, value: isSearchModeActive)
+        .accessibilityIdentifier("PlaylistDetail.search")
+    }
+
+    private func updateSearchInteraction(scrollOffset: CGFloat) {
+        let pullDistance = max(0, -scrollOffset)
+
+        if searchRevealState.update(
+            pullDistance: pullDistance,
+            isSearchVisible: isSearchVisible,
+            isActivelyPulling: isActivelyPulling
+        ) {
+            AppHaptic.medium.play()
+            canAutoHideSearch = false
+            artworkPullOverride = reduceMotion
+                ? 0
+                : min(pullDistance, PlaylistSearchRevealState.revealThreshold)
+            isArtworkPullOverridden = !reduceMotion
+            withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.2)) {
+                isSearchVisible = true
+            }
+            Task { @MainActor in
+                isSearchFocused = true
+            }
+        }
+
+        guard isSearchVisible else { return }
+
+        if abs(scrollOffset) <= PlaylistSearchRevealState.resetThreshold {
+            canAutoHideSearch = true
+            return
+        }
+
+        guard PlaylistSearchRevealState.shouldAutoHide(
+            scrollOffset: scrollOffset,
+            isReady: canAutoHideSearch,
+            isActivelyScrolling: isActivelyPulling,
+            isSearchModeActive: isSearchModeActive
+        ) else { return }
+
+        isSearchFocused = false
+        searchText = ""
+        canAutoHideSearch = false
+        withAnimation(reduceMotion ? nil : AppMotion.quick) {
+            isSearchVisible = false
+            isSearchModeActive = false
+            isArtworkPullOverridden = false
+        }
+    }
+
+    private func dismissSearch() {
+        isSearchFocused = false
+        searchText = ""
+        canAutoHideSearch = false
+        searchRevealState.reset()
+        withAnimation(reduceMotion ? nil : AppMotion.quick) {
+            isSearchVisible = false
+            isSearchModeActive = false
+            isArtworkPullOverridden = false
         }
     }
 
@@ -212,7 +389,8 @@ struct PlaylistDetailView: View {
                 baseSize: baseSize,
                 restingOffset: 12,
                 fadesWhenCollapsed: true,
-                reduceMotion: reduceMotion
+                reduceMotion: reduceMotion,
+                pullDownOverride: isArtworkPullOverridden ? artworkPullOverride : nil
             )
             .padding(.top, 12)
     }
@@ -247,11 +425,12 @@ struct PlaylistDetailView: View {
         displayedSongs: [Song],
         isSearching: Bool,
         isWideOverview: Bool = false,
+        showsActionButtons: Bool = true,
         rowHorizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) -> some View {
         if !displayedSongs.isEmpty {
             VStack(spacing: 0) {
-                if !isWideOverview {
+                if showsActionButtons, !isWideOverview {
                     actionButtons(songs: displayedSongs)
                 }
                 LazyVStack(spacing: 0) {

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -57,6 +57,9 @@ struct PlaylistDetailView: View {
                 if wasActivelyPulling, !isActivelyPulling, isArtworkPullOverridden {
                     withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.24)) {
                         artworkPullOverride = 0
+                    } completion: {
+                        guard artworkPullOverride == 0 else { return }
+                        isArtworkPullOverridden = false
                     }
                 }
             }
@@ -102,7 +105,12 @@ struct PlaylistDetailView: View {
             RecentlyPlayedStore.shared.record(playlist)
             prefetchArtwork(songs: displayedSongs)
         }
-        .onChange(of: Array(displayedSongs.prefix(18)).map(\.id)) { _, _ in
+        .task(id: Array(displayedSongs.prefix(18)).map(\.id)) {
+            do {
+                try await Task.sleep(for: .milliseconds(180))
+            } catch {
+                return
+            }
             prefetchArtwork(songs: displayedSongs)
         }
         .onChange(of: favorites.favoriteIDs) { _, _ in
@@ -218,6 +226,7 @@ struct PlaylistDetailView: View {
                 isSearchVisible = true
             }
             Task { @MainActor in
+                guard isSearchVisible, !isSearchModeActive else { return }
                 isSearchFocused = true
             }
         }
@@ -458,8 +467,8 @@ struct PlaylistDetailView: View {
                 .transition(.opacity)
         } else if isSearching, !songs.isEmpty {
             MusicEmptyState(
-                title: "No Results",
-                message: "Try another song title or artist."
+                title: String(localized: "No Results"),
+                message: String(localized: "Try another song title or artist.")
             )
             .frame(maxWidth: .infinity)
             .padding(.vertical, 48)

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -9,6 +9,7 @@ struct PlaylistDetailView: View {
     @ObservedObject private var favorites = FavoritesManager.shared
     @ObservedObject private var fallbackArt = FallbackArtProvider.shared
     @State private var showsCollapsedTitle = false
+    @State private var searchText = ""
     private func usesWideOverview(availableWidth: CGFloat) -> Bool {
         AM.Layout.usesWideCanvas(
             horizontalSizeClass: horizontalSizeClass,
@@ -19,9 +20,16 @@ struct PlaylistDetailView: View {
 
     var body: some View {
         let songs: [Song] = loader.songs ?? playlist.songListDTOs ?? []
+        let displayedSongs = PlaylistSongSearch.filter(songs, matching: searchText)
+        let isSearching = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         GeometryReader { geo in
             ScrollView {
-                playlistOverview(songs: songs, width: geo.size.width)
+                playlistOverview(
+                    songs: songs,
+                    displayedSongs: displayedSongs,
+                    isSearching: isSearching,
+                    width: geo.size.width
+                )
                     .padding(.bottom, 16)
             }
             .smoothScrolling()
@@ -35,10 +43,16 @@ struct PlaylistDetailView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 PlaylistMoreMenu(
                     playlist: playlist,
-                    songs: songs
+                    songs: songs,
+                    onRefresh: refresh
                 )
             }
         }
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .automatic),
+            prompt: "Find in Playlist"
+        )
         .animation(
             reduceMotion ? nil : AppMotion.quick,
             value: showsCollapsedTitle
@@ -49,17 +63,13 @@ struct PlaylistDetailView: View {
         )
         .scrollIndicators(.hidden)
         .musicScreenBackground()
-        .refreshable {
-            AppHaptic.selection.play()
-            loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
-        }
         .onAppear {
             loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
             RecentlyPlayedStore.shared.record(playlist)
-            prefetchArtwork(songs: songs)
+            prefetchArtwork(songs: displayedSongs)
         }
-        .onChange(of: Array(songs.prefix(18)).map(\.id)) { _, _ in
-            prefetchArtwork(songs: songs)
+        .onChange(of: Array(displayedSongs.prefix(18)).map(\.id)) { _, _ in
+            prefetchArtwork(songs: displayedSongs)
         }
         .onChange(of: favorites.favoriteIDs) { _, _ in
             guard playlist.isFavorites else { return }
@@ -69,6 +79,11 @@ struct PlaylistDetailView: View {
             ArtworkPrefetcher.shared.cancel(reason: "playlist cover \(playlist.id)")
             ArtworkPrefetcher.shared.cancel(reason: "playlist songs \(playlist.id)")
         }
+    }
+
+    private func refresh() {
+        AppHaptic.selection.play()
+        loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
     }
 
     private func prefetchArtwork(songs: [Song]) {
@@ -87,15 +102,34 @@ struct PlaylistDetailView: View {
     }
 
     @ViewBuilder
-    private func playlistOverview(songs: [Song], width: CGFloat) -> some View {
+    private func playlistOverview(
+        songs: [Song],
+        displayedSongs: [Song],
+        isSearching: Bool,
+        width: CGFloat
+    ) -> some View {
         if usesWideOverview(availableWidth: width) {
-            widePlaylistOverview(songs: songs)
+            widePlaylistOverview(
+                songs: songs,
+                displayedSongs: displayedSongs,
+                isSearching: isSearching
+            )
         } else {
-            compactPlaylistOverview(songs: songs, width: width)
+            compactPlaylistOverview(
+                songs: songs,
+                displayedSongs: displayedSongs,
+                isSearching: isSearching,
+                width: width
+            )
         }
     }
 
-    private func compactPlaylistOverview(songs: [Song], width: CGFloat) -> some View {
+    private func compactPlaylistOverview(
+        songs: [Song],
+        displayedSongs: [Song],
+        isSearching: Bool,
+        width: CGFloat
+    ) -> some View {
         VStack(spacing: 18) {
             parallaxHero(width: width)
                 .contextMenu {
@@ -108,11 +142,19 @@ struct PlaylistDetailView: View {
                     )
                 }
             playlistTitleBlock(alignment: .center)
-            playlistSongsContent(songs: songs)
+            playlistSongsContent(
+                songs: songs,
+                displayedSongs: displayedSongs,
+                isSearching: isSearching
+            )
         }
     }
 
-    private func widePlaylistOverview(songs: [Song]) -> some View {
+    private func widePlaylistOverview(
+        songs: [Song],
+        displayedSongs: [Song],
+        isSearching: Bool
+    ) -> some View {
         HStack(alignment: .top, spacing: AM.Spacing.xxl) {
             VStack(alignment: .leading, spacing: AM.Spacing.l) {
                 playlistArtwork(size: 280)
@@ -126,13 +168,19 @@ struct PlaylistDetailView: View {
                         )
                     }
                 playlistTitleBlock(alignment: .leading)
-                if !songs.isEmpty {
-                    actionButtons(songs: songs, horizontalPadding: 0)
+                if !displayedSongs.isEmpty {
+                    actionButtons(songs: displayedSongs, horizontalPadding: 0)
                 }
             }
             .frame(width: 320, alignment: .topLeading)
 
-            playlistSongsContent(songs: songs, isWideOverview: true, rowHorizontalPadding: 0)
+            playlistSongsContent(
+                songs: songs,
+                displayedSongs: displayedSongs,
+                isSearching: isSearching,
+                isWideOverview: true,
+                rowHorizontalPadding: 0
+            )
                 .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: 1120, alignment: .topLeading)
@@ -196,23 +244,25 @@ struct PlaylistDetailView: View {
     @ViewBuilder
     private func playlistSongsContent(
         songs: [Song],
+        displayedSongs: [Song],
+        isSearching: Bool,
         isWideOverview: Bool = false,
         rowHorizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) -> some View {
-        if !songs.isEmpty {
+        if !displayedSongs.isEmpty {
             VStack(spacing: 0) {
                 if !isWideOverview {
-                    actionButtons(songs: songs)
+                    actionButtons(songs: displayedSongs)
                 }
                 LazyVStack(spacing: 0) {
-                    ForEach(songs) { song in
+                    ForEach(displayedSongs) { song in
                         Button {
-                            play(song, context: songs)
+                            play(song, context: displayedSongs)
                         } label: {
                             PlaylistRow(song: song, showsArtwork: true, horizontalPadding: rowHorizontalPadding)
                                 .contentShape(Rectangle())
                                 .songRowAccessibility(song: song) {
-                                    play(song, context: songs)
+                                    play(song, context: displayedSongs)
                                 }
                         }
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
@@ -224,9 +274,17 @@ struct PlaylistDetailView: View {
                 }
             }
             .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .bottom)))
-        } else if loader.isLoading {
+        } else if loader.isLoading, songs.isEmpty {
             PlaylistLoadingRows(horizontalPadding: rowHorizontalPadding)
                 .transition(.opacity)
+        } else if isSearching, !songs.isEmpty {
+            MusicEmptyState(
+                title: "No Results",
+                message: "Try another song title or artist."
+            )
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 48)
+            .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
         } else {
             PlaylistEmptyStateView(
                 isFavorites: playlist.isFavorites,
@@ -340,9 +398,16 @@ private struct PlaylistDetailContextPreview: View {
 private struct PlaylistMoreMenu: View {
     let playlist: Playlist
     let songs: [Song]
+    let onRefresh: () -> Void
     var body: some View {
         Menu {
             PlaylistActionsMenuItems(playlist: playlist, songs: songs)
+            Divider()
+            Button {
+                onRefresh()
+            } label: {
+                Label("Refresh Playlist", systemImage: "arrow.clockwise")
+            }
         } label: {
             Label("More Actions", systemImage: "ellipsis")
                 .font(.headline)

--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -14,6 +14,51 @@ nonisolated enum PlaylistSongSearch {
     }
 }
 
+nonisolated struct PlaylistSearchRevealState: Equatable {
+    static let revealThreshold: CGFloat = 88
+    static let resetThreshold: CGFloat = 6
+    static let hideThreshold: CGFloat = 18
+
+    private(set) var isArmed = false
+
+    mutating func update(
+        pullDistance: CGFloat,
+        isSearchVisible: Bool,
+        isActivelyPulling: Bool
+    ) -> Bool {
+        if pullDistance <= Self.resetThreshold {
+            isArmed = false
+        }
+
+        guard !isSearchVisible,
+              isActivelyPulling,
+              !isArmed,
+              pullDistance >= Self.revealThreshold
+        else {
+            return false
+        }
+
+        isArmed = true
+        return true
+    }
+
+    mutating func reset() {
+        isArmed = false
+    }
+
+    static func shouldAutoHide(
+        scrollOffset: CGFloat,
+        isReady: Bool,
+        isActivelyScrolling: Bool,
+        isSearchModeActive: Bool
+    ) -> Bool {
+        isReady
+            && isActivelyScrolling
+            && !isSearchModeActive
+            && scrollOffset >= hideThreshold
+    }
+}
+
 @MainActor
 class PlaylistDetailViewModel: ObservableObject {
     @Published var songs: [Song]?

--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -1,6 +1,19 @@
 import Combine
 import Foundation
 
+nonisolated enum PlaylistSongSearch {
+    static func filter(_ songs: [Song], matching searchText: String) -> [Song] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return songs }
+
+        return songs.filter { song in
+            song.title.localizedCaseInsensitiveContains(query)
+                || song.displayArtist.localizedCaseInsensitiveContains(query)
+                || song.displayTitle.localizedCaseInsensitiveContains(query)
+        }
+    }
+}
+
 @MainActor
 class PlaylistDetailViewModel: ObservableObject {
     @Published var songs: [Song]?
@@ -12,7 +25,7 @@ class PlaylistDetailViewModel: ObservableObject {
         if loadFailed {
             return "The playlist couldn't be loaded. Check your connection and try again."
         }
-        return "Pull down or tap refresh to check for new songs."
+        return "Tap refresh to check for new songs."
     }
 
     func reload(playlistID: String, fallback: [Song]? = nil) {

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -20635,6 +20635,9 @@
         }
       }
     },
+    "Try another song title or artist." : {
+
+    },
     "Tune playback for Twinskaraoke" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -7138,6 +7138,9 @@
     "Features & Content" : {
 
     },
+    "Find in Playlist" : {
+
+    },
     "Follow the artist gallery for new covers as they arrive." : {
       "localizations" : {
         "de" : {
@@ -15234,6 +15237,9 @@
           }
         }
       }
+    },
+    "Refresh Playlist" : {
+
     },
     "Refresh radio metadata" : {
       "localizations" : {

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -630,6 +630,80 @@ struct SongModelTests {
         #expect(playlist.songListDTOs.map(\.id) == ["youtube-1"])
     }
 
+    @Test("Playlist search matches song titles and artists")
+    func playlistSearchMatchesTitlesAndArtists() {
+        let titleMatch = Song(
+            id: "title-match",
+            title: "Dancing Queen",
+            duration: 210,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: ["ABBA"],
+            coverArtists: nil,
+            userUploaded: false
+        )
+        let artistMatch = Song(
+            id: "artist-match",
+            title: "As It Was",
+            duration: 167,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: ["Harry Styles"],
+            coverArtists: ["Twinskaraoke"],
+            userUploaded: false
+        )
+
+        #expect(
+            PlaylistSongSearch.filter([titleMatch, artistMatch], matching: "dancing")
+                .map(\.id) == ["title-match"]
+        )
+        #expect(
+            PlaylistSongSearch.filter([titleMatch, artistMatch], matching: "harry")
+                .map(\.id) == ["artist-match"]
+        )
+        #expect(
+            PlaylistSongSearch.filter([titleMatch, artistMatch], matching: "twins")
+                .map(\.id) == ["artist-match"]
+        )
+    }
+
+    @Test("Playlist search trims its query and preserves order")
+    func playlistSearchTrimsQueryAndPreservesOrder() {
+        let first = Song(
+            id: "first",
+            title: "First Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: ["Shared Artist"],
+            coverArtists: nil,
+            userUploaded: false
+        )
+        let second = Song(
+            id: "second",
+            title: "Second Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: ["Shared Artist"],
+            coverArtists: nil,
+            userUploaded: false
+        )
+
+        #expect(
+            PlaylistSongSearch.filter([first, second], matching: "  SHARED  ")
+                .map(\.id) == ["first", "second"]
+        )
+        #expect(
+            PlaylistSongSearch.filter([first, second], matching: "   ")
+                .map(\.id) == ["first", "second"]
+        )
+    }
+
     @Test("Display artist combines original and cover artists")
     func displayArtistUsesOriginalAndCoverMetadata() {
         let song = Song(

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -704,6 +704,126 @@ struct SongModelTests {
         )
     }
 
+    @Test("Playlist search reveal requires a deliberate pull")
+    func playlistSearchRevealRequiresThreshold() {
+        var state = PlaylistSearchRevealState()
+
+        let belowThreshold = state.update(
+            pullDistance: PlaylistSearchRevealState.revealThreshold - 1,
+            isSearchVisible: false,
+            isActivelyPulling: true
+        )
+        let atThreshold = state.update(
+            pullDistance: PlaylistSearchRevealState.revealThreshold,
+            isSearchVisible: false,
+            isActivelyPulling: true
+        )
+        let repeatedAboveThreshold = state.update(
+            pullDistance: PlaylistSearchRevealState.revealThreshold + 20,
+            isSearchVisible: false,
+            isActivelyPulling: true
+        )
+
+        #expect(!belowThreshold)
+        #expect(atThreshold)
+        #expect(!repeatedAboveThreshold)
+    }
+
+    @Test("Playlist search reveal rearms after returning to rest")
+    func playlistSearchRevealRearmsAfterRelease() {
+        var state = PlaylistSearchRevealState()
+
+        let initialReveal = state.update(
+            pullDistance: PlaylistSearchRevealState.revealThreshold,
+            isSearchVisible: false,
+            isActivelyPulling: true
+        )
+        let release = state.update(
+            pullDistance: PlaylistSearchRevealState.resetThreshold,
+            isSearchVisible: false,
+            isActivelyPulling: false
+        )
+        let secondReveal = state.update(
+            pullDistance: PlaylistSearchRevealState.revealThreshold,
+            isSearchVisible: false,
+            isActivelyPulling: true
+        )
+
+        #expect(initialReveal)
+        #expect(!release)
+        #expect(secondReveal)
+    }
+
+    @Test("Playlist search reveal stays inactive while search is visible")
+    func playlistSearchRevealStaysInactiveWhileVisible() {
+        var state = PlaylistSearchRevealState()
+
+        let revealWhileVisible = state.update(
+            pullDistance: PlaylistSearchRevealState.revealThreshold + 40,
+            isSearchVisible: true,
+            isActivelyPulling: true
+        )
+
+        #expect(!revealWhileVisible)
+    }
+
+    @Test("Playlist search reveal cannot arm during ordinary scrolling")
+    func playlistSearchRevealRequiresActivePulling() {
+        var state = PlaylistSearchRevealState()
+
+        let armedWhileSettling = state.update(
+            pullDistance: PlaylistSearchRevealState.revealThreshold + 20,
+            isSearchVisible: false,
+            isActivelyPulling: false
+        )
+
+        #expect(!armedWhileSettling)
+    }
+
+    @Test("Playlist search pill hides during an intentional downward scroll")
+    func playlistSearchPillAutoHideRules() {
+        #expect(
+            PlaylistSearchRevealState.shouldAutoHide(
+                scrollOffset: PlaylistSearchRevealState.hideThreshold,
+                isReady: true,
+                isActivelyScrolling: true,
+                isSearchModeActive: false
+            )
+        )
+        #expect(
+            !PlaylistSearchRevealState.shouldAutoHide(
+                scrollOffset: PlaylistSearchRevealState.hideThreshold - 1,
+                isReady: true,
+                isActivelyScrolling: true,
+                isSearchModeActive: false
+            )
+        )
+        #expect(
+            !PlaylistSearchRevealState.shouldAutoHide(
+                scrollOffset: PlaylistSearchRevealState.hideThreshold + 20,
+                isReady: false,
+                isActivelyScrolling: true,
+                isSearchModeActive: false
+            )
+        )
+        #expect(
+            !PlaylistSearchRevealState.shouldAutoHide(
+                scrollOffset: PlaylistSearchRevealState.hideThreshold + 20,
+                isReady: true,
+                isActivelyScrolling: false,
+                isSearchModeActive: false
+            )
+        )
+        #expect(
+            !PlaylistSearchRevealState.shouldAutoHide(
+                scrollOffset: PlaylistSearchRevealState.hideThreshold + 20,
+                isReady: true,
+                isActivelyScrolling: true,
+                isSearchModeActive: true
+            )
+        )
+    }
+
     @Test("Display artist combines original and cover artists")
     func displayArtistUsesOriginalAndCoverMetadata() {
         let song = Song(


### PR DESCRIPTION
## Summary

- replace pull-to-refresh on playlist details with a deliberate pull-down search reveal
- add haptic feedback and preserve the playlist artwork parallax transition
- automatically focus search and switch to a dedicated full-song list
- filter songs live by title and artist while typing
- hide the keyboard interactively while keeping active search results stable
- move playlist refresh to the overflow menu

## Why

Playlist pull-down behavior now follows the Apple Music interaction more closely. Search is immediately available from the top of a playlist without conflating the gesture with refresh, and focused search prioritizes the complete song list instead of the playlist header.

## Validation

- `xcodebuild build` for the Debug iOS Simulator configuration
- `xcodebuild test` for `TwinskaraokeTests/SongModelTests`

## Summary by Sourcery

Add a pull-down search interaction to playlist detail screens that reveals a focused search field, drives a dedicated filtered song list, and moves playlist refresh into the overflow menu while preserving artwork parallax and improved scroll/keyboard behavior.

New Features:
- Introduce a pull-down search field at the top of playlist detail screens that focuses automatically and filters the song list by title and artist.
- Provide an inline cancelable search mode that shows dedicated playlist search results and a "No Results" empty state while keeping the full playlist accessible.

Enhancements:
- Adjust playlist artwork parallax behavior to respond to the new pull-down search interaction and preserve smooth animations with reduced motion support.
- Update playlist detail empty and loading states to work correctly with filtered search results and clarify the reload guidance text.
- Refine scroll handling and keyboard dismissal to support interactive pull-down search reveal and auto-hide behavior that avoids accidental activation.

Tests:
- Add unit tests for playlist song search filtering behavior, including title/artist matching, trimming, and order preservation.
- Add unit tests covering the pull-down search reveal and auto-hide state machine to ensure deliberate activation and stable behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-playlist search with case-insensitive matching by song title and artist.
  * Search controls can appear or hide based on scrolling and pull-down gestures.
  * Added improved search, empty, and refresh states.
  * Added a dedicated “Refresh Playlist” action.
  * Enhanced artwork motion while interacting with the playlist search.

* **Localization**
  * Added labels for “Find in Playlist” and “Refresh Playlist”.

* **Bug Fixes**
  * Updated empty playlist guidance to direct users to refresh.

* **Tests**
  * Added coverage for playlist filtering and search interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->