### PR TITLE
Live-update playlist download status

### DIFF
--- a/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
+++ b/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
@@ -4,24 +4,12 @@ struct PlaylistActionsMenuItems: View {
     let playlist: Playlist
     let songs: [Song]
     private let isSaved: Bool
-    private let pendingSongs: [Song]
-    private let inFlightCount: Int
+    @ObservedObject private var downloads = DownloadManager.shared
 
     init(playlist: Playlist, songs: [Song]) {
         self.playlist = playlist
         self.songs = songs
         isSaved = SavedPlaylistsStore.shared.isSaved(playlist)
-
-        let downloads = DownloadManager.shared
-        let state = songs.reduce(into: (pendingSongs: [Song](), inFlightCount: 0)) { state, song in
-            if downloads.isDownloading(song.id) {
-                state.inFlightCount += 1
-            } else if !downloads.isDownloaded(song.id) {
-                state.pendingSongs.append(song)
-            }
-        }
-        pendingSongs = state.pendingSongs
-        inFlightCount = state.inFlightCount
     }
 
     private var canSaveToLibrary: Bool {
@@ -29,6 +17,15 @@ struct PlaylistActionsMenuItems: View {
     }
 
     var body: some View {
+        let state = songs.reduce(into: (pendingSongs: [Song](), inFlightCount: 0)) { state, song in
+            if downloads.isDownloading(song.id) {
+                state.inFlightCount += 1
+            } else if !downloads.isDownloaded(song.id) {
+                state.pendingSongs.append(song)
+            }
+        }
+        let pendingSongs = state.pendingSongs
+        let inFlightCount = state.inFlightCount
         let pendingCount = pendingSongs.count
         let allDownloaded = !songs.isEmpty
             && pendingCount == 0
@@ -73,14 +70,14 @@ struct PlaylistActionsMenuItems: View {
             } else if allDownloaded {
                 Button(role: .destructive) {
                     AppHaptic.warning.play()
-                    DownloadManager.shared.remove(songIDs: songs.map(\.id))
+                    downloads.remove(songIDs: songs.map(\.id))
                 } label: {
                     Label("Remove Downloads", systemImage: "trash")
                 }
             } else {
                 Button {
                     AppHaptic.success.play()
-                    DownloadManager.shared.download(songs: pendingSongs)
+                    downloads.download(songs: pendingSongs)
                 } label: {
                     let label = pendingCount < songs.count ? "Download Remaining" : "Download"
                     Label(label, systemImage: "arrow.down.circle")

--- a/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
+++ b/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
@@ -17,13 +17,7 @@ struct PlaylistActionsMenuItems: View {
     }
 
     var body: some View {
-        let state = songs.reduce(into: (pendingSongs: [Song](), inFlightCount: 0)) { state, song in
-            if downloads.isDownloading(song.id) {
-                state.inFlightCount += 1
-            } else if !downloads.isDownloaded(song.id) {
-                state.pendingSongs.append(song)
-            }
-        }
+        let state = downloads.status(for: songs)
         let pendingSongs = state.pendingSongs
         let inFlightCount = state.inFlightCount
         let pendingCount = pendingSongs.count

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -60,6 +60,33 @@ struct SongDownloadStatus: Equatable, Sendable {
     }
 }
 
+struct SongCollectionDownloadStatus: Equatable, Sendable {
+    let pendingSongs: [Song]
+    let inFlightCount: Int
+
+    static func make(
+        downloadedIDs: Set<String>,
+        inProgress: Set<String>,
+        songs: [Song]
+    ) -> SongCollectionDownloadStatus {
+        var pendingSongs: [Song] = []
+        var inFlightCount = 0
+
+        for song in songs {
+            if inProgress.contains(song.id) {
+                inFlightCount += 1
+            } else if !downloadedIDs.contains(song.id) {
+                pendingSongs.append(song)
+            }
+        }
+
+        return SongCollectionDownloadStatus(
+            pendingSongs: pendingSongs,
+            inFlightCount: inFlightCount
+        )
+    }
+}
+
 @MainActor
 final class DownloadManager: ObservableObject {
     private struct PublishedState: Equatable {
@@ -304,6 +331,14 @@ final class DownloadManager: ObservableObject {
             downloadedIDs: downloadedIDs,
             inProgress: inProgress,
             songID: songID
+        )
+    }
+
+    func status(for songs: [Song]) -> SongCollectionDownloadStatus {
+        SongCollectionDownloadStatus.make(
+            downloadedIDs: downloadedIDs,
+            inProgress: inProgress,
+            songs: songs
         )
     }
 

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -241,6 +241,32 @@ struct DownloadManagerTests {
         )
     }
 
+    @Test("Collection download status separates pending and in-flight songs")
+    func collectionDownloadStatusClassifiesSongs() {
+        let songs = ["downloaded", "downloading", "pending", "overlap"].map { id in
+            Song(
+                id: id,
+                title: id,
+                duration: 180,
+                absolutePath: "/audio/\(id).mp3",
+                cloudflareID: nil,
+                coverArt: nil,
+                originalArtists: nil,
+                coverArtists: nil,
+                userUploaded: false
+            )
+        }
+
+        let status = SongCollectionDownloadStatus.make(
+            downloadedIDs: ["downloaded", "overlap"],
+            inProgress: ["downloading", "overlap"],
+            songs: songs
+        )
+
+        #expect(status.pendingSongs.map(\.id) == ["pending"])
+        #expect(status.inFlightCount == 2)
+    }
+
     @Test("Audio cache access does not mutate persistent download files")
     func cacheTouchLeavesExternalFilesUnchanged() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(


### PR DESCRIPTION
## Summary

- observe the shared download manager from the playlist actions menu
- recompute pending and in-flight song counts whenever download state changes
- keep the visible `Downloading <count>…` label current as the queue progresses

## Root cause

The playlist menu captured pending and in-flight downloads once during initialization. Because those values were immutable snapshots, the menu could not reflect later queue changes until the playlist view was recreated.

## User impact

Playlist download progress now updates live in the three-dot menu without leaving and reopening the playlist.

## Validation

- Debug iOS Simulator build
- `TwinskaraokeTests`

## Summary by Sourcery

Enhancements:
- Make playlist download progress label update dynamically as songs start or finish downloading.