### PR TITLE
Show authoritative playlist song counts

### DIFF
--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -5,24 +5,34 @@ import SwiftUI
 struct PlaylistSongCountLabel: View {
     let playlist: Playlist
     var fallbackText: String?
+    var prefersDetailCount = true
 
     @ObservedObject private var countStore = PlaylistSongCountStore.shared
 
     private var labelText: String? {
-        if let count = countStore.displayedCount(for: playlist) {
+        if let count = countStore.displayedCount(
+            for: playlist,
+            prefersDetailCount: prefersDetailCount
+        ) {
             return SongCountText.songs(count)
         }
         return fallbackText
     }
 
     var body: some View {
-        Group {
+        ZStack(alignment: .leading) {
+            Color.clear
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
             if let labelText {
                 Text(labelText)
             }
         }
         .task(id: playlist.id) {
-            countStore.loadIfNeeded(for: playlist)
+            countStore.loadIfNeeded(
+                for: playlist,
+                forceDetailCount: prefersDetailCount
+            )
         }
     }
 }
@@ -633,7 +643,10 @@ struct PlaylistsGridScreen: View {
                     LazyVGrid(columns: cols, spacing: AM.Spacing.l) {
                         ForEach(displayed) { playlist in
                             NavigationLink(destination: PlaylistDetailView(playlist: playlist)) {
-                                PlaylistGridCell(playlist: playlist)
+                                PlaylistGridCell(
+                                    playlist: playlist,
+                                    prefersDetailCount: true
+                                )
                             }
                             .buttonStyle(PressableButtonStyle())
                             .contextMenu {
@@ -681,6 +694,7 @@ struct PlaylistsGridScreen: View {
 struct PlaylistGridCell: View {
     let playlist: Playlist
     var width: CGFloat?
+    var prefersDetailCount = true
     var body: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.s) {
             artwork
@@ -690,12 +704,14 @@ struct PlaylistGridCell: View {
                 .font(AM.Font.tileTitle)
                 .foregroundStyle(.primary)
                 .lineLimit(1)
-            if !playlist.isFavorites {
-                PlaylistSongCountLabel(playlist: playlist, fallbackText: "Playlist")
-                    .font(AM.Font.tileCaption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
+            PlaylistSongCountLabel(
+                playlist: playlist,
+                fallbackText: prefersDetailCount ? nil : "Playlist",
+                prefersDetailCount: prefersDetailCount
+            )
+                .font(AM.Font.tileCaption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
         }
         .frame(width: width, alignment: .leading)
         .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -426,7 +426,7 @@ struct PlaylistDetailView: View {
     }
 
     private var songCountText: String? {
-        guard loader.hasLoadedRemoteSongs else { return nil }
+        guard loader.hasAuthoritativeSongs else { return nil }
         let songs = loader.songs ?? playlist.songListDTOs ?? []
         return SongCountText.songs(songs.count)
     }

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -415,17 +415,20 @@ struct PlaylistDetailView: View {
             Text(playlist.name)
                 .font(.title2.bold())
                 .multilineTextAlignment(alignment)
-            Text(songCountText)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            if let songCountText {
+                Text(songCountText)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
         }
         .frame(maxWidth: .infinity, alignment: alignment == .leading ? .leading : .center)
         .padding(.horizontal, alignment == .leading ? 0 : AM.Spacing.screenMargin)
     }
 
-    private var songCountText: String {
+    private var songCountText: String? {
+        guard loader.hasLoadedRemoteSongs else { return nil }
         let songs = loader.songs ?? playlist.songListDTOs ?? []
-        return SongCountText.songs(songs.isEmpty ? playlist.songCount : songs.count)
+        return SongCountText.songs(songs.count)
     }
 
     @ViewBuilder

--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -63,7 +63,7 @@ nonisolated struct PlaylistSearchRevealState: Equatable {
 class PlaylistDetailViewModel: ObservableObject {
     @Published var songs: [Song]?
     @Published var isLoading = false
-    @Published private(set) var hasLoadedRemoteSongs = false
+    @Published private(set) var hasAuthoritativeSongs = false
     @Published private var loadFailed = false
     private var loadedID: String?
     private var loadTask: Task<Void, Never>?
@@ -77,7 +77,7 @@ class PlaylistDetailViewModel: ObservableObject {
     func reload(playlistID: String, fallback: [Song]? = nil) {
         loadedID = nil
         loadFailed = false
-        hasLoadedRemoteSongs = false
+        hasAuthoritativeSongs = false
         load(playlistID: playlistID, fallback: fallback)
     }
 
@@ -85,7 +85,7 @@ class PlaylistDetailViewModel: ObservableObject {
         let alreadyLoaded = (loadedID == playlistID) && songs != nil && !isLoading
         if alreadyLoaded { return }
         if loadedID != playlistID {
-            hasLoadedRemoteSongs = false
+            hasAuthoritativeSongs = false
         }
         loadedID = playlistID
         loadTask?.cancel()
@@ -99,7 +99,7 @@ class PlaylistDetailViewModel: ObservableObject {
             songs = fallback
             isLoading = false
             loadFailed = false
-            hasLoadedRemoteSongs = true
+            hasAuthoritativeSongs = true
             return
         }
         isLoading = true
@@ -173,7 +173,7 @@ class PlaylistDetailViewModel: ObservableObject {
         if let list {
             songs = list
             if isAuthoritative {
-                hasLoadedRemoteSongs = true
+                hasAuthoritativeSongs = true
                 PlaylistSongCountStore.shared.recordResolvedCount(list.count, for: playlistID)
             }
         }

--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -63,6 +63,7 @@ nonisolated struct PlaylistSearchRevealState: Equatable {
 class PlaylistDetailViewModel: ObservableObject {
     @Published var songs: [Song]?
     @Published var isLoading = false
+    @Published private(set) var hasLoadedRemoteSongs = false
     @Published private var loadFailed = false
     private var loadedID: String?
     private var loadTask: Task<Void, Never>?
@@ -76,12 +77,16 @@ class PlaylistDetailViewModel: ObservableObject {
     func reload(playlistID: String, fallback: [Song]? = nil) {
         loadedID = nil
         loadFailed = false
+        hasLoadedRemoteSongs = false
         load(playlistID: playlistID, fallback: fallback)
     }
 
     func load(playlistID: String, fallback: [Song]?) {
         let alreadyLoaded = (loadedID == playlistID) && songs != nil && !isLoading
         if alreadyLoaded { return }
+        if loadedID != playlistID {
+            hasLoadedRemoteSongs = false
+        }
         loadedID = playlistID
         loadTask?.cancel()
         if songs?.isEmpty ?? true, let fallback, !fallback.isEmpty {
@@ -94,6 +99,7 @@ class PlaylistDetailViewModel: ObservableObject {
             songs = fallback
             isLoading = false
             loadFailed = false
+            hasLoadedRemoteSongs = true
             return
         }
         isLoading = true
@@ -108,7 +114,8 @@ class PlaylistDetailViewModel: ObservableObject {
                     self?.applyLoadedSongs(
                         fallbackWithDurations,
                         playlistID: playlistID,
-                        requestFailed: false
+                        requestFailed: false,
+                        isAuthoritative: false
                     )
                 }
 
@@ -117,7 +124,8 @@ class PlaylistDetailViewModel: ObservableObject {
                 self?.applyLoadedSongs(
                     loadedSongs,
                     playlistID: playlistID,
-                    requestFailed: false
+                    requestFailed: false,
+                    isAuthoritative: true
                 )
 
                 let songsWithDurations = await UploadedSongDurationResolver.shared
@@ -132,7 +140,8 @@ class PlaylistDetailViewModel: ObservableObject {
                 self?.applyLoadedSongs(
                     songsWithDurations,
                     playlistID: playlistID,
-                    requestFailed: false
+                    requestFailed: false,
+                    isAuthoritative: true
                 )
             } catch {
                 guard !Task.isCancelled else { return }
@@ -140,7 +149,12 @@ class PlaylistDetailViewModel: ObservableObject {
                     "Playlist \(playlistID) load failed: \(String(describing: error))",
                     category: .network
                 )
-                self?.applyLoadedSongs(nil, playlistID: playlistID, requestFailed: true)
+                self?.applyLoadedSongs(
+                    nil,
+                    playlistID: playlistID,
+                    requestFailed: true,
+                    isAuthoritative: false
+                )
             }
         }
     }
@@ -149,10 +163,19 @@ class PlaylistDetailViewModel: ObservableObject {
         loadTask?.cancel()
     }
 
-    private func applyLoadedSongs(_ list: [Song]?, playlistID: String, requestFailed: Bool) {
+    private func applyLoadedSongs(
+        _ list: [Song]?,
+        playlistID: String,
+        requestFailed: Bool,
+        isAuthoritative: Bool
+    ) {
         guard loadedID == playlistID else { return }
         if let list {
             songs = list
+            if isAuthoritative {
+                hasLoadedRemoteSongs = true
+                PlaylistSongCountStore.shared.recordResolvedCount(list.count, for: playlistID)
+            }
         }
         loadFailed = requestFailed && (songs?.isEmpty ?? true)
         isLoading = false

--- a/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
+++ b/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
@@ -8,20 +8,29 @@ final class PlaylistSongCountStore: ObservableObject {
     @Published private var resolvedCounts: [String: Int] = [:]
     private var loadingIDs: Set<String> = []
 
-    func displayedCount(for playlist: Playlist) -> Int? {
-        if let resolved = resolvedCounts[playlist.id], resolved > 0 {
+    func displayedCount(for playlist: Playlist, prefersDetailCount: Bool = false) -> Int? {
+        if playlist.isFavorites {
+            return playlist.songCount
+        }
+        if let resolved = resolvedCounts[playlist.id] {
             return resolved
         }
-        let embeddedCount = playlist.songListDTOs?.count ?? 0
-        if embeddedCount > 0 {
-            return max(playlist.songCount, embeddedCount)
+        if prefersDetailCount {
+            return nil
         }
-        return playlist.songCount > 0 ? playlist.songCount : nil
+        if playlist.songCount > 0 {
+            return playlist.songCount
+        }
+        let embeddedCount = playlist.songListDTOs?.count ?? 0
+        return embeddedCount > 0 ? embeddedCount : nil
     }
 
-    func loadIfNeeded(for playlist: Playlist) {
-        guard !playlist.isFavorites, !playlist.isPersonal else { return }
-        guard playlist.songCount == 0 else { return }
+    func loadIfNeeded(for playlist: Playlist, forceDetailCount: Bool = false) {
+        guard !playlist.isFavorites else { return }
+        let isSavedPlaylist = SavedPlaylistsStore.shared.isSaved(playlist)
+        guard forceDetailCount
+            || Self.needsDetailCount(for: playlist, isSaved: isSavedPlaylist)
+        else { return }
         guard resolvedCounts[playlist.id] == nil else { return }
         guard !loadingIDs.contains(playlist.id) else { return }
 
@@ -35,9 +44,18 @@ final class PlaylistSongCountStore: ObservableObject {
             }
 
             loadingIDs.remove(playlist.id)
-            if let count, count > 0 {
+            if let count {
                 resolvedCounts[playlist.id] = count
             }
         }
+    }
+
+    func recordResolvedCount(_ count: Int, for playlistID: String) {
+        resolvedCounts[playlistID] = max(0, count)
+    }
+
+    static func needsDetailCount(for playlist: Playlist, isSaved: Bool) -> Bool {
+        guard !playlist.isFavorites else { return false }
+        return playlist.isPersonal || isSaved || playlist.songCount == 0
     }
 }

--- a/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
+++ b/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
@@ -9,11 +9,11 @@ final class PlaylistSongCountStore: ObservableObject {
     private var loadingIDs: Set<String> = []
 
     func displayedCount(for playlist: Playlist, prefersDetailCount: Bool = false) -> Int? {
-        if playlist.isFavorites {
-            return playlist.songCount
-        }
         if let resolved = resolvedCounts[playlist.id] {
             return resolved
+        }
+        if playlist.isFavorites {
+            return playlist.songCount
         }
         if prefersDetailCount {
             return nil

--- a/Twinskaraoke/Models/Library/UserPlaylist.swift
+++ b/Twinskaraoke/Models/Library/UserPlaylist.swift
@@ -38,7 +38,7 @@ struct UserPlaylist: Codable, Identifiable, Hashable {
                 mediaArray = [Media(absolutePath: path)]
             }
         }
-        let effectiveCount = max(songCount, songListDTOs?.count ?? 0)
+        let effectiveCount = songCount > 0 ? songCount : songListDTOs?.count ?? 0
         var p = Playlist(
             id: id,
             name: name,

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -619,7 +619,7 @@ nonisolated struct PlaylistListItem: Decodable, Identifiable, Sendable {
   }
 
   func asPlaylist() -> Playlist {
-    let effectiveCount = max(songCount, songListDTOs?.count ?? 0)
+    let effectiveCount = songCount > 0 ? songCount : songListDTOs?.count ?? 0
     return Playlist(
       id: id,
       name: name,

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -169,7 +169,7 @@ nonisolated enum KaraokeAPIClient {
   static func playlistSongCount(id: String) async throws -> Int? {
     let data = try await playlistDetailData(id: id)
     if let playlist = try? decode(Playlist.self, from: data) {
-      return max(playlist.songCount, playlist.songListDTOs?.count ?? 0)
+      return playlist.songListDTOs?.count ?? (playlist.songCount > 0 ? playlist.songCount : nil)
     }
     return SongPayloadDecoder.decodeSongs(from: data)?.count
   }

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -630,6 +630,93 @@ struct SongModelTests {
         #expect(playlist.songListDTOs.map(\.id) == ["youtube-1"])
     }
 
+    @Test("Playlist summaries prefer the declared song count")
+    func playlistSummaryPrefersDeclaredSongCount() throws {
+        let json = """
+        {
+          "id": "playlist-count",
+          "name": "Bangers",
+          "songCount": 2,
+          "songListDTOs": [
+            {"id": "song-1", "title": "One"},
+            {"id": "song-2", "title": "Two"},
+            {"id": "song-3", "title": "Three"}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let item = try JSONDecoder().decode(PlaylistListItem.self, from: json)
+
+        #expect(item.asPlaylist().songCount == 2)
+    }
+
+    @Test("Playlist summaries fall back to the embedded song count")
+    func playlistSummaryFallsBackToEmbeddedSongCount() throws {
+        let json = """
+        {
+          "id": "playlist-fallback-count",
+          "name": "Bangers",
+          "songCount": 0,
+          "songListDTOs": [
+            {"id": "song-1", "title": "One"},
+            {"id": "song-2", "title": "Two"}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let item = try JSONDecoder().decode(PlaylistListItem.self, from: json)
+
+        #expect(item.asPlaylist().songCount == 2)
+    }
+
+    @Test("Favourite Songs exposes a zero count")
+    @MainActor
+    func favoritesPlaylistExposesZeroCount() {
+        let playlist = Playlist(
+            id: Playlist.favoritesID,
+            name: "Favourite Songs",
+            songCount: 0,
+            mosaicMedia: nil,
+            songListDTOs: []
+        )
+
+        #expect(PlaylistSongCountStore.shared.displayedCount(for: playlist) == 0)
+    }
+
+    @Test("Personal playlist counts are resolved from playlist detail")
+    @MainActor
+    func personalPlaylistCountUsesDetail() {
+        var playlist = Playlist(
+            id: "personal-bangers",
+            name: "Bangers",
+            songCount: 498,
+            mosaicMedia: nil,
+            songListDTOs: nil
+        )
+        playlist.isPersonal = true
+
+        #expect(PlaylistSongCountStore.needsDetailCount(for: playlist, isSaved: false))
+    }
+
+    @Test("Playlist grid hides an unverified summary count")
+    @MainActor
+    func playlistGridWaitsForDetailCount() {
+        let playlist = Playlist(
+            id: "summary-bangers",
+            name: "Bangers",
+            songCount: 498,
+            mosaicMedia: nil,
+            songListDTOs: nil
+        )
+
+        #expect(
+            PlaylistSongCountStore.shared.displayedCount(
+                for: playlist,
+                prefersDetailCount: true
+            ) == nil
+        )
+    }
+
     @Test("Playlist search matches song titles and artists")
     func playlistSearchMatchesTitlesAndArtists() {
         let titleMatch = Song(

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -672,6 +672,7 @@ struct SongModelTests {
     @Test("Favourite Songs exposes a zero count")
     @MainActor
     func favoritesPlaylistExposesZeroCount() {
+        let store = PlaylistSongCountStore()
         let playlist = Playlist(
             id: Playlist.favoritesID,
             name: "Favourite Songs",
@@ -680,7 +681,24 @@ struct SongModelTests {
             songListDTOs: []
         )
 
-        #expect(PlaylistSongCountStore.shared.displayedCount(for: playlist) == 0)
+        #expect(store.displayedCount(for: playlist) == 0)
+    }
+
+    @Test("Favourite Songs prefers an authoritative cached count")
+    @MainActor
+    func favoritesPlaylistPrefersAuthoritativeCount() {
+        let store = PlaylistSongCountStore()
+        let playlist = Playlist(
+            id: Playlist.favoritesID,
+            name: "Favourite Songs",
+            songCount: 73,
+            mosaicMedia: nil,
+            songListDTOs: nil
+        )
+
+        store.recordResolvedCount(74, for: playlist.id)
+
+        #expect(store.displayedCount(for: playlist) == 74)
     }
 
     @Test("Personal playlist counts are resolved from playlist detail")
@@ -701,6 +719,7 @@ struct SongModelTests {
     @Test("Playlist grid hides an unverified summary count")
     @MainActor
     func playlistGridWaitsForDetailCount() {
+        let store = PlaylistSongCountStore()
         let playlist = Playlist(
             id: "summary-bangers",
             name: "Bangers",
@@ -710,7 +729,7 @@ struct SongModelTests {
         )
 
         #expect(
-            PlaylistSongCountStore.shared.displayedCount(
+            store.displayedCount(
                 for: playlist,
                 prefersDetailCount: true
             ) == nil


### PR DESCRIPTION
## What changed

- resolve visible playlist-card counts from playlist detail instead of trusting stale summary totals
- keep unverified counts hidden without displaying loading text
- cache authoritative detail counts across playlist views
- display the server-backed count for Favourite Songs
- prefer declared summary counts over embedded fallback collections when decoding playlist lists

## Why

Playlist summary responses can report a different total than the actual song collection. For example, Bangers reports 498 songs in overview data but its detail response contains 497 playable tracks. The UI previously displayed the stale total until the playlist was opened.

## User impact

Playlist cards now load and display only a verified detail count. Opening a playlist is no longer required to correct its count, and Favourite Songs displays its song total consistently with other playlists.

## Validation

- `TwinskaraokeTests/SongModelTests`
- Debug build for the generic iOS Simulator

## Summary by Sourcery

Align playlist song counts with authoritative server-backed detail data across playlist cards and detail views.

New Features:
- Use playlist detail responses to resolve and cache authoritative song counts for personal and saved playlists.
- Expose Favourite Songs count consistently with other playlists, including when the total is zero.

Enhancements:
- Prefer declared summary song counts over embedded collections when building playlist models, with a fallback to embedded counts when no explicit count is provided.
- Hide unverified playlist counts on grid cells until a detail-backed value is available, instead of showing potentially stale totals.
- Propagate playlist detail load state to only display song totals after remote songs have been fetched.

Tests:
- Add unit tests covering playlist summary count preference and fallback behavior, Favourite Songs zero-count handling, and detail-based resolution of personal playlist counts and grid display behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Playlist song counts now display more accurately across library grids and playlist details.
  * Detailed counts load when needed for saved and personal playlists, including playlists with zero songs.
  * Playlist details avoid showing unverified summary counts until current song data has loaded.
  * Favorite playlists continue to display their established count behavior, while unavailable counts use clearer fallback text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->