### PR TITLE
UI polish, performance optimizations, and bug fixes

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -131,6 +131,7 @@ struct ContentView: View {
 private struct PopupHostView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.appReduceMotion) private var reduceMotion
+    @StateObject private var homeViewModel = HomeViewModel()
     @State private var selectedSection: RootSection?
     @State private var showCaptcha = false
 
@@ -140,6 +141,7 @@ private struct PopupHostView: View {
 
     var body: some View {
         rootShell
+            .environmentObject(homeViewModel)
             .modifier(PopupModifier())
             .onAppear {
                 configureTabBarAppearance()
@@ -260,7 +262,7 @@ private struct PopupHostView: View {
     }
 
     private var shellTransition: AnyTransition {
-        reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .trailing))
+        reduceMotion ? .opacity : .opacity
     }
 
     private func configureTabBarAppearance() {
@@ -435,8 +437,10 @@ private struct SidebarNowPlayingHint: View {
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Now Playing")
                 .accessibilityValue(popupState.subtitle.isEmpty ? popupState.title : "\(popupState.title), \(popupState.subtitle)")
+                .transition(.opacity)
             }
         }
+        .animation(AppMotion.quick, value: popupState.hasCurrentSong)
     }
 
     @ViewBuilder

--- a/Twinskaraoke/Components/Account/AboutComponents.swift
+++ b/Twinskaraoke/Components/Account/AboutComponents.swift
@@ -70,7 +70,7 @@ struct AboutIconBadge: View {
         Image(systemName: systemImage)
             .font(.system(size: size * 0.63, weight: .semibold))
             .symbolRenderingMode(.hierarchical)
-            .foregroundStyle(Color.appAccent)
+            .foregroundStyle(color)
             .frame(width: size + 6, height: size)
     }
 }

--- a/Twinskaraoke/Components/Account/BadgeViews.swift
+++ b/Twinskaraoke/Components/Account/BadgeViews.swift
@@ -48,7 +48,7 @@ struct BadgeGridCell: View {
                 if !badge.unlocked {
                     Image(systemName: "lock.fill")
                         .font(.caption.bold())
-                        .foregroundStyle(.white)
+                        .foregroundStyle(Color.appBackground)
                         .frame(width: 19, height: 19)
                         .background(Color.primary.opacity(0.72), in: Circle())
                         .overlay(Circle().strokeBorder(Color.appBackground, lineWidth: 2))
@@ -145,7 +145,7 @@ private struct BadgeDetailIcon: View {
             if !badge.unlocked {
                 Image(systemName: "lock.fill")
                     .font(.headline)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color.appBackground)
                     .frame(width: 44, height: 44)
                     .background(Color.primary.opacity(0.76), in: Circle())
                     .overlay(Circle().strokeBorder(Color.appBackground, lineWidth: 3))

--- a/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
+++ b/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
@@ -3,13 +3,11 @@ import SwiftUI
 struct PlaylistActionsMenuItems: View {
     let playlist: Playlist
     let songs: [Song]
-    private let isSaved: Bool
+    @ObservedObject private var savedStore = SavedPlaylistsStore.shared
     @ObservedObject private var downloads = DownloadManager.shared
 
-    init(playlist: Playlist, songs: [Song]) {
-        self.playlist = playlist
-        self.songs = songs
-        isSaved = SavedPlaylistsStore.shared.isSaved(playlist)
+    private var isSaved: Bool {
+        savedStore.isSaved(playlist)
     }
 
     private var canSaveToLibrary: Bool {

--- a/Twinskaraoke/Components/Media/ArtThumbnail.swift
+++ b/Twinskaraoke/Components/Media/ArtThumbnail.swift
@@ -27,6 +27,5 @@ struct ArtThumbnail: View {
                     .padding(7)
             }
         }
-        .shadow(color: Color.appShadow.opacity(0.7), radius: 8, y: 4)
     }
 }

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -11,6 +11,7 @@ struct RemoteArtworkImage: View {
     var fullResolution: Bool = false
 
     var fixedDisplaySize: CGSize?
+    @ObservedObject private var scrollState = ScrollPerformanceState.shared
     @State private var fullLoaded: Bool = false
     @State private var loadFailed: Bool = false
     @State private var renderedFullURL: URL?
@@ -53,7 +54,7 @@ struct RemoteArtworkImage: View {
                         .aspectRatio(contentMode: contentMode)
                         .frame(width: displaySize.width, height: displaySize.height)
                         .clipped()
-                        .blur(radius: 2)
+                        .blur(radius: scrollState.isScrolling ? 0 : 2)
                 } placeholder: {
                     Color.clear
                 }
@@ -137,7 +138,7 @@ struct RemoteArtworkImage: View {
     }
 
     private var shouldAnimateLoad: Bool {
-        !ScrollPerformanceState.shared.isScrolling && shouldPreferProgressiveArtwork
+        !scrollState.isScrolling && shouldPreferProgressiveArtwork
     }
 
     private var shouldPreferProgressiveArtwork: Bool {
@@ -158,8 +159,9 @@ struct RemoteArtworkImage: View {
 
     private func evictFailedImageCache(for failedURL: URL) {
         let cacheKey = failedURL.absoluteString
-        SDImageCache.shared.removeImageFromMemory(forKey: cacheKey)
-        SDImageCache.shared.removeImageFromDisk(forKey: cacheKey)
+        // Async variant: removes from memory immediately and evicts the disk
+        // entry off the calling (main) queue.
+        SDImageCache.shared.removeImage(forKey: cacheKey, fromDisk: true, withCompletion: nil)
     }
 
     private func sanitizedDisplaySize(_ size: CGSize) -> CGSize {

--- a/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
+++ b/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
@@ -101,6 +101,7 @@ struct AppleMusicProgressBar: View {
                     }
             )
             .animation(scrubAnimation, value: isScrubbing)
+            .animation(isScrubbing || reduceMotion ? nil : .linear(duration: 0.25), value: clampedProgress)
         }
         .frame(height: controlHeight)
         .accessibilityElement(children: .ignore)

--- a/Twinskaraoke/Components/Player/KaraokeRightDock.swift
+++ b/Twinskaraoke/Components/Player/KaraokeRightDock.swift
@@ -44,7 +44,7 @@ struct KaraokeRightDock: View {
             return "On, removal level \(vocalRemovalPercent)%"
         }
         if shouldShowProcessingIndicator {
-            return "Preparing, \(processingPercentText)"
+            return isProcessing ? "Preparing, \(processingPercentText)" : "Preparing"
         }
         return "Off"
     }
@@ -99,7 +99,7 @@ struct KaraokeRightDock: View {
         }
         .buttonStyle(PressableButtonStyle(scale: 0.9, dim: 0.7))
         .disabled(!canActivateKaraoke)
-        .animation(dockAnimation, value: processingFraction)
+        .animation(reduceMotion ? nil : .linear(duration: 0.2), value: processingFraction)
         .accessibilityLabel(audioManager.karaokeMode ? "Turn Off Vocal Removal" : "Vocal Removal")
         .accessibilityValue(karaokeButtonAccessibilityValue)
         .accessibilityHint(karaokeButtonAccessibilityHint)
@@ -138,16 +138,27 @@ struct KaraokeRightDock: View {
 
     private var processingIndicator: some View {
         VStack(spacing: 4) {
-            Text(processingPercentText)
-                .font(.caption.monospacedDigit())
-                .bold()
-                .foregroundStyle(isProcessing ? Color.appAccent : .secondary)
-                .monospacedDigit()
+            // progressFraction is only non-zero while VocalSeparator is actively
+            // processing this song, so only show a percentage then; while merely
+            // queued/locked show an indeterminate label instead of "0%".
+            if isProcessing {
+                Text(processingPercentText)
+                    .font(.caption.monospacedDigit())
+                    .bold()
+                    .foregroundStyle(Color.appAccent)
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+            } else {
+                Text("Preparing")
+                    .font(.caption)
+                    .bold()
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding(.top, -2)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Preparing vocal removal")
-        .accessibilityValue(processingPercentText)
+        .accessibilityValue(isProcessing ? processingPercentText : "Preparing")
     }
 
     private var dockAnimation: Animation? {
@@ -160,7 +171,9 @@ struct KaraokeRightDock: View {
 
     private var karaokeButtonAccessibilityValue: String {
         if audioManager.karaokeMode { return "On" }
-        if shouldShowProcessingIndicator { return "Preparing, \(processingPercentText)" }
+        if shouldShowProcessingIndicator {
+            return isProcessing ? "Preparing, \(processingPercentText)" : "Preparing"
+        }
         return "Off"
     }
 

--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -10,6 +10,7 @@ struct PlayerAmbientBackground: View {
     var isPlaying: Bool = true
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var palette: ArtworkPalette = .placeholder
+    @State private var paletteSourceURL: URL?
     @State private var animationPhase: Bool = false
 
     private var shouldAnimateAmbient: Bool {
@@ -85,13 +86,13 @@ struct PlayerAmbientBackground: View {
                         .frame(width: geo.size.width, height: geo.size.height)
                         .blur(radius: runtimeBlurRadius)
                         .saturation(1.05)
+                        .drawingGroup()
                         .scaleEffect(shouldAnimateAmbient ? 1.28 : 1.22)
                         .offset(
                             x: shouldAnimateAmbient ? 8 : -8,
                             y: shouldAnimateAmbient ? -6 : 6
                         )
                         .clipped()
-                        .drawingGroup()
                         .transition(.opacity)
                 } placeholder: {
                     fallbackGradient
@@ -189,9 +190,13 @@ struct PlayerAmbientBackground: View {
 
     private func loadPalette() {
         guard let url = artworkURL else {
+            paletteSourceURL = nil
             palette = .placeholder
             return
         }
+        // Tag the request with its URL so a slow extraction for an older
+        // artwork can't overwrite a newer palette after quick song skips.
+        paletteSourceURL = url
         #if canImport(UIKit)
             SDWebImageManager.shared.loadImage(
                 with: url,
@@ -204,6 +209,7 @@ struct PlayerAmbientBackground: View {
                 Task.detached(priority: .utility) {
                     let extracted = ArtworkPalette(image: image)
                     await MainActor.run {
+                        guard paletteSourceURL == url else { return }
                         palette = extracted
                     }
                 }

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -213,13 +213,6 @@ enum MusicGridCardSize: Equatable {
         case .compact: 6
         }
     }
-
-    var usesShadow: Bool {
-        switch self {
-        case .regular: true
-        case .compact: false
-        }
-    }
 }
 
 struct MusicGridCard: View {
@@ -292,13 +285,11 @@ struct MusicGridCard: View {
             artworkContent
                 .frame(width: width, height: width)
                 .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
-                .modifier(MusicGridCardShadow(enabled: size.usesShadow))
         } else {
             artworkContent
                 .aspectRatio(1, contentMode: .fit)
                 .frame(maxWidth: .infinity)
                 .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
-                .modifier(MusicGridCardShadow(enabled: size.usesShadow))
         }
     }
 
@@ -314,18 +305,6 @@ struct MusicGridCard: View {
         } else {
             MusicArtworkPlaceholder(cornerRadius: AM.Radius.card)
         }
-    }
-}
-
-private struct MusicGridCardShadow: ViewModifier {
-    let enabled: Bool
-
-    func body(content: Content) -> some View {
-        content.shadow(
-            color: enabled ? AM.Shadow.card.color : .clear,
-            radius: enabled ? AM.Shadow.card.radius : 0,
-            y: enabled ? AM.Shadow.card.y : 0
-        )
     }
 }
 

--- a/Twinskaraoke/Features/Account/DeveloperMenuView.swift
+++ b/Twinskaraoke/Features/Account/DeveloperMenuView.swift
@@ -51,7 +51,23 @@ struct DeveloperMenuView: View {
                 .first(where: { $0.activationState == .foregroundActive }),
                 let root = windowScene.keyWindow?.rootViewController
             {
-                root.present(av, animated: true)
+                var presenter = root
+                while let presented = presenter.presentedViewController {
+                    presenter = presented
+                }
+                // UIActivityViewController is a popover on iPad and crashes
+                // without a source view/rect.
+                if let popover = av.popoverPresentationController {
+                    popover.sourceView = presenter.view
+                    popover.sourceRect = CGRect(
+                        x: presenter.view.bounds.midX,
+                        y: presenter.view.bounds.midY,
+                        width: 0,
+                        height: 0
+                    )
+                    popover.permittedArrowDirections = []
+                }
+                presenter.present(av, animated: true)
             }
         #endif
     }

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -710,7 +710,7 @@ private struct EqualizerBands: View {
         HStack(alignment: .bottom, spacing: 6) {
             ForEach(0 ..< AVEnginePlayback.eqBandCount, id: \.self) { i in
                 VStack(spacing: 6) {
-                    Text(gainLabel(gainsDB[i]))
+                    Text(gainLabel(gainsDB.indices.contains(i) ? gainsDB[i] : 0))
                         .font(.caption.monospacedDigit())
                         .foregroundStyle(.secondary)
                         .frame(height: 12)

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 struct BrowseSongCollectionView: View {
     let title: String
@@ -6,6 +7,7 @@ struct BrowseSongCollectionView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showsCollapsedTitle = false
+    @State private var fallbackHeroURL: URL?
 
     private func usesWideOverview(availableWidth: CGFloat) -> Bool {
         AM.Layout.usesWideCanvas(
@@ -122,8 +124,21 @@ struct BrowseSongCollectionView: View {
     @ViewBuilder
     private var heroArtwork: some View {
         let heroSong = songs.first(where: { $0.hasOwnArtwork })
-        let artURL = heroSong?.imageURL ?? FallbackArtProvider.shared.randomURL
+        // The random fallback is picked once per collection; drawing it in
+        // `body` directly would swap the hero image on every re-render.
+        let artURL = heroSong?.imageURL ?? fallbackHeroURL
         RemoteArtworkImage(url: artURL, cornerRadius: 0, contentMode: .fill, lowResURL: heroSong?.thumbnailURL)
+            .onAppear {
+                pickFallbackHeroURLIfNeeded()
+            }
+            .onReceive(FallbackArtProvider.shared.objectWillChange) { _ in
+                pickFallbackHeroURLIfNeeded()
+            }
+    }
+
+    private func pickFallbackHeroURLIfNeeded() {
+        guard fallbackHeroURL == nil else { return }
+        fallbackHeroURL = FallbackArtProvider.shared.randomURL
     }
 
     @ViewBuilder

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -132,6 +132,7 @@ struct BrowseSongCollectionView: View {
                 pickFallbackHeroURLIfNeeded()
             }
             .onReceive(FallbackArtProvider.shared.objectWillChange) { _ in
+                fallbackHeroURL = nil
                 pickFallbackHeroURLIfNeeded()
             }
     }

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct HomeView: View {
-    @StateObject var viewModel = HomeViewModel()
+    @EnvironmentObject var viewModel: HomeViewModel
     @StateObject private var recentlyPlayed = RecentlyPlayedStore.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.appReduceMotion) private var reduceMotion
@@ -40,7 +40,7 @@ struct HomeView: View {
                     AccountToolbarButton()
                 }
             }
-            .refreshable { viewModel.fetchHomeData(force: true) }
+            .refreshable { await viewModel.refreshHomeData() }
             .onChange(of: artworkPrefetchSignature) { _, _ in
                 prefetchVisibleArtworkIfNeeded()
             }

--- a/Twinskaraoke/Features/Home/HomeWideHero.swift
+++ b/Twinskaraoke/Features/Home/HomeWideHero.swift
@@ -163,7 +163,7 @@ private struct WideSongHeroCard: View {
                 RoundedRectangle(cornerRadius: AM.Radius.hero, style: .continuous)
                     .strokeBorder(Color.appDivider, lineWidth: 0.8)
             }
-            .amShadow(AM.Shadow.heroPlaying)
+            .amShadow(AM.Shadow.heroIdle)
         }
         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.88, haptic: .selection))
         .accessibilityElement(children: .combine)

--- a/Twinskaraoke/Features/Home/NewView.swift
+++ b/Twinskaraoke/Features/Home/NewView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct NewView: View {
-    @StateObject var viewModel = HomeViewModel()
+    @EnvironmentObject var viewModel: HomeViewModel
     @StateObject private var recentlyPlayed = RecentlyPlayedStore.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.appReduceMotion) private var reduceMotion
@@ -39,7 +39,7 @@ struct NewView: View {
                     AccountToolbarButton()
                 }
             }
-            .refreshable { viewModel.fetchHomeData(force: true) }
+            .refreshable { await viewModel.refreshHomeData() }
             .onChange(of: artworkPrefetchSignature) { _, _ in
                 prefetchVisibleArtworkIfNeeded()
             }

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 #if canImport(UIKit)
+    import SDWebImage
     import UIKit
 #endif
 
@@ -10,6 +11,7 @@ struct ArtDetailView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showFullScreen = false
     @State private var saveStatus: ArtworkSaveStatus = .idle
+    @State private var saveGeneration = 0
     @State private var appeared = false
     private var fullResURL: URL? {
         art.fullHDImageURL ?? art.imageURL
@@ -100,29 +102,52 @@ struct ArtDetailView: View {
         guard let url = fullResURL else { return }
         AppHaptic.selection.play()
         saveStatus = .saving
+        saveGeneration &+= 1
+        let generation = saveGeneration
+        #if canImport(UIKit)
+            // RemoteArtworkImage already downloaded this exact URL into the
+            // shared SDWebImage memory cache; reuse it instead of re-downloading.
+            if let cached = SDImageCache.shared.imageFromMemoryCache(forKey: url.absoluteString) {
+                saveLoadedImage(cached, generation: generation)
+                return
+            }
+        #endif
         URLSession.shared.dataTask(with: url) { data, _, error in
             DispatchQueue.main.async {
                 #if canImport(UIKit)
                     if let data, let image = UIImage(data: data) {
-                        ImageSaver.shared.save(image: image) { result in
-                            DispatchQueue.main.async {
-                                switch result {
-                                case .success:
-                                    saveStatus = .success
-                                case let .failure(err):
-                                    saveStatus = .failed(err.localizedDescription)
-                                }
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                    saveStatus = .idle
-                                }
-                            }
-                        }
+                        saveLoadedImage(image, generation: generation)
                         return
                     }
                 #endif
                 saveStatus = .failed(error?.localizedDescription ?? "Couldn't save")
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { saveStatus = .idle }
+                resetSaveStatusLater(generation: generation)
             }
         }.resume()
+    }
+
+    #if canImport(UIKit)
+        private func saveLoadedImage(_ image: UIImage, generation: Int) {
+            ImageSaver.shared.save(image: image) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success:
+                        saveStatus = .success
+                    case let .failure(err):
+                        saveStatus = .failed(err.localizedDescription)
+                    }
+                    resetSaveStatusLater(generation: generation)
+                }
+            }
+        }
+    #endif
+
+    private func resetSaveStatusLater(generation: Int) {
+        // A second save may start before this timer fires; only reset the
+        // status that belongs to this save cycle.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            guard saveGeneration == generation else { return }
+            saveStatus = .idle
+        }
     }
 }

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtGalleryView.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtGalleryView.swift
@@ -100,12 +100,11 @@ struct ArtGalleryView: View {
     }
 
     private var featuredArt: (art: GalleryArt, artist: GalleryArtist)? {
-        for artist in viewModel.artists {
-            if let art = artist.arts?.max(by: { ($0.upvotes ?? 0) < ($1.upvotes ?? 0) }) {
-                return (art, artist)
+        viewModel.artists
+            .flatMap { artist in
+                (artist.arts ?? []).map { (art: $0, artist: artist) }
             }
-        }
-        return nil
+            .max { ($0.art.upvotes ?? 0) < ($1.art.upvotes ?? 0) }
     }
 
     private var topArtists: [GalleryArtist] {

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
@@ -28,7 +28,6 @@ struct ArtistCircleCard: View {
             }
             .frame(width: 96, height: 96)
             .clipShape(Circle())
-            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
             Text(artist.name)
                 .scaledSystemFont(size: 13, weight: .medium)
                 .foregroundColor(.primary)

--- a/Twinskaraoke/Features/Library/ArtGallery/FeaturedArtCard.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/FeaturedArtCard.swift
@@ -20,7 +20,6 @@ struct FeaturedArtCard: View {
             .aspectRatio(4 / 5, contentMode: .fill)
             .frame(maxWidth: .infinity)
             .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-            .shadow(color: .black.opacity(0.2), radius: 14, y: 6)
             LinearGradient(
                 colors: [.clear, .black.opacity(0.7)],
                 startPoint: .center, endPoint: .bottom

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -7,6 +7,10 @@ struct ArtistsView: View {
     @State private var searchText = ""
 
 
+    private var isQueryEmpty: Bool {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     private var displayedArtists: [Artist] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return viewModel.artists }
@@ -22,7 +26,7 @@ struct ArtistsView: View {
                 ArtistsSkeletonView()
                     .transition(.opacity)
             } else if displayedArtists.isEmpty {
-                if viewModel.loadFailed, searchText.isEmpty {
+                if viewModel.loadFailed, isQueryEmpty {
                     VStack(spacing: AM.Spacing.l) {
                         MusicEmptyState(
                             title: "Couldn't Load Artists",
@@ -36,8 +40,8 @@ struct ArtistsView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     MusicEmptyState(
-                        title: searchText.isEmpty ? "No Artists" : "No Results",
-                        message: searchText.isEmpty
+                        title: isQueryEmpty ? "No Artists" : "No Results",
+                        message: isQueryEmpty
                             ? "Artists you load from Twinskaraoke will appear here."
                             : "Try another artist."
                     )

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -22,13 +22,27 @@ struct ArtistsView: View {
                 ArtistsSkeletonView()
                     .transition(.opacity)
             } else if displayedArtists.isEmpty {
-                MusicEmptyState(
-                    title: searchText.isEmpty ? "No Artists" : "No Results",
-                    message: searchText.isEmpty
-                        ? "Artists you load from Twinskaraoke will appear here."
-                        : "Try another artist."
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                if viewModel.loadFailed, searchText.isEmpty {
+                    VStack(spacing: AM.Spacing.l) {
+                        MusicEmptyState(
+                            title: "Couldn't Load Artists",
+                            message: "Check your connection and try again."
+                        )
+                        MusicEmptyActionButton(title: "Try Again") {
+                            AppHaptic.selection.play()
+                            viewModel.refresh()
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    MusicEmptyState(
+                        title: searchText.isEmpty ? "No Artists" : "No Results",
+                        message: searchText.isEmpty
+                            ? "Artists you load from Twinskaraoke will appear here."
+                            : "Try another artist."
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             } else {
                 List {
                     ForEach(displayedArtists) { artist in

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -196,7 +196,6 @@ private struct CreatePlaylistTextField: View {
             TextField(prompt, text: $text, axis: axis)
                 .scaledSystemFont(size: 17)
                 .textInputAutocapitalization(.words)
-                .disableAutocorrection(false)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -218,9 +218,16 @@ struct DownloadedSongsView: View {
         durationTask = Task { @MainActor in
             // File-existence checks hit the disk once per song; keep them off
             // the main actor so refresh/onAppear stays responsive.
-            let localAudioURLs = await Task.detached(priority: .utility) {
-                localAudioCandidates.filter { FileManager.default.fileExists(atPath: $0.value.path) }
-            }.value
+            let scanTask = Task.detached(priority: .utility) {
+                localAudioCandidates.filter {
+                    !Task.isCancelled && FileManager.default.fileExists(atPath: $0.value.path)
+                }
+            }
+            let localAudioURLs = await withTaskCancellationHandler {
+                await scanTask.value
+            } onCancel: {
+                scanTask.cancel()
+            }
             guard !Task.isCancelled else { return }
 
             let songsWithDurations = await UploadedSongDurationResolver.shared

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -203,10 +203,8 @@ struct DownloadedSongsView: View {
     private func refresh() {
         let cached = recentlyPlayed.playlists.flatMap { $0.songListDTOs ?? [] }
         let songs = downloads.downloadedSongs(knownSongs: cached)
-        let localAudioURLs = songs.reduce(into: [String: URL]()) { urls, song in
-            let url = downloads.localURL(for: song.id)
-            guard FileManager.default.fileExists(atPath: url.path) else { return }
-            urls[song.id] = url
+        let localAudioCandidates = songs.reduce(into: [String: URL]()) { urls, song in
+            urls[song.id] = downloads.localURL(for: song.id)
         }
         ArtworkPrefetcher.shared.prefetchSongs(
             Array(songs.prefix(18)),
@@ -218,6 +216,13 @@ struct DownloadedSongsView: View {
 
         durationTask?.cancel()
         durationTask = Task { @MainActor in
+            // File-existence checks hit the disk once per song; keep them off
+            // the main actor so refresh/onAppear stays responsive.
+            let localAudioURLs = await Task.detached(priority: .utility) {
+                localAudioCandidates.filter { FileManager.default.fileExists(atPath: $0.value.path) }
+            }.value
+            guard !Task.isCancelled else { return }
+
             let songsWithDurations = await UploadedSongDurationResolver.shared
                 .fillingMissingDurations(
                     in: songs,

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -32,6 +32,10 @@ struct PlaylistSongCountLabel: View {
             countStore.loadIfNeeded(
                 for: playlist,
                 forceDetailCount: prefersDetailCount
+                    && PlaylistSongCountStore.needsDetailCount(
+                        for: playlist,
+                        isSaved: SavedPlaylistsStore.shared.isSaved(playlist)
+                    )
             )
         }
     }
@@ -46,7 +50,7 @@ struct LibraryView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showCreateSheet = false
     @State private var path = NavigationPath()
-    let cols = AM.Layout.playlistGridColumns
+    @State private var favoritesRefreshTask: Task<Void, Never>?
 
     private var usesCompactToolbar: Bool {
         horizontalSizeClass == .compact
@@ -102,7 +106,15 @@ struct LibraryView: View {
                 recentSongsViewModel.loadIfNeeded()
             }
             .onChange(of: favorites.favoriteIDs) { _, _ in
-                viewModel.fetchFavoriteSongs(force: true)
+                // Every star tap anywhere in the app fires this; LibraryView is a
+                // tab root that is always alive, so coalesce rapid toggles into a
+                // single refetch instead of fetching the whole list per tap.
+                favoritesRefreshTask?.cancel()
+                favoritesRefreshTask = Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(1))
+                    guard !Task.isCancelled else { return }
+                    viewModel.fetchFavoriteSongs(force: true)
+                }
             }
             .sheet(isPresented: $showCreateSheet) {
                 CreatePlaylistSheet()
@@ -209,14 +221,6 @@ struct LibraryView: View {
                 showsDivider: false
             )
         }
-    }
-
-    private var librarySecondaryLinks: some View {
-        EmptyView()
-    }
-
-    private var librarySecondaryLinksContent: some View {
-        EmptyView()
     }
 
     @ViewBuilder
@@ -511,13 +515,29 @@ struct LibrarySongsView: View {
     }
 
     private func emptyState(isSearching: Bool) -> some View {
-        MusicEmptyState(
-            title: isSearching ? "No Results" : "No Songs",
-            message: isSearching
-                ? "Try another song or artist."
-                : "Songs you load from Twins Karaoke will appear here."
-        )
+        VStack(spacing: AM.Spacing.l) {
+            MusicEmptyState(title: emptyTitle(isSearching: isSearching), message: emptyMessage(isSearching: isSearching))
+
+            if viewModel.loadFailed, !isSearching {
+                MusicEmptyActionButton(title: "Try Again") {
+                    AppHaptic.selection.play()
+                    viewModel.refresh()
+                }
+            }
+        }
         .frame(maxWidth: .infinity, minHeight: 360)
+    }
+
+    private func emptyTitle(isSearching: Bool) -> String {
+        if isSearching { return "No Results" }
+        if viewModel.loadFailed { return "Couldn't Load Songs" }
+        return "No Songs"
+    }
+
+    private func emptyMessage(isSearching: Bool) -> String {
+        if isSearching { return "Try another song or artist." }
+        if viewModel.loadFailed { return "Check your connection and try again." }
+        return "Songs you load from Twins Karaoke will appear here."
     }
 
     private var skeletonRows: some View {
@@ -600,6 +620,7 @@ struct PlaylistsGridScreen: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showCreateSheet = false
     @State private var searchText = ""
+    @State private var favoritesRefreshTask: Task<Void, Never>?
     let cols = AM.Layout.playlistGridColumns
 
 
@@ -683,7 +704,12 @@ struct PlaylistsGridScreen: View {
         }
         .task { userManager.loadIfNeeded() }
         .onChange(of: favorites.favoriteIDs) { _, _ in
-            viewModel.fetchFavoriteSongs(force: true)
+            favoritesRefreshTask?.cancel()
+            favoritesRefreshTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                viewModel.fetchFavoriteSongs(force: true)
+            }
         }
         .sheet(isPresented: $showCreateSheet) {
             CreatePlaylistSheet()
@@ -699,7 +725,6 @@ struct PlaylistGridCell: View {
         VStack(alignment: .leading, spacing: AM.Spacing.s) {
             artwork
                 .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
-                .amShadow(AM.Shadow.card)
             Text(playlist.name)
                 .font(AM.Font.tileTitle)
                 .foregroundStyle(.primary)

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -12,14 +12,23 @@ struct PlaylistDetailView: View {
     @ObservedObject private var fallbackArt = FallbackArtProvider.shared
     @State private var showsCollapsedTitle = false
     @State private var searchText = ""
+    @State private var filteredSongs: [Song]
     @State private var isSearchVisible = false
     @State private var isSearchModeActive = false
     @State private var artworkPullOverride: CGFloat = 0
     @State private var isArtworkPullOverridden = false
     @State private var canAutoHideSearch = false
     @State private var isActivelyPulling = false
+    @State private var shouldActivateSearchAfterPull = false
     @State private var searchRevealState = PlaylistSearchRevealState()
     @FocusState private var isSearchFocused: Bool
+
+    init(playlist: Playlist) {
+        self.playlist = playlist
+        // searchText starts empty, so the initial filtered list is the fallback.
+        _filteredSongs = State(initialValue: playlist.songListDTOs ?? [])
+    }
+
     private func usesWideOverview(availableWidth: CGFloat) -> Bool {
         AM.Layout.usesWideCanvas(
             horizontalSizeClass: horizontalSizeClass,
@@ -30,7 +39,7 @@ struct PlaylistDetailView: View {
 
     var body: some View {
         let songs: [Song] = loader.songs ?? playlist.songListDTOs ?? []
-        let displayedSongs = PlaylistSongSearch.filter(songs, matching: searchText)
+        let displayedSongs = filteredSongs
         let isSearching = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         GeometryReader { geo in
             ScrollView {
@@ -54,13 +63,16 @@ struct PlaylistDetailView: View {
             .onScrollPhaseChange { _, phase in
                 let wasActivelyPulling = isActivelyPulling
                 isActivelyPulling = phase == .tracking || phase == .interacting
-                if wasActivelyPulling, !isActivelyPulling, isArtworkPullOverridden {
-                    withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.24)) {
-                        artworkPullOverride = 0
-                    } completion: {
-                        guard artworkPullOverride == 0 else { return }
-                        isArtworkPullOverridden = false
+                if wasActivelyPulling, !isActivelyPulling {
+                    if isArtworkPullOverridden {
+                        withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.24)) {
+                            artworkPullOverride = 0
+                        } completion: {
+                            guard artworkPullOverride == 0 else { return }
+                            isArtworkPullOverridden = false
+                        }
                     }
+                    activateSearchAfterPull()
                 }
             }
         }
@@ -113,12 +125,28 @@ struct PlaylistDetailView: View {
             }
             prefetchArtwork(songs: displayedSongs)
         }
+        .onChange(of: searchText) { _, _ in
+            filteredSongs = PlaylistSongSearch.filter(songs, matching: searchText)
+        }
+        .onReceive(loader.$songs) { newSongs in
+            let next = PlaylistSongSearch.filter(
+                newSongs ?? playlist.songListDTOs ?? [],
+                matching: searchText
+            )
+            // Animating a huge structural swap can stall the main thread;
+            // only animate small list changes (e.g. unfavoriting a row).
+            let canAnimate = filteredSongs.count < 300 && next.count < 300
+            withOptionalAnimation(reduceMotion || !canAnimate ? nil : AppMotion.quick) {
+                filteredSongs = next
+            }
+        }
         .onChange(of: favorites.favoriteIDs) { _, _ in
             guard playlist.isFavorites else { return }
             loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
         }
         .onChange(of: isSearchFocused) { _, isFocused in
             guard isFocused, !isSearchModeActive else { return }
+            shouldActivateSearchAfterPull = false
             isArtworkPullOverridden = false
             withAnimation(reduceMotion ? nil : AppMotion.quick) {
                 isSearchModeActive = true
@@ -148,7 +176,7 @@ struct PlaylistDetailView: View {
             .transition(
                 reduceMotion
                     ? .opacity
-                    : .opacity.combined(with: .move(edge: .bottom))
+                    : .opacity.combined(with: .scale(scale: 0.98))
             )
             .accessibilityIdentifier("PlaylistDetail.SearchResults")
         } else {
@@ -222,12 +250,9 @@ struct PlaylistDetailView: View {
                 ? 0
                 : min(pullDistance, PlaylistSearchRevealState.revealThreshold)
             isArtworkPullOverridden = !reduceMotion
-            withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.2)) {
+            shouldActivateSearchAfterPull = true
+            withAnimation(reduceMotion ? nil : AppMotion.snap) {
                 isSearchVisible = true
-            }
-            Task { @MainActor in
-                guard isSearchVisible, !isSearchModeActive else { return }
-                isSearchFocused = true
             }
         }
 
@@ -248,6 +273,7 @@ struct PlaylistDetailView: View {
         isSearchFocused = false
         searchText = ""
         canAutoHideSearch = false
+        shouldActivateSearchAfterPull = false
         withAnimation(reduceMotion ? nil : AppMotion.quick) {
             isSearchVisible = false
             isSearchModeActive = false
@@ -259,11 +285,27 @@ struct PlaylistDetailView: View {
         isSearchFocused = false
         searchText = ""
         canAutoHideSearch = false
+        shouldActivateSearchAfterPull = false
         searchRevealState.reset()
         withAnimation(reduceMotion ? nil : AppMotion.quick) {
             isSearchVisible = false
             isSearchModeActive = false
             isArtworkPullOverridden = false
+        }
+    }
+
+    private func activateSearchAfterPull() {
+        guard shouldActivateSearchAfterPull, isSearchVisible else { return }
+        shouldActivateSearchAfterPull = false
+
+        withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.18)) {
+            isSearchModeActive = true
+        } completion: {
+            Task { @MainActor in
+                await Task.yield()
+                guard isSearchVisible, isSearchModeActive else { return }
+                isSearchFocused = true
+            }
         }
     }
 
@@ -446,7 +488,9 @@ struct PlaylistDetailView: View {
                     actionButtons(songs: displayedSongs)
                 }
                 LazyVStack(spacing: 0) {
-                    ForEach(displayedSongs) { song in
+                    // Positional identity: playlists can contain the same song
+                    // twice, and duplicate ForEach IDs can hang AttributeGraph.
+                    ForEach(Array(displayedSongs.enumerated()), id: \.offset) { idx, song in
                         Button {
                             play(song, context: displayedSongs)
                         } label: {
@@ -457,14 +501,15 @@ struct PlaylistDetailView: View {
                                 }
                         }
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
-                        .id("\(song.id):\(song.duration)")
                         .accessibilityHint("Starts playback.")
                         .accessibilityIdentifier("PlaylistDetail.song.\(song.id)")
-                        Divider().padding(.leading, rowHorizontalPadding + 60)
+                        if idx < displayedSongs.count - 1 {
+                            Divider().padding(.leading, rowHorizontalPadding + 60)
+                        }
                     }
                 }
             }
-            .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .bottom)))
+            .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
         } else if loader.isLoading, songs.isEmpty {
             PlaylistLoadingRows(horizontalPadding: rowHorizontalPadding)
                 .transition(.opacity)

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -102,14 +102,11 @@ struct PlaylistDetailView: View {
             reduceMotion ? nil : AppMotion.quick,
             value: showsCollapsedTitle
         )
-        .animation(
-            reduceMotion ? nil : AppMotion.quick,
-            value: loader.isLoading
-        )
-        .animation(
-            reduceMotion ? nil : AppMotion.quick,
-            value: isSearchModeActive
-        )
+        // No container .animation(value:) for isLoading / isSearchModeActive:
+        // an implicit animation on those flips animates the whole scroll
+        // content swap, which makes SwiftUI re-measure every row of a large
+        // playlist per frame and can hang the main thread. The section-level
+        // .transition(.opacity) modifiers still animate the swap cheaply.
         .scrollIndicators(.hidden)
         .musicScreenBackground()
         .onAppear {

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -164,7 +164,7 @@ struct RandomSongsView: View {
                 }
 
                 LazyVStack(spacing: 0) {
-                    ForEach(songs) { song in
+                    ForEach(Array(songs.enumerated()), id: \.offset) { idx, song in
                         Button {
                             play(song, context: songs)
                         } label: {
@@ -181,7 +181,9 @@ struct RandomSongsView: View {
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
                         .accessibilityHint("Starts playback.")
                         .accessibilityIdentifier("RandomSongs.song.\(song.id)")
-                        Divider().padding(.leading, rowHorizontalPadding + 60)
+                        if idx < songs.count - 1 {
+                            Divider().padding(.leading, rowHorizontalPadding + 60)
+                        }
                     }
                 }
             }

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -40,7 +40,7 @@ struct UploadedSongsView: View {
                                     play(song, context: songs)
                                 }
                         }
-                        .id("\(song.id):\(song.duration)")
+                        .id(song.id)
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
                         .accessibilityHint("Starts playback.")
                         .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -76,12 +76,12 @@ private struct PlayerLayoutMetrics {
 
     var lyricsTopSpacer: CGFloat {
         if usesTwoColumnPlayer { return artworkTopSpacer }
-        return isCompactHeight ? 8 : 8
+        return isCompactHeight ? 8 : 12
     }
 
     var lyricsBottomSpacer: CGFloat {
         if usesTwoColumnPlayer { return artworkBottomSpacer }
-        return isCompactHeight ? 12 : 10
+        return isCompactHeight ? 10 : 12
     }
 
     var progressTopPadding: CGFloat {
@@ -668,11 +668,14 @@ struct FullScreenPlayerView: View {
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .contentTransition(.opacity)
                 Text(song.displayArtist)
                     .font(metrics.artistSize <= 15 ? .subheadline : AM.Font.nowPlayingArtist)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .contentTransition(.opacity)
             }
+            .animation(reduceMotion ? nil : AppMotion.quick, value: song.id)
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Now playing")
             .accessibilityValue("\(song.title), \(song.displayArtist)")
@@ -879,7 +882,6 @@ struct FullScreenPlayerView: View {
             artworkURL: audioManager.displayImageURL(for: song, variant: .blur),
             isPlaying: audioManager.isPlaying && popupPresentation.isExpanded
         )
-        .id(song.id)
     }
 
     private func formattedTime(_ seconds: Double) -> String {

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -92,7 +92,7 @@ struct QueueView: View {
                     .transition(emptyQueueTransition)
                 } else {
                     List {
-                        ForEach(Array(upNext.enumerated()), id: \.element.id) { index, song in
+                        ForEach(Array(upNext.enumerated()), id: \.offset) { index, song in
                             QueueRow(
                                 song: song,
                                 position: index + 1,
@@ -158,6 +158,7 @@ struct QueueView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
+                    .contentTransition(.numericText())
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Playing Next")
@@ -224,7 +225,7 @@ struct QueueView: View {
                 }
                 Spacer()
 
-                EqualizerBars(isAnimating: false)
+                EqualizerBars(isAnimating: audioManager.isPlaying)
                     .frame(width: 16, height: 16)
                     .foregroundStyle(Color.appAccent)
             }
@@ -280,8 +281,10 @@ struct QueueView: View {
     }
 
     private var upNextSongs: [Song] {
+        // Match by id: applyEnrichedMetadata replaces currentSong with a fresh
+        // instance that no longer == the queue copy.
         guard let current = audioManager.currentSong,
-              let idx = audioManager.queue.firstIndex(of: current),
+              let idx = audioManager.queue.firstIndex(where: { $0.id == current.id }),
               idx + 1 < audioManager.queue.count
         else { return [] }
         return Array(audioManager.queue[(idx + 1)...])

--- a/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
+++ b/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct RadioPlayerLayout: View {
     @EnvironmentObject var audioManager: AudioPlayerManager
     @ObservedObject var favorites: FavoritesManager
+    @ObservedObject private var radio = RadioController.shared
     @Environment(\.appReduceMotion) private var reduceMotion
     @Binding var showingQueue: Bool
     let song: Song
@@ -51,7 +52,7 @@ struct RadioPlayerLayout: View {
                         .font(.caption.bold())
                         .foregroundStyle(Color.appAccent)
                         .tracking(1.2)
-                    if let listeners = RadioController.shared.nowPlaying?.listeners {
+                    if let listeners = radio.nowPlaying?.listeners {
                         Text("·")
                             .font(.caption.bold())
                             .foregroundStyle(.tertiary)
@@ -177,7 +178,7 @@ struct RadioPlayerLayout: View {
     }
 
     private var radioFavoriteID: String? {
-        RadioController.shared.nowPlaying?.nowPlaying?.song.resolvedSongID
+        radio.nowPlaying?.nowPlaying?.song.resolvedSongID
     }
 
     private var canFavoriteRadioSong: Bool {

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -102,6 +102,14 @@ struct RadioView: View {
                 await retryRadioRefresh()
             }
             .onAppear { radio.start() }
+            .onDisappear {
+                // Polling must keep running while the stream is playing so
+                // now-playing metadata stays fresh; stop() only invalidates
+                // the metadata poll timer and never touches playback.
+                if !playback.isRadioMode {
+                    radio.stop()
+                }
+            }
             .sheet(isPresented: $showingRadioSchedule) {
                 RadioQueueView()
                     .presentationDetents([.medium, .large])

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -291,9 +291,9 @@ private struct BrowseCategoriesView: View {
         .tabBarScrollInset()
         .refreshable {
             AppHaptic.selection.play()
-            genresVM.loadIfNeeded()
-            topChartVM.loadIfNeeded()
-            publicPlaylistsVM.loadIfNeeded()
+            genresVM.refresh()
+            topChartVM.refresh()
+            publicPlaylistsVM.refresh()
         }
         .onAppear {
             genresVM.loadIfNeeded()
@@ -451,8 +451,17 @@ private struct BrowseCategoriesView: View {
         }) {
             return match.1
         }
-        let stable = genres[abs(name.hashValue) % genres.count]
-        return stable.1
+        return genres[Self.stablePaletteIndex(for: name, count: genres.count)].1
+    }
+
+    /// FNV-1a over unicode scalars: stable across launches, unlike `hashValue`.
+    private static func stablePaletteIndex(for name: String, count: Int) -> Int {
+        var hash: UInt64 = 1_469_598_103_934_665_603
+        for scalar in name.unicodeScalars {
+            hash ^= UInt64(scalar.value)
+            hash &*= 1_099_511_628_211
+        }
+        return Int(hash % UInt64(count))
     }
 }
 
@@ -880,7 +889,6 @@ private struct SearchFeaturedShortcutTile: View {
         }
         .frame(height: isCompactWidth ? 124 : 144)
         .clipShape(RoundedRectangle(cornerRadius: AM.Radius.tile, style: .continuous))
-        .amShadow(AM.Shadow.card)
         .contentShape(RoundedRectangle(cornerRadius: AM.Radius.tile, style: .continuous))
     }
 
@@ -948,7 +956,6 @@ private struct CategoryTile: View {
         }
         .frame(height: isCompactWidth ? 92 : 102)
         .clipShape(RoundedRectangle(cornerRadius: AM.Radius.tile, style: .continuous))
-        .amShadow(AM.Shadow.card)
         .contentShape(RoundedRectangle(cornerRadius: AM.Radius.tile, style: .continuous))
     }
 }

--- a/Twinskaraoke/Models/Home/HomeViewModel.swift
+++ b/Twinskaraoke/Models/Home/HomeViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 
+@MainActor
 final class HomeViewModel: ObservableObject {
     private enum TopPicksSource {
         case publicPlaylists
@@ -38,7 +39,11 @@ final class HomeViewModel: ObservableObject {
         dataGeneration += 1
         let generation = dataGeneration
         hasLoaded = true
-        isLoading = true
+        // Only swap to the skeleton on the first load; a pull-to-refresh with
+        // existing content keeps it on screen until the new data arrives.
+        if trending.isEmpty, suggestions.isEmpty, recentPlaylists.isEmpty, newReleases.isEmpty {
+            isLoading = true
+        }
         isLoadingMoreTopPicks = false
         topPicksPage = 0
         canLoadMoreTopPicks = true
@@ -72,6 +77,13 @@ final class HomeViewModel: ObservableObject {
             isLoading = false
             homeLoadTask = nil
         }
+    }
+
+    /// Awaitable reload for pull-to-refresh; keeps the refresh spinner alive
+    /// until the home data has actually finished loading.
+    func refreshHomeData() async {
+        fetchHomeData(force: true)
+        await homeLoadTask?.value
     }
 
     func loadMoreTopPicksIfNeeded(current: Playlist) {

--- a/Twinskaraoke/Models/Library/ArtistsViewModel.swift
+++ b/Twinskaraoke/Models/Library/ArtistsViewModel.swift
@@ -6,6 +6,7 @@ final class ArtistsViewModel: ObservableObject {
     @Published var artists: [Artist] = []
     @Published var isLoading = false
     @Published var canLoadMore = true
+    @Published private(set) var loadFailed = false
     private var page = 0
     private let pageSize = 25
     private var loadGeneration = 0
@@ -41,6 +42,9 @@ final class ArtistsViewModel: ObservableObject {
             "\(StorageHost.api)/api/artists?startIndex=\(startIndex)&pageSize=\(pageSize)&search=&sortBy=Name&sortDescending=False"
         guard let url = URL(string: urlString) else { return }
         isLoading = true
+        if reset {
+            loadFailed = false
+        }
         loadGeneration += 1
         let generation = loadGeneration
         var request = URLRequest(url: url)
@@ -78,6 +82,9 @@ final class ArtistsViewModel: ObservableObject {
               let data,
               let decoded = try? JSONDecoder().decode([Artist].self, from: data)
         else {
+            if reset, artists.isEmpty {
+                loadFailed = true
+            }
             return
         }
 

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -18,6 +18,7 @@ final class LibrarySongsViewModel: ObservableObject {
     private var canLoadMore = true
     private var page = 1
     private var requestToken = 0
+    private var isReplacing = false
     private var activeTask: URLSessionDataTask?
     private let pageSize = 40
 
@@ -64,7 +65,7 @@ final class LibrarySongsViewModel: ObservableObject {
     }
 
     func loadMoreIfNeeded(current: Song) {
-        guard canLoadMore, !isLoading, !isLoadingMore else { return }
+        guard canLoadMore, !isLoading, !isLoadingMore, !isReplacing else { return }
         guard searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         let visible = displayedSongs
         guard let index = visible.firstIndex(where: { $0.id == current.id }) else { return }
@@ -73,7 +74,7 @@ final class LibrarySongsViewModel: ObservableObject {
     }
 
     func loadMore() {
-        guard canLoadMore, !isLoading, !isLoadingMore else { return }
+        guard canLoadMore, !isLoading, !isLoadingMore, !isReplacing else { return }
         guard searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         fetch(page: page + 1, replace: false)
     }
@@ -87,6 +88,7 @@ final class LibrarySongsViewModel: ObservableObject {
         let token = requestToken
         if replace {
             loadFailed = false
+            isReplacing = true
             isLoading = songs.isEmpty
         } else {
             isLoadingMore = true
@@ -137,6 +139,7 @@ final class LibrarySongsViewModel: ObservableObject {
             activeTask = nil
             isLoading = false
             isLoadingMore = false
+            if replace { isReplacing = false }
         }
 
         if let error {
@@ -156,7 +159,14 @@ final class LibrarySongsViewModel: ObservableObject {
             return
         }
 
-        let decoded = Self.decodeSongs(from: data)
+        guard let decoded = Self.decodeSongs(from: data) else {
+            DebugLogger.log("Library songs decode failed", category: .network)
+            if replace, songs.isEmpty {
+                hasLoaded = true
+                loadFailed = true
+            }
+            return
+        }
         let filtered = decoded.filter {
             !$0.title.localizedCaseInsensitiveContains("Temporary Stream Audio")
         }
@@ -183,12 +193,12 @@ final class LibrarySongsViewModel: ObservableObject {
         )
     }
 
-    private static func decodeSongs(from data: Data?) -> [Song] {
-        guard let data else { return [] }
+    private static func decodeSongs(from data: Data?) -> [Song]? {
+        guard let data else { return nil }
         if let decoded = try? JSONDecoder().decode(SearchResponse.self, from: data) {
             return decoded.items
         }
-        return SongPayloadDecoder.decodeSongs(from: data) ?? []
+        return SongPayloadDecoder.decodeSongs(from: data)
     }
 
     deinit {

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -13,6 +13,7 @@ final class LibrarySongsViewModel: ObservableObject {
         didSet { rebuildDisplayedSongs() }
     }
     @Published private(set) var displayedSongs: [Song] = []
+    @Published private(set) var loadFailed = false
     private var hasLoaded = false
     private var canLoadMore = true
     private var page = 1
@@ -85,6 +86,7 @@ final class LibrarySongsViewModel: ObservableObject {
         requestToken += 1
         let token = requestToken
         if replace {
+            loadFailed = false
             isLoading = songs.isEmpty
         } else {
             isLoadingMore = true
@@ -139,10 +141,18 @@ final class LibrarySongsViewModel: ObservableObject {
 
         if let error {
             DebugLogger.log("Library songs fetch failed: \(error.localizedDescription)", category: .network)
+            if replace, songs.isEmpty {
+                hasLoaded = true
+                loadFailed = true
+            }
             return
         }
         if let http = response as? HTTPURLResponse, !(200 ... 299).contains(http.statusCode) {
             DebugLogger.log("Library songs HTTP \(http.statusCode)", category: .network)
+            if replace, songs.isEmpty {
+                hasLoaded = true
+                loadFailed = true
+            }
             return
         }
 

--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -178,6 +178,10 @@ class PlaylistDetailViewModel: ObservableObject {
             }
         }
         loadFailed = requestFailed && (songs?.isEmpty ?? true)
-        isLoading = false
+        // A non-authoritative fallback apply means the remote fetch is still in
+        // flight; keep isLoading true until the authoritative or failure apply.
+        if isAuthoritative || requestFailed {
+            isLoading = false
+        }
     }
 }

--- a/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
+++ b/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
@@ -7,6 +7,7 @@ final class PlaylistSongCountStore: ObservableObject {
 
     @Published private var resolvedCounts: [String: Int] = [:]
     private var loadingIDs: Set<String> = []
+    private var generations: [String: UInt64] = [:]
 
     func displayedCount(for playlist: Playlist, prefersDetailCount: Bool = false) -> Int? {
         if let resolved = resolvedCounts[playlist.id] {
@@ -46,6 +47,7 @@ final class PlaylistSongCountStore: ObservableObject {
         // body until later, so inserting inside it would let same-runloop
         // callers pass the guard twice and fire duplicate requests.
         loadingIDs.insert(playlist.id)
+        let generation = generations[playlist.id, default: 0]
         Task {
             let count: Int?
             do {
@@ -55,7 +57,7 @@ final class PlaylistSongCountStore: ObservableObject {
             }
 
             loadingIDs.remove(playlist.id)
-            if let count {
+            if let count, generations[playlist.id, default: 0] == generation {
                 resolvedCounts[playlist.id] = count
             }
         }
@@ -66,6 +68,9 @@ final class PlaylistSongCountStore: ObservableObject {
     }
 
     func invalidate(playlistID: String) {
+        // Bump the generation so any older in-flight count request for this
+        // playlist is fenced off and cannot overwrite fresher local state.
+        generations[playlistID, default: 0] &+= 1
         resolvedCounts.removeValue(forKey: playlistID)
     }
 

--- a/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
+++ b/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
@@ -15,7 +15,15 @@ final class PlaylistSongCountStore: ObservableObject {
         if playlist.isFavorites {
             return playlist.songCount
         }
-        if prefersDetailCount {
+        // Only withhold the summary count for playlists whose summary is known
+        // to be unreliable; those fetch a detail count via loadIfNeeded.
+        // Public playlists already carry an accurate server-side count — show
+        // it immediately instead of staying blank until a detail fetch or visit.
+        let needsDetail = Self.needsDetailCount(
+            for: playlist,
+            isSaved: SavedPlaylistsStore.shared.isSaved(playlist)
+        )
+        if prefersDetailCount && needsDetail {
             return nil
         }
         if playlist.songCount > 0 {
@@ -34,8 +42,11 @@ final class PlaylistSongCountStore: ObservableObject {
         guard resolvedCounts[playlist.id] == nil else { return }
         guard !loadingIDs.contains(playlist.id) else { return }
 
+        // Mark in-flight synchronously: an unstructured Task does not run its
+        // body until later, so inserting inside it would let same-runloop
+        // callers pass the guard twice and fire duplicate requests.
+        loadingIDs.insert(playlist.id)
         Task {
-            loadingIDs.insert(playlist.id)
             let count: Int?
             do {
                 count = try await KaraokeAPIClient.playlistSongCount(id: playlist.id)
@@ -52,6 +63,10 @@ final class PlaylistSongCountStore: ObservableObject {
 
     func recordResolvedCount(_ count: Int, for playlistID: String) {
         resolvedCounts[playlistID] = max(0, count)
+    }
+
+    func invalidate(playlistID: String) {
+        resolvedCounts.removeValue(forKey: playlistID)
     }
 
     static func needsDetailCount(for playlist: Playlist, isSaved: Bool) -> Bool {

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -41,6 +41,7 @@ final class PublicPlaylistsViewModel: ObservableObject {
     @Published var isLoadingMore = false
     private var canLoadMore = true
     private var hasLoaded = false
+    private var requestToken = 0
     private let pageSize = 25
 
     func loadIfNeeded() {
@@ -72,7 +73,12 @@ final class PublicPlaylistsViewModel: ObservableObject {
     }
 
     private func fetchPage(startIndex: Int, replace: Bool) {
-        if !replace { isLoadingMore = true }
+        if replace {
+            requestToken += 1
+        } else {
+            isLoadingMore = true
+        }
+        let token = requestToken
         Task { [weak self] in
             guard let self else { return }
             do {
@@ -80,6 +86,7 @@ final class PublicPlaylistsViewModel: ObservableObject {
                     startIndex: startIndex,
                     pageSize: pageSize
                 )
+                guard token == requestToken else { return }
                 if replace {
                     playlists = items
                 } else {
@@ -88,6 +95,7 @@ final class PublicPlaylistsViewModel: ObservableObject {
                 }
                 canLoadMore = items.count >= pageSize
             } catch {
+                guard token == requestToken else { return }
                 if replace { playlists = [] }
                 canLoadMore = false
             }
@@ -141,6 +149,7 @@ final class TopChartViewModel: ObservableObject {
     @Published var songs: [Song] = []
     @Published var weeklyTrending: [Song] = []
     private var hasLoaded = false
+    private var requestToken = 0
 
     func loadIfNeeded() {
         guard !hasLoaded else { return }
@@ -150,12 +159,17 @@ final class TopChartViewModel: ObservableObject {
             return
         }
         hasLoaded = true
+        requestToken += 1
+        let token = requestToken
         Task { [weak self] in
             guard let self else { return }
             async let allTime = try? KaraokeAPIClient.trendingSongs(days: "all")
             async let weekly = try? KaraokeAPIClient.trendingSongs(take: 20)
-            songs = await allTime ?? []
-            weeklyTrending = await weekly ?? []
+            let allTimeSongs = await allTime ?? []
+            let weeklySongs = await weekly ?? []
+            guard token == requestToken else { return }
+            songs = allTimeSongs
+            weeklyTrending = weeklySongs
         }
     }
 
@@ -202,6 +216,7 @@ final class GenresViewModel: ObservableObject {
     private var pendingDetails: [String: GenreSummary] = [:]
     private var detailTasks: [String: URLSessionDataTask] = [:]
     private var detailGeneration: UInt64 = 0
+    private var pageGeneration: UInt64 = 0
     private var detailFailureDates: [String: Date] = [:]
     private let maxConcurrentDetailRequests = 4
     private var genresNeedingFallback = Set<String>()
@@ -295,22 +310,25 @@ final class GenresViewModel: ObservableObject {
             )
         else { return }
         if replace {
+            pageGeneration &+= 1
             isLoading = true
             pendingDetailOrder.removeAll()
             pendingDetails.removeAll()
         } else {
             isLoadingMore = true
         }
+        let generation = pageGeneration
         var request = URLRequest(url: url)
         GuestIdentity.applyIfNeeded(to: &request)
         URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
-            Task { @MainActor [weak self, data, page, replace] in
-                self?.applyGenrePageResponse(data, page: page, replace: replace)
+            Task { @MainActor [weak self, data, page, replace, generation] in
+                self?.applyGenrePageResponse(data, page: page, replace: replace, generation: generation)
             }
         }.resume()
     }
 
-    private func applyGenrePageResponse(_ data: Data?, page: Int, replace: Bool) {
+    private func applyGenrePageResponse(_ data: Data?, page: Int, replace: Bool, generation: UInt64) {
+        guard generation == pageGeneration else { return }
         defer {
             isLoading = false
             isLoadingMore = false

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -54,6 +54,12 @@ final class PublicPlaylistsViewModel: ObservableObject {
         fetchPage(startIndex: 0, replace: true)
     }
 
+    func refresh() {
+        hasLoaded = false
+        canLoadMore = true
+        loadIfNeeded()
+    }
+
     func loadMoreIfNeeded(current: Playlist) {
         guard let idx = playlists.firstIndex(where: { $0.id == current.id }) else { return }
         if idx >= playlists.count - 4, !isLoadingMore, canLoadMore {
@@ -153,6 +159,11 @@ final class TopChartViewModel: ObservableObject {
         }
     }
 
+    func refresh() {
+        hasLoaded = false
+        loadIfNeeded()
+    }
+
     private func applyUITestFixture() {
         songs = Self.uiTestFixtureSongs
         weeklyTrending = Array(Self.uiTestFixtureSongs.prefix(2))
@@ -227,6 +238,11 @@ final class GenresViewModel: ObservableObject {
             return
         }
         fetchPage(0, replace: true)
+    }
+
+    func refresh() {
+        hasLoaded = false
+        loadIfNeeded()
     }
 
     func loadMoreIfNeeded(current: GenreSummary) {

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -213,7 +213,7 @@ final class ArtworkPrefetcher {
             return min(limit, reason == "radio metadata" ? 3 : 2)
         }
         if AudioPlayerManager.shared.isPlaying {
-            return min(limit, reason == "radio metadata" ? 4 : 4)
+            return min(limit, 4)
         }
         return min(limit, reason == "radio metadata" ? 6 : 8)
     }

--- a/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
+++ b/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
@@ -24,10 +24,16 @@ final class PlaylistCoverLoader: ObservableObject {
 
         guard let request = try? KaraokeAPIClient.request(
             pathSegments: ["api", "playlist", playlistID]
-        ) else { return }
+        ) else {
+            loadedID = nil
+            return
+        }
 
         loadTask = Task { [weak self, request] in
-            guard let data = try? await URLSession.shared.data(for: request).0 else { return }
+            guard let data = try? await URLSession.shared.data(for: request).0 else {
+                self?.handleLoadFailure(playlistID: playlistID)
+                return
+            }
             guard !Task.isCancelled else { return }
             self?.applyLoadedPlaylistData(data, playlistID: playlistID)
         }
@@ -35,6 +41,11 @@ final class PlaylistCoverLoader: ObservableObject {
 
     deinit {
         loadTask?.cancel()
+    }
+
+    private func handleLoadFailure(playlistID: String) {
+        guard loadedID == playlistID else { return }
+        loadedID = nil
     }
 
     private func applyLoadedPlaylistData(_ data: Data, playlistID: String) {

--- a/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
+++ b/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
@@ -30,7 +30,9 @@ final class PlaylistCoverLoader: ObservableObject {
         }
 
         loadTask = Task { [weak self, request] in
-            guard let data = try? await URLSession.shared.data(for: request).0 else {
+            guard let (data, response) = try? await URLSession.shared.data(for: request),
+                  let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
                 self?.handleLoadFailure(playlistID: playlistID)
                 return
             }

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -956,6 +956,16 @@ final class AVEnginePlayback {
                     for: url, token: token, loadGeneration: loadGeneration
                 )
                 guard self.suppressionToken == token, self.crossfadeLoadGeneration == loadGeneration else {
+                    // Superseded before the crossfade could start. Clear the
+                    // pending marker only if it is still ours — a newer
+                    // beginCrossfade owns the marker when it differs.
+                    if self.pendingCrossfadeURL == url {
+                        self.pendingCrossfadeURL = nil
+                        DebugLogger.log(
+                            "Crossfade begin superseded for \(url.lastPathComponent)",
+                            category: .playback
+                        )
+                    }
                     return
                 }
                 let fadeDuration = max(0.5, duration)

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -687,20 +687,32 @@ class AudioPlayerManager: ObservableObject {
         localPlaybackFileURL(for: song)
     }
 
-    private func cachedStems(for song: Song, sourceURL: URL? = nil) -> CachedStems? {
-        let expectedDuration: TimeInterval?
-        if song.duration > 0 {
-            expectedDuration = TimeInterval(song.duration)
-        } else if let sourceURL {
-            let duration = AudioCacheStore.audioDuration(at: sourceURL)
-            expectedDuration = duration.isFinite && duration > 1.0 ? duration : nil
-        } else {
-            expectedDuration = nil
-        }
-        return VocalSeparator.shared.cachedStems(
+    private func cachedStems(for song: Song, sourceURL: URL? = nil) async -> CachedStems? {
+        await VocalSeparator.shared.cachedStems(
             forSongID: song.id,
-            expectedDuration: expectedDuration
+            expectedDuration: expectedStemDuration(for: song, sourceURL: sourceURL)
         )
+    }
+
+    /// Non-decompressing stem lookup for main-thread fast paths: returns nil
+    /// when only the compressed cache exists so callers can defer the
+    /// decompression to the async `cachedStems` path instead.
+    private func immediatelyCachedStems(for song: Song, sourceURL: URL? = nil) -> CachedStems? {
+        VocalSeparator.shared.immediatelyAvailableStems(
+            forSongID: song.id,
+            expectedDuration: expectedStemDuration(for: song, sourceURL: sourceURL)
+        )
+    }
+
+    private func expectedStemDuration(for song: Song, sourceURL: URL?) -> TimeInterval? {
+        if song.duration > 0 {
+            return TimeInterval(song.duration)
+        }
+        if let sourceURL {
+            let duration = AudioCacheStore.audioDuration(at: sourceURL)
+            return duration.isFinite && duration > 1.0 ? duration : nil
+        }
+        return nil
     }
 
     private func activeSongIDs() -> Set<String> {
@@ -976,14 +988,19 @@ class AudioPlayerManager: ObservableObject {
     private func prepareBackgroundStemPlaybackIfPossible(for song: Song) {
         guard aiEnabled, aiAutoAnalyze, !isRadioMode else { return }
         guard let sourceURL = localPlaybackFileURL(for: song) else { return }
-        guard let stems = cachedStems(for: song, sourceURL: sourceURL) else { return }
+        // Decompresses compressed stem caches off the main thread.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let stems = await cachedStems(for: song, sourceURL: sourceURL) else { return }
+            guard currentSong?.id == song.id, !isRadioMode else { return }
 
-        preparedStemSongID = song.id
-        guard anyAIEffectActive else { return }
-        switchActivePlaybackToStems(
-            for: song, stems: stems, sourceURL: sourceURL,
-            onReady: { [weak self] in self?.applyAIMixVolumes() }
-        )
+            preparedStemSongID = song.id
+            guard anyAIEffectActive else { return }
+            switchActivePlaybackToStems(
+                for: song, stems: stems, sourceURL: sourceURL,
+                onReady: { [weak self] in self?.applyAIMixVolumes() }
+            )
+        }
     }
 
     private func scheduleIdleCacheCompression(excluding songIDs: Set<String>) {
@@ -1306,9 +1323,7 @@ class AudioPlayerManager: ObservableObject {
         }
         progress = 0
         if currentSong?.id != song.id {
-            withAnimation(.easeInOut(duration: 0.32)) {
-                currentSong = song
-            }
+            currentSong = song
         } else {
             currentSong = song
         }
@@ -1726,6 +1741,8 @@ class AudioPlayerManager: ObservableObject {
             )
             return true
         }
+        configureAudioSessionCategory()
+        activateAudioSession()
         NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
         avEngine.resume()
         setPlaybackState(playing: true, buffering: false, reason: "resume.file.\(source)")
@@ -1753,6 +1770,7 @@ class AudioPlayerManager: ObservableObject {
         progress = fraction
         if isStreamMode {
             guard let player = streamPlayer else { return }
+            cancelPendingTransitionWork()
             let totalDur = playbackDuration
             guard totalDur.isFinite, totalDur > 0 else { return }
             let targetSeconds = min(totalDur * fraction, totalDur - 1.5)
@@ -1767,6 +1785,7 @@ class AudioPlayerManager: ObservableObject {
             return
         }
         if isRemotePlaybackCaching, let song = currentSong, song.duration > 0 {
+            cancelPendingTransitionWork()
             let totalDur = Double(song.duration)
             let targetSeconds = min(totalDur * fraction, totalDur - 1.5)
             guard targetSeconds >= 0 else { return }
@@ -2064,7 +2083,7 @@ class AudioPlayerManager: ObservableObject {
         progress = 0
         queue = []
         originalQueue = []
-        withAnimation(.easeInOut(duration: 0.32)) { currentSong = song }
+        currentSong = song
         startRadio(url: streamURL)
     }
 
@@ -2396,14 +2415,14 @@ class AudioPlayerManager: ObservableObject {
         guard aiEnabled, anyAIEffectActive, !isRadioMode, VocalSeparator.shared.isAvailable else {
             return nil
         }
-        return cachedStems(for: song, sourceURL: localPlaybackFileURL(for: song))
+        return immediatelyCachedStems(for: song, sourceURL: localPlaybackFileURL(for: song))
     }
 
     private func triggerBackgroundAnalysis(for song: Song) {
         guard aiEnabled, aiAutoAnalyze, !isRadioMode, !anyAIEffectActive else { return }
         guard VocalSeparator.shared.isAvailable else { return }
 
-        if cachedStems(for: song, sourceURL: localPlaybackFileURL(for: song)) != nil {
+        if VocalSeparator.shared.hasCachedStems(forSongID: song.id) {
             prepareBackgroundStemPlaybackIfPossible(for: song)
             return
         }
@@ -2480,17 +2499,48 @@ class AudioPlayerManager: ObservableObject {
             applyAIMixVolumes()
             return
         }
-        if let sourceURL = localPlaybackFileURL(for: song),
-           let stems = cachedStems(for: song, sourceURL: sourceURL)
-        {
-            DebugLogger.log("Using cached stems for \(song.id)", category: .ai)
-            preparedStemSongID = song.id
-            switchActivePlaybackToStems(
-                for: song, stems: stems, sourceURL: sourceURL,
-                onReady: { [weak self] in self?.applyAIMixVolumes() }
-            )
+        if let sourceURL = localPlaybackFileURL(for: song) {
+            if let stems = immediatelyCachedStems(for: song, sourceURL: sourceURL) {
+                DebugLogger.log("Using cached stems for \(song.id)", category: .ai)
+                preparedStemSongID = song.id
+                switchActivePlaybackToStems(
+                    for: song, stems: stems, sourceURL: sourceURL,
+                    onReady: { [weak self] in self?.applyAIMixVolumes() }
+                )
+                return
+            }
+            // Compressed-only stem caches are decompressed off the main thread
+            // before falling back to real-time separation.
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                guard let stems = await cachedStems(for: song, sourceURL: sourceURL) else {
+                    guard separationGeneration == gen,
+                          currentSong?.id == song.id
+                    else { return }
+                    startRealTimeSeparation(for: song, generation: gen)
+                    return
+                }
+                guard separationGeneration == gen,
+                      currentSong?.id == song.id
+                else { return }
+                guard avEngine.mode != .aiStems else {
+                    applyAIMixVolumes()
+                    return
+                }
+                guard anyAIEffectActive else { return }
+                DebugLogger.log("Using cached stems for \(song.id)", category: .ai)
+                preparedStemSongID = song.id
+                switchActivePlaybackToStems(
+                    for: song, stems: stems, sourceURL: sourceURL,
+                    onReady: { [weak self] in self?.applyAIMixVolumes() }
+                )
+            }
             return
         }
+        startRealTimeSeparation(for: song, generation: gen)
+    }
+
+    private func startRealTimeSeparation(for song: Song, generation gen: UInt64) {
         guard anyAIEffectActive else {
             triggerBackgroundAnalysis(for: song)
             return
@@ -3373,9 +3423,7 @@ class AudioPlayerManager: ObservableObject {
             var excludeIDs = activeSongIDs()
             excludeIDs.insert(song.id)
             scheduleIdleCacheCompression(excluding: excludeIDs)
-            withAnimation(.easeInOut(duration: 0.32)) {
-                currentSong = song
-            }
+            currentSong = song
         }
         upcomingSong = nil
         checkEasterEgg(for: song)

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -365,6 +365,7 @@ class AudioPlayerManager: ObservableObject {
     private var warmedPlayerArtworkAt: [String: Date] = [:]
     private var currentPlaybackURL: URL?
     private var instrumentalTask: Task<Void, Never>?
+    private var preparedStemTask: Task<Void, Never>?
     private var backgroundAnalysisRetryTask: Task<Void, Never>?
     private var cacheCompressionTask: Task<Void, Never>?
     private var aiStemSwitchInFlightSongID: String?
@@ -637,6 +638,7 @@ class AudioPlayerManager: ObservableObject {
             streamFadeTimer?.invalidate()
             transitionStartTask?.cancel()
             instrumentalTask?.cancel()
+            preparedStemTask?.cancel()
             backgroundAnalysisRetryTask?.cancel()
             remotePlaybackCacheTask?.cancel()
             easterEggLyricsTask?.cancel()
@@ -988,11 +990,15 @@ class AudioPlayerManager: ObservableObject {
     private func prepareBackgroundStemPlaybackIfPossible(for song: Song) {
         guard aiEnabled, aiAutoAnalyze, !isRadioMode else { return }
         guard let sourceURL = localPlaybackFileURL(for: song) else { return }
+        preparedStemTask?.cancel()
+        let gen = separationGeneration
         // Decompresses compressed stem caches off the main thread.
-        Task { @MainActor [weak self] in
+        preparedStemTask = Task { @MainActor [weak self] in
             guard let self else { return }
             guard let stems = await cachedStems(for: song, sourceURL: sourceURL) else { return }
-            guard currentSong?.id == song.id, !isRadioMode else { return }
+            guard separationGeneration == gen,
+                  currentSong?.id == song.id, !isRadioMode
+            else { return }
 
             preparedStemSongID = song.id
             guard anyAIEffectActive else { return }
@@ -1132,6 +1138,8 @@ class AudioPlayerManager: ObservableObject {
         cancelPlayerArtworkWarmups()
         instrumentalTask?.cancel()
         instrumentalTask = nil
+        preparedStemTask?.cancel()
+        preparedStemTask = nil
         resetEasterEggWork()
         cancelBackgroundAnalysisRetry()
         VocalSeparator.shared.cancel()
@@ -1303,6 +1311,8 @@ class AudioPlayerManager: ObservableObject {
         avEngine.stop()
         instrumentalTask?.cancel()
         instrumentalTask = nil
+        preparedStemTask?.cancel()
+        preparedStemTask = nil
         separationGeneration &+= 1
         VocalSeparator.shared.cancel()
         VocalSeparator.shared.cancelBackgroundAnalysis()
@@ -1349,6 +1359,8 @@ class AudioPlayerManager: ObservableObject {
         if let fileURL, let stems = stemsForCachedAIMode(song: song) {
             instrumentalTask?.cancel()
             instrumentalTask = nil
+            preparedStemTask?.cancel()
+            preparedStemTask = nil
             separationGeneration &+= 1
             VocalSeparator.shared.cancel()
             preparedStemSongID = song.id
@@ -1444,6 +1456,8 @@ class AudioPlayerManager: ObservableObject {
         stopStreamPlayer()
         instrumentalTask?.cancel()
         instrumentalTask = nil
+        preparedStemTask?.cancel()
+        preparedStemTask = nil
         if resetSeparation {
             separationGeneration &+= 1
             VocalSeparator.shared.cancel()
@@ -2073,6 +2087,8 @@ class AudioPlayerManager: ObservableObject {
         stopStreamPlayer()
         instrumentalTask?.cancel()
         instrumentalTask = nil
+        preparedStemTask?.cancel()
+        preparedStemTask = nil
         preparedStemSongID = nil
         deferredAIEffect = nil
         VocalSeparator.shared.cancel()
@@ -2390,6 +2406,8 @@ class AudioPlayerManager: ObservableObject {
         remotePlaybackCacheTask?.cancel()
         instrumentalTask?.cancel()
         instrumentalTask = nil
+        preparedStemTask?.cancel()
+        preparedStemTask = nil
         resetEasterEggWork()
         preparedStemSongID = nil
         deferredAIEffect = nil
@@ -2459,6 +2477,8 @@ class AudioPlayerManager: ObservableObject {
     private func applyMLSeparationIfNeeded() {
         instrumentalTask?.cancel()
         instrumentalTask = nil
+        preparedStemTask?.cancel()
+        preparedStemTask = nil
         separationGeneration &+= 1
         let gen = separationGeneration
         guard aiEnabled, !isRadioMode, let song = currentSong else {
@@ -3341,6 +3361,8 @@ class AudioPlayerManager: ObservableObject {
         cancelQuickCutTimer(resetVolume: false)
         instrumentalTask?.cancel()
         instrumentalTask = nil
+        preparedStemTask?.cancel()
+        preparedStemTask = nil
         VocalSeparator.shared.cancel()
         VocalSeparator.shared.cancelBackgroundAnalysis()
         quickCutGeneration &+= 1

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -50,7 +50,9 @@ final class TransitionCoordinator {
 
     private static let bpmCacheKey = "nk.bpmCache.v2"
     private static let legacyBPMCacheKey = "nk.bpmCache"
-    private static let bpmCacheTTL: TimeInterval = 3600
+    // BPM of a static audio file never changes, so entries only expire after
+    // a week (and stay bounded by the LRU limit) to avoid re-analyzing audio.
+    private static let bpmCacheTTL: TimeInterval = 60 * 60 * 24 * 7
     private static let bpmCacheLimit = 500
 
     private var bpmCache: [String: BPMCacheEntry] = TransitionCoordinator.loadBPMCache()

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -140,10 +140,7 @@ final class VocalSeparator: ObservableObject {
         AudioCacheStore.removeStemCache(for: songID)
     }
 
-    func cachedStems(
-        forSongID songID: String,
-        expectedDuration: TimeInterval? = nil
-    ) -> CachedStems? {
+    private func validatedStemStartOffset(forSongID songID: String) -> TimeInterval? {
         let offset = AudioCacheStore.readStartOffset(for: songID)
         guard offset <= 1.0 else {
             DebugLogger.log(
@@ -153,8 +150,42 @@ final class VocalSeparator: ObservableObject {
             removeCachedStems(forSongID: songID)
             return nil
         }
+        return offset
+    }
+
+    func cachedStems(
+        forSongID songID: String,
+        expectedDuration: TimeInterval? = nil
+    ) async -> CachedStems? {
+        guard let offset = validatedStemStartOffset(forSongID: songID) else { return nil }
+        // Decompression of compressed cache entries is blocking file I/O, so
+        // the lookup runs off the main actor.
+        let stems = await Task.detached(priority: .userInitiated) {
+            AudioCacheStore.playableStems(
+                for: songID,
+                startOffset: offset,
+                expectedDuration: expectedDuration
+            )
+        }.value
+        guard let stems else {
+            return nil
+        }
+        DebugLogger.log("Cache hit for stems: \(songID)", category: .separation)
+        CacheManager.shared.recordAccess(for: stems.vocals)
+        CacheManager.shared.recordAccess(for: stems.instruments)
+        return stems
+    }
+
+    /// Non-decompressing variant of `cachedStems` for main-thread fast paths:
+    /// returns nil when only the compressed cache exists so callers can defer
+    /// the decompression to the async path instead of blocking the main thread.
+    func immediatelyAvailableStems(
+        forSongID songID: String,
+        expectedDuration: TimeInterval? = nil
+    ) -> CachedStems? {
+        guard let offset = validatedStemStartOffset(forSongID: songID) else { return nil }
         guard
-            let stems = AudioCacheStore.playableStems(
+            let stems = AudioCacheStore.immediatelyPlayableStems(
                 for: songID,
                 startOffset: offset,
                 expectedDuration: expectedDuration
@@ -168,6 +199,11 @@ final class VocalSeparator: ObservableObject {
         return stems
     }
 
+    /// Existence-only stem check (plain or compressed) that never decompresses.
+    func hasCachedStems(forSongID songID: String) -> Bool {
+        cachedVocalsURL(forSongID: songID) != nil && cachedInstrumentsURL(forSongID: songID) != nil
+    }
+
     func cachedStartOffset(forSongID songID: String) -> TimeInterval {
         AudioCacheStore.readStartOffset(for: songID)
     }
@@ -176,14 +212,14 @@ final class VocalSeparator: ObservableObject {
         forSongID songID: String, sourceURL: URL, initiatedByBackground: Bool = false
     ) async throws -> CachedStems {
         let expectedDuration = Self.expectedDuration(for: sourceURL)
-        if let cached = cachedStems(forSongID: songID, expectedDuration: expectedDuration) {
+        if let cached = await cachedStems(forSongID: songID, expectedDuration: expectedDuration) {
             return cached
         }
         guard isAvailable, let modelURL else { throw VocalSeparatorError.unavailable }
         if processingSongID == songID, let active = activeTask {
             DebugLogger.log("Waiting for in-progress separation: \(songID)", category: .separation)
             _ = try await active.value
-            if let cached = cachedStems(forSongID: songID, expectedDuration: expectedDuration) {
+            if let cached = await cachedStems(forSongID: songID, expectedDuration: expectedDuration) {
                 return cached
             }
             throw VocalSeparatorError.unavailable
@@ -242,7 +278,7 @@ final class VocalSeparator: ObservableObject {
         activeTask = task
         _ = try await task.value
         CacheManager.shared.enforceMusicCacheLimits()
-        guard let stems = cachedStems(forSongID: songID, expectedDuration: expectedDuration) else {
+        guard let stems = await cachedStems(forSongID: songID, expectedDuration: expectedDuration) else {
             throw VocalSeparatorError.unavailable
         }
         DebugLogger.log("Full separation complete for \(songID)", category: .separation)
@@ -350,7 +386,7 @@ final class VocalSeparator: ObservableObject {
 
     func analyzeInBackground(songID: String, sourceURL: URL) {
         guard isAvailable else { return }
-        guard cachedStems(forSongID: songID) == nil else {
+        guard !hasCachedStems(forSongID: songID) else {
             DebugLogger.log(
                 "Background analysis skipped — stems already cached for \(songID)",
                 category: .ai

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -182,6 +182,38 @@ nonisolated enum AudioCacheStore {
         return CachedStems(vocals: vocals, instruments: instruments, startOffset: startOffset)
     }
 
+    /// Like `playableStems`, but never decompresses: returns nil when only the
+    /// compressed cache exists, so callers on the main thread can defer that
+    /// work to a background path instead.
+    static func immediatelyPlayableStems(
+        for songID: String,
+        startOffset: TimeInterval,
+        expectedDuration: TimeInterval? = nil
+    ) -> CachedStems? {
+        let songFiles = files(for: songID)
+        let vocals = songFiles.vocals
+        let instruments = songFiles.instruments
+        guard fm.fileExists(atPath: vocals.path), isValidAudioFile(at: vocals),
+              fm.fileExists(atPath: instruments.path), isValidAudioFile(at: instruments)
+        else {
+            return nil
+        }
+        guard validateStemPair(
+            vocals: vocals,
+            instruments: instruments,
+            startOffset: startOffset,
+            expectedDuration: expectedDuration
+        )
+        else {
+            DebugLogger.log("Removing invalid stem cache for \(songID)", category: .cache)
+            removeStemCache(for: songID)
+            return nil
+        }
+        touch(vocals)
+        touch(instruments)
+        return CachedStems(vocals: vocals, instruments: instruments, startOffset: startOffset)
+    }
+
     static func hasCachedMainAudio(for songID: String, expectedRemoteURL: URL? = nil, expectedDuration: TimeInterval? = nil) -> Bool {
         playableMainURL(
             for: songID,

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -372,6 +372,83 @@ final class DownloadManager: ObservableObject {
     }
 
     func download(songs: [Song]) {
+        // Already-downloaded songs are revalidated through playableURL, which
+        // on a validation-cache miss opens the file with AVAudioFile. Validate
+        // those off the main actor first so 'download all' on a large playlist
+        // never decodes audio on the main thread; the warmed cache then makes
+        // the enqueue pass skip them for the price of a dictionary lookup.
+        let needsValidation = songs.filter {
+            $0.audioURL != nil
+                && downloadedIDs.contains($0.id)
+                && !hasCachedPlayableValidation(for: $0)
+        }
+        guard needsValidation.isEmpty else {
+            let deferredIDs = Set(needsValidation.map(\.id))
+            enqueueDownloads(songs.filter { !deferredIDs.contains($0.id) })
+            prewarmValidationCache(for: needsValidation)
+            return
+        }
+        enqueueDownloads(songs)
+    }
+
+    private func hasCachedPlayableValidation(for song: Song) -> Bool {
+        guard let cached = validDownloadCache[song.id] else { return false }
+        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+        return cached.expectedDuration == expectedDuration
+    }
+
+    private func prewarmValidationCache(for songs: [Song]) {
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let entries = self.validateDownloadsForCachePrewarm(songs)
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                for (songID, entry) in entries where self.validDownloadCache[songID] == nil {
+                    self.validDownloadCache[songID] = entry
+                }
+                self.enqueueDownloads(songs)
+            }
+        }
+    }
+
+    /// Mirrors the early-exit checks in playableURL so warmed cache entries
+    /// make it return the audio file without AVAudioFile on the main actor.
+    /// Missing, stale, or invalid downloads get no entry and fall back to the
+    /// on-main validation and repair path.
+    private nonisolated func validateDownloadsForCachePrewarm(
+        _ songs: [Song]
+    ) -> [String: ValidDownloadCacheEntry] {
+        var entries: [String: ValidDownloadCacheEntry] = [:]
+        for song in songs {
+            migrateLegacyDownloadIfNeeded(for: song.id)
+            migrateMislabeledDownloadedAudioIfNeeded(
+                for: song.id,
+                expectedSourceURL: song.audioURL
+            )
+            let cachedSource = readSourceURL(for: song.id)
+            let storedSourceURL = cachedSource.flatMap(URL.init(string:))
+            let songFiles = files(
+                for: song.id,
+                sourceURL: storedSourceURL ?? song.audioURL
+            )
+            guard FileManager.default.fileExists(atPath: songFiles.audio.path) else { continue }
+            let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+            let expectedSource = song.audioURL?.absoluteString
+            if let cachedSource, let expectedSource, cachedSource != expectedSource { continue }
+            guard Self.isValidDownloadedAudio(
+                at: songFiles.audio,
+                expectedDuration: expectedDuration
+            ) else { continue }
+            entries[song.id] = ValidDownloadCacheEntry(
+                source: cachedSource ?? expectedSource,
+                expectedDuration: expectedDuration,
+                modifiedAt: Self.modificationDate(at: songFiles.audio)
+            )
+        }
+        return entries
+    }
+
+    private func enqueueDownloads(_ songs: [Song]) {
         var nextInProgress = inProgress
         var acceptedAny = false
 
@@ -399,8 +476,14 @@ final class DownloadManager: ObservableObject {
     }
 
     private func startQueuedDownloadsIfPossible() {
-        while activeDownloadWorkCount < Self.maxConcurrentDownloads, !queuedDownloadOrder.isEmpty {
-            let songID = queuedDownloadOrder.removeFirst()
+        // Iterate by index and remove the drained prefix in one batch instead
+        // of removeFirst() per element, which shifts the whole array each time.
+        var drainedCount = 0
+        while activeDownloadWorkCount < Self.maxConcurrentDownloads,
+              drainedCount < queuedDownloadOrder.count
+        {
+            let songID = queuedDownloadOrder[drainedCount]
+            drainedCount += 1
             guard let song = queuedDownloads.removeValue(forKey: songID) else { continue }
             guard inProgress.contains(songID), !downloadedIDs.contains(songID) else {
                 updatePublishedState { $0.inProgress.remove(songID) }
@@ -408,6 +491,7 @@ final class DownloadManager: ObservableObject {
             }
             startDownloadTask(song: song)
         }
+        queuedDownloadOrder.removeFirst(drainedCount)
     }
 
     private func startDownloadTask(song: Song) {
@@ -1006,9 +1090,7 @@ final class DownloadManager: ObservableObject {
             sourceURL: storedSourceURL ?? song.audioURL
         )
         guard FileManager.default.fileExists(atPath: songFiles.audio.path) else {
-            updatePublishedState { $0.downloadedIDs.remove(song.id) }
-            validDownloadCache.removeValue(forKey: song.id)
-            downloadedMetadata.removeValue(forKey: song.id)
+            discardBrokenDownloadAndScheduleRepair(for: song, reason: "audio file is missing")
             return nil
         }
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -392,9 +392,16 @@ final class DownloadManager: ObservableObject {
     }
 
     private func hasCachedPlayableValidation(for song: Song) -> Bool {
-        guard let cached = validDownloadCache[song.id] else { return false }
+        let cachedSource = readSourceURL(for: song.id)
+        let storedSourceURL = cachedSource.flatMap(URL.init(string:))
+        let songFiles = files(for: song.id, sourceURL: storedSourceURL ?? song.audioURL)
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
-        return cached.expectedDuration == expectedDuration
+        return hasCachedValidation(
+            for: song.id,
+            audioURL: songFiles.audio,
+            source: cachedSource ?? song.audioURL?.absoluteString,
+            expectedDuration: expectedDuration
+        )
     }
 
     private func prewarmValidationCache(for songs: [Song]) {

--- a/Twinskaraoke/Services/User/AuthManager.swift
+++ b/Twinskaraoke/Services/User/AuthManager.swift
@@ -58,6 +58,21 @@ final class AuthManager: NSObject, ObservableObject {
     override init() {
         super.init()
         loadPersisted()
+        NotificationCenter.default.addObserver(
+            forName: .karaokeSessionExpired,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.handleExpiredSession()
+            }
+        }
+    }
+
+    private func handleExpiredSession() {
+        guard isLoggedIn else { return }
+        logout()
+        errorMessage = "Your session expired — please sign in again"
     }
 
     private func loadPersisted() {

--- a/Twinskaraoke/Services/User/UserPlaylistsManager.swift
+++ b/Twinskaraoke/Services/User/UserPlaylistsManager.swift
@@ -109,8 +109,40 @@ final class UserPlaylistsManager: ObservableObject {
             }
             req.httpMethod = "PUT"
             let ok = (try? await KaraokeAPIClient.data(for: req)) != nil
+            if ok {
+                bumpSongCount(forPlaylist: playlistID)
+                PlaylistSongCountStore.shared.invalidate(playlistID: playlistID)
+            }
             completion?(ok)
         }
+    }
+
+    private func bumpSongCount(forPlaylist playlistID: String) {
+        guard let index = playlists.firstIndex(where: { $0.id == playlistID }) else { return }
+        let playlist = playlists[index]
+        playlists[index] = UserPlaylist(
+            id: playlist.id,
+            name: playlist.name,
+            description: playlist.description,
+            createdBy: playlist.createdBy,
+            updatedBy: playlist.updatedBy,
+            media: playlist.media,
+            createdAt: playlist.createdAt,
+            updatedAt: playlist.updatedAt,
+            totalDuration: playlist.totalDuration,
+            songCount: playlist.songCount + 1,
+            playCount: playlist.playCount,
+            favoriteCount: playlist.favoriteCount,
+            playlistType: playlist.playlistType,
+            songListDTOs: playlist.songListDTOs,
+            mosaicMedia: playlist.mosaicMedia,
+            genres: playlist.genres,
+            editable: playlist.editable,
+            deletable: playlist.deletable,
+            isPublic: playlist.isPublic,
+            isSetList: playlist.isSetList,
+            setListDate: playlist.setListDate
+        )
     }
 
     func clear() {

--- a/TwinskaraokeShared/Components/PressableButtonStyle.swift
+++ b/TwinskaraokeShared/Components/PressableButtonStyle.swift
@@ -120,7 +120,7 @@ private struct PressableButtonBody: View {
   }
 
   private var animation: Animation {
-    pressAnimation ?? AppMotion.playful
+    pressAnimation ?? AppMotion.snap
   }
 
   private func updatePressState(_ isPressed: Bool) {

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -13955,6 +13955,9 @@
         }
       }
     },
+    "Preparing" : {
+
+    },
     "Preparing karaoke" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TwinskaraokeShared/Services/CredentialStore.swift
+++ b/TwinskaraokeShared/Services/CredentialStore.swift
@@ -17,6 +17,7 @@ nonisolated enum CredentialStore {
 
   private static let tokenCacheLock = NSLock()
   private nonisolated(unsafe) static var cachedToken: String?
+  private nonisolated(unsafe) static var cacheGeneration: UInt64 = 0
 
   static var token: String? {
     if UserDefaults.standard.object(forKey: sessionCommittedKey) as? Bool == false {
@@ -24,6 +25,7 @@ nonisolated enum CredentialStore {
     }
     tokenCacheLock.lock()
     let cached = cachedToken
+    let generation = cacheGeneration
     tokenCacheLock.unlock()
     if let cached {
       return cached
@@ -32,7 +34,9 @@ nonisolated enum CredentialStore {
       return nil
     }
     tokenCacheLock.lock()
-    cachedToken = resolved
+    if cacheGeneration == generation {
+      cachedToken = resolved
+    }
     tokenCacheLock.unlock()
     return resolved
   }
@@ -99,6 +103,7 @@ nonisolated enum CredentialStore {
   private static func setCachedToken(_ token: String?) {
     tokenCacheLock.lock()
     cachedToken = token
+    cacheGeneration &+= 1
     tokenCacheLock.unlock()
   }
 

--- a/TwinskaraokeShared/Services/CredentialStore.swift
+++ b/TwinskaraokeShared/Services/CredentialStore.swift
@@ -15,10 +15,29 @@ nonisolated enum CredentialStore {
   private static let legacyTokenKey = "nk.token"
   private static let sessionCommittedKey = "nk.sessionCommitted"
 
+  private static let tokenCacheLock = NSLock()
+  private nonisolated(unsafe) static var cachedToken: String?
+
   static var token: String? {
     if UserDefaults.standard.object(forKey: sessionCommittedKey) as? Bool == false {
       return nil
     }
+    tokenCacheLock.lock()
+    let cached = cachedToken
+    tokenCacheLock.unlock()
+    if let cached {
+      return cached
+    }
+    guard let resolved = resolveToken() else {
+      return nil
+    }
+    tokenCacheLock.lock()
+    cachedToken = resolved
+    tokenCacheLock.unlock()
+    return resolved
+  }
+
+  private static func resolveToken() -> String? {
     if let stored = readTokenFromKeychain() {
       return stored
     }
@@ -54,6 +73,7 @@ nonisolated enum CredentialStore {
     let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     if updateStatus == errSecSuccess {
       UserDefaults.standard.removeObject(forKey: legacyTokenKey)
+      setCachedToken(token)
       return
     }
     guard updateStatus == errSecItemNotFound else {
@@ -67,11 +87,19 @@ nonisolated enum CredentialStore {
       throw StoreError.keychain(insertStatus)
     }
     UserDefaults.standard.removeObject(forKey: legacyTokenKey)
+    setCachedToken(token)
   }
 
   static func deleteToken() {
     SecItemDelete(baseQuery as CFDictionary)
     UserDefaults.standard.removeObject(forKey: legacyTokenKey)
+    setCachedToken(nil)
+  }
+
+  private static func setCachedToken(_ token: String?) {
+    tokenCacheLock.lock()
+    cachedToken = token
+    tokenCacheLock.unlock()
   }
 
   private static var baseQuery: [String: Any] {

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -538,7 +538,9 @@ nonisolated enum KaraokeAPIClient {
         }
         guard (200..<300).contains(httpResponse.statusCode) else {
           if httpResponse.statusCode == 401,
-            request.value(forHTTPHeaderField: "Authorization") != nil
+            let authorization = request.value(forHTTPHeaderField: "Authorization"),
+            let currentToken = CredentialStore.token,
+            authorization == "Bearer \(currentToken)"
           {
             NotificationCenter.default.post(name: .karaokeSessionExpired, object: nil)
           }

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -1,6 +1,10 @@
 import Foundation
 import os
 
+extension Notification.Name {
+  nonisolated static let karaokeSessionExpired = Notification.Name("KaraokeSessionExpired")
+}
+
 actor UploadedSongMetadataCache {
   private struct Entry: Sendable {
     let songs: [Song]
@@ -41,7 +45,9 @@ actor UploadedSongMetadataCache {
 
     do {
       let songs = try await request.task.value
-      let coveredIDs = (cachedValue?.coveredIDs ?? []).union(requestedIDs)
+      let coveredIDs = (cachedValue?.coveredIDs ?? [])
+        .union(requestedIDs)
+        .union(songs.map(\.id))
       cachedValue = Entry(
         songs: songs,
         coveredIDs: coveredIDs,
@@ -305,7 +311,7 @@ nonisolated enum KaraokeAPIClient {
     }
     guard !uniqueIDs.isEmpty else { return [] }
     let request = try songsByIDsRequest(uniqueIDs)
-    let data = try await data(for: request)
+    let data = try await data(for: request, retriesNonIdempotentRequest: true)
     guard let songs = SongPayloadDecoder.decodeSongs(from: data) else {
       throw APIError.decodeFailed
     }
@@ -416,7 +422,7 @@ nonisolated enum KaraokeAPIClient {
       path: "/api/songs",
       body: body
     )
-    return try await data(for: request)
+    return try await data(for: request, retriesNonIdempotentRequest: true)
   }
 
   private static func playlistDetailData(id: String) async throws -> Data {
@@ -516,9 +522,13 @@ nonisolated enum KaraokeAPIClient {
     return allowed
   }()
 
-  static func data(for request: URLRequest) async throws -> Data {
+  static func data(
+    for request: URLRequest,
+    retriesNonIdempotentRequest: Bool = false
+  ) async throws -> Data {
     let maxRetries = 3
     let baseDelay: UInt64 = 500_000_000
+    let canRetry = retriesNonIdempotentRequest || isIdempotent(request)
 
     for attempt in 0..<maxRetries {
       do {
@@ -527,8 +537,13 @@ nonisolated enum KaraokeAPIClient {
           throw APIError.invalidResponse
         }
         guard (200..<300).contains(httpResponse.statusCode) else {
+          if httpResponse.statusCode == 401,
+            request.value(forHTTPHeaderField: "Authorization") != nil
+          {
+            NotificationCenter.default.post(name: .karaokeSessionExpired, object: nil)
+          }
 
-          if shouldRetry(statusCode: httpResponse.statusCode) && attempt < maxRetries - 1 {
+          if canRetry && shouldRetry(statusCode: httpResponse.statusCode) && attempt < maxRetries - 1 {
             let delay = baseDelay * UInt64(1 << attempt)
             try await Task.sleep(nanoseconds: delay)
             continue
@@ -538,7 +553,7 @@ nonisolated enum KaraokeAPIClient {
         return data
       } catch let error as URLError {
 
-        if shouldRetry(urlError: error) && attempt < maxRetries - 1 {
+        if canRetry && shouldRetry(urlError: error) && attempt < maxRetries - 1 {
           let delay = baseDelay * UInt64(1 << attempt)
           try await Task.sleep(nanoseconds: delay)
           continue
@@ -551,6 +566,11 @@ nonisolated enum KaraokeAPIClient {
     }
 
     throw APIError.invalidResponse
+  }
+
+  private static func isIdempotent(_ request: URLRequest) -> Bool {
+    guard let method = request.httpMethod?.uppercased() else { return true }
+    return method == "GET" || method == "HEAD" || method == "PUT" || method == "DELETE"
   }
 
   private static func shouldRetry(statusCode: Int) -> Bool {

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -720,9 +720,27 @@ struct SongModelTests {
     @MainActor
     func playlistGridWaitsForDetailCount() {
         let store = PlaylistSongCountStore()
-        let playlist = Playlist(
+        var personalPlaylist = Playlist(
             id: "summary-bangers",
             name: "Bangers",
+            songCount: 498,
+            mosaicMedia: nil,
+            songListDTOs: nil
+        )
+        personalPlaylist.isPersonal = true
+
+        #expect(
+            store.displayedCount(
+                for: personalPlaylist,
+                prefersDetailCount: true
+            ) == nil
+        )
+
+        // Public playlists carry an accurate server-side count: show it
+        // immediately instead of staying blank until a detail fetch.
+        let publicPlaylist = Playlist(
+            id: "summary-public",
+            name: "Public Bangers",
             songCount: 498,
             mosaicMedia: nil,
             songListDTOs: nil
@@ -730,9 +748,9 @@ struct SongModelTests {
 
         #expect(
             store.displayedCount(
-                for: playlist,
+                for: publicPlaylist,
                 prefersDetailCount: true
-            ) == nil
+            ) == 498
         )
     }
 

--- a/TwinskaraokeWatchApp/App/ContentView.swift
+++ b/TwinskaraokeWatchApp/App/ContentView.swift
@@ -54,7 +54,7 @@ struct WatchSongArtwork: View {
 
     var body: some View {
         ZStack {
-            AsyncImage(url: url) { image in
+            WatchCachedImage(url: url) { image in
                 image.resizable().scaledToFill()
             } placeholder: {
                 RoundedRectangle(cornerRadius: cornerRadius)

--- a/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
+++ b/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// In-memory + disk image cache for the watch app (no SDWebImage on this target).
+final class WatchImageCache {
+    static let shared = WatchImageCache()
+
+    private let memory = NSCache<NSURL, UIImage>()
+    private let disk = URLCache.shared
+
+    private init() {}
+
+    /// Synchronous memory-cache lookup used to seed views without a placeholder frame.
+    func cachedImage(for url: URL) -> UIImage? {
+        memory.object(forKey: url as NSURL)
+    }
+
+    func image(for url: URL) async -> UIImage? {
+        let key = url as NSURL
+        if let cached = memory.object(forKey: key) { return cached }
+
+        let request = URLRequest(url: url)
+        if let stored = disk.cachedResponse(for: request),
+           let image = UIImage(data: stored.data) {
+            memory.setObject(image, forKey: key)
+            return image
+        }
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let image = UIImage(data: data)
+        else { return nil }
+
+        memory.setObject(image, forKey: key)
+        disk.storeCachedResponse(CachedURLResponse(response: response, data: data), for: request)
+        return image
+    }
+}
+
+/// Drop-in replacement for AsyncImage that serves repeated loads from WatchImageCache,
+/// avoiding re-fetch/re-decode flicker when rows re-enter the view hierarchy.
+struct WatchCachedImage<Content: View, Placeholder: View>: View {
+    let url: URL?
+    @ViewBuilder let content: (Image) -> Content
+    @ViewBuilder let placeholder: () -> Placeholder
+
+    @State private var image: UIImage?
+
+    init(
+        url: URL?,
+        @ViewBuilder content: @escaping (Image) -> Content,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.url = url
+        self.content = content
+        self.placeholder = placeholder
+        _image = State(initialValue: url.flatMap { WatchImageCache.shared.cachedImage(for: $0) })
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                content(Image(uiImage: image))
+            } else {
+                placeholder()
+            }
+        }
+        .task(id: url) {
+            guard let url else {
+                image = nil
+                return
+            }
+            let loaded = await WatchImageCache.shared.image(for: url)
+            guard !Task.isCancelled else { return }
+            image = loaded
+        }
+    }
+}

--- a/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
+++ b/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
@@ -68,6 +68,9 @@ struct WatchCachedImage<Content: View, Placeholder: View>: View {
                 image = nil
                 return
             }
+            // URL changed: drop the previous artwork, re-seeding from the
+            // memory cache exactly like the initial State value in init.
+            image = WatchImageCache.shared.cachedImage(for: url)
             let loaded = await WatchImageCache.shared.image(for: url)
             guard !Task.isCancelled else { return }
             image = loaded

--- a/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
@@ -147,7 +147,7 @@ private struct WatchPlaylistCard: View {
                             .font(.system(size: 22, weight: .semibold))
                             .foregroundColor(.secondary.opacity(0.65))
                     }
-                AsyncImage(url: playlist.thumbnailURL ?? playlist.imageURL) { image in
+                WatchCachedImage(url: playlist.thumbnailURL ?? playlist.imageURL) { image in
                     image.resizable().scaledToFill()
                 } placeholder: {
                     Color.clear

--- a/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
@@ -90,7 +90,7 @@ struct PlayerView: View {
                 ScrollView {
                     VStack(spacing: metrics.contentSpacing) {
                         ZStack {
-                            AsyncImage(url: song.thumbnailURL) { image in
+                            WatchCachedImage(url: song.thumbnailURL) { image in
                                 image.resizable().scaledToFit()
                             } placeholder: {
                                 RoundedRectangle(cornerRadius: 10)
@@ -286,7 +286,7 @@ struct PlayerView: View {
             .background(
                 Group {
                     if let url = audioManager.currentSong?.thumbnailURL {
-                        AsyncImage(url: url) { image in
+                        WatchCachedImage(url: url) { image in
                             image.resizable().scaledToFill()
                         } placeholder: {
                             backgroundBase

--- a/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
@@ -32,7 +32,11 @@ final class SearchViewModel: ObservableObject {
         isLoading = true
         Task { [weak self] in
             guard let self else { return }
-            defer { isLoading = false }
+            defer {
+                // Only the latest query clears the spinner; a stale completion
+                // must not hide the loader while a newer search is in flight.
+                if queryToken == token { isLoading = false }
+            }
             do {
                 let items = try await KaraokeAPIClient.searchSongItems(query: query, pageSize: 20)
                 guard queryToken == token else { return }

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -678,6 +678,7 @@ class AudioManager: ObservableObject {
 
     private func setupInterruptionHandler() {
         NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] note in self?.handleInterruption(note) }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## Summary

A broad polish pass across iOS and watchOS focused on UI improvements, scrolling/animation performance, and bug fixes. 58 files changed, tested on device.

## Highlights

**Bug fixes**
- Fixed a hard freeze when loading large playlists, caused by duplicate `ForEach` identities — song rows now use positional identity in `PlaylistDetailView`, `QueueView`, and `RandomSongsView`, and large (>300 item) result swaps skip diff animations
- Playlist song counts now display immediately instead of waiting for detail load (`PlaylistSongCountStore`)
- Assorted crash, race, and stale-state fixes across playback, downloads, networking, library, and search

**Performance**
- Removed shadows from dense small tiles (song grids, playlist cells, art thumbnails, artist circles, search cards); heroes keep permanent shadows
- Blur placeholder work in `RemoteArtworkImage` is gated while scrolling
- Animation fluidity: removed per-track view teardown in the player, smoother progress bar ticks, snappier press states, coalesced popup state updates
- Artwork prefetching and playlist cover loading improvements

**UI**
- Pull-to-search in playlist detail
- Layout and interaction polish across iOS and watchOS, including a shared `WatchCachedImage` component

## Testing
- Built for iOS and watchOS; full `TwinskaraokeTests` suite passes
- Verified on device: large playlist loading, playback, queue, search, pull-to-search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer error states and “Try Again” actions when artists or library songs fail to load.
  * Added cached artwork loading on Apple Watch for faster repeat viewing.
  * Added session-expiration handling that prompts users to sign in again.
* **Improvements**
  * Refresh controls now reliably complete while preserving existing content during updates.
  * Playlist save status and song counts update more accurately.
  * Improved player, queue, karaoke preparation, search, and artwork transitions.
  * Downloaded and cached audio validation is more reliable.
* **Bug Fixes**
  * Fixed stale search results, artwork updates, playlist counts, and audio playback state.
  * Improved iPad debug-log sharing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->