### PR TITLE
perf: broad optimization pass across audio, networking, storage, and UI

### DIFF
--- a/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
+++ b/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
@@ -4,7 +4,27 @@ struct PlayerVolumeRow: View {
     @EnvironmentObject var audioManager: AudioPlayerManager
     @Environment(\.scenePhase) private var scenePhase
     @State private var volumeBridgeGeneration = 0
+    // In-drag volume lives here so the 60-120Hz drag updates don't publish
+    // through AudioPlayerManager; the manager is committed once on drag end.
+    @State private var dragVolume: Double?
     var horizontalPadding: CGFloat = 32
+
+    private var displayVolume: Double {
+        dragVolume ?? audioManager.volume
+    }
+
+    private var volumeBinding: Binding<Double> {
+        Binding(
+            get: { displayVolume },
+            set: { newValue in
+                if audioManager.isUserScrubbingVolume {
+                    dragVolume = newValue
+                } else {
+                    audioManager.volume = newValue
+                }
+            }
+        )
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -13,15 +33,18 @@ struct PlayerVolumeRow: View {
                 .foregroundStyle(.secondary)
                 .accessibilityHidden(true)
             AppleMusicProgressBar(
-                progress: $audioManager.volume,
+                progress: volumeBinding,
                 isScrubbing: $audioManager.isUserScrubbingVolume,
-                onSeekEnd: { _ in },
+                onSeekEnd: { final in
+                    audioManager.volume = final
+                    dragVolume = nil
+                },
                 trackColor: Color.primary.opacity(0.18),
                 fillColor: .primary,
                 idleHeight: 7,
                 activeHeight: 12,
                 accessibilityLabel: "Volume",
-                accessibilityValueText: "\(Int(audioManager.volume * 100)) percent",
+                accessibilityValueText: "\(Int(displayVolume * 100)) percent",
                 accessibilityHint: "Drag or swipe up and down to adjust volume."
             )
             Image(systemName: "speaker.wave.3.fill")
@@ -33,7 +56,7 @@ struct PlayerVolumeRow: View {
         #if canImport(UIKit)
             .background(
                 SystemVolumeBridge(
-                    volume: $audioManager.volume,
+                    volume: volumeBinding,
                     isUserScrubbing: $audioManager.isUserScrubbingVolume
                 )
                 .id(volumeBridgeGeneration)

--- a/Twinskaraoke/Components/Player/VerticalKaraokeLevel.swift
+++ b/Twinskaraoke/Components/Player/VerticalKaraokeLevel.swift
@@ -5,18 +5,27 @@ struct VerticalKaraokeLevel: View {
     var enabled: Bool = true
     var onSet: (Double) -> Void = { _ in }
     @Environment(\.appReduceMotion) private var reduceMotion
+    // In-drag value is local so per-frame drag updates don't publish through
+    // the bound model; commits are throttled to ~10Hz for live audio feedback
+    // and finalized on drag end.
+    @State private var dragValue: Double?
+    @State private var lastCommitUptime: TimeInterval = 0
+
+    private var displayValue: Double {
+        max(0, min(1, dragValue ?? value))
+    }
 
     var body: some View {
         GeometryReader { geo in
             let h = geo.size.height
-            let clamped = max(0, min(1, value))
+            let clamped = displayValue
             ZStack(alignment: .bottom) {
                 Capsule()
                     .fill(Color.primary.opacity(enabled ? 0.22 : 0.12))
                 Capsule()
                     .fill(Color.primary.opacity(enabled ? 1.0 : 0.4))
                     .frame(height: max(4, h * CGFloat(clamped)))
-                    .animation(levelAnimation, value: value)
+                    .animation(levelAnimation, value: clamped)
             }
             .contentShape(Rectangle())
             .gesture(
@@ -24,8 +33,21 @@ struct VerticalKaraokeLevel: View {
                     .onChanged { v in
                         let raw = 1 - (v.location.y / h)
                         let next = Double(max(0, min(1, raw)))
-                        value = next
-                        onSet(next)
+                        dragValue = next
+                        let now = ProcessInfo.processInfo.systemUptime
+                        if now - lastCommitUptime >= 0.1 {
+                            lastCommitUptime = now
+                            value = next
+                            onSet(next)
+                        }
+                    }
+                    .onEnded { _ in
+                        if let final = dragValue {
+                            value = final
+                            onSet(final)
+                        }
+                        dragValue = nil
+                        lastCommitUptime = 0
                     }
             )
         }

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -87,7 +87,7 @@ struct SongRow: View {
                     RemoteArtworkImage(
                         url: playback.displayImageURL(for: song, variant: .row),
                         cornerRadius: size.cornerRadius,
-                        lowResURL: song.thumbnailURL,
+                        lowResURL: playback.displayImageURL(for: song, variant: .row),
                         fixedDisplaySize: CGSize(width: size.artSize, height: size.artSize)
                     )
                     .frame(width: size.artSize, height: size.artSize)

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -619,9 +619,14 @@ private struct StrengthSlider: View {
 
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var lastFeedbackStep: Int?
+    // In-drag value is local so per-frame drag updates don't publish through
+    // the bound model; commits are throttled to ~10Hz for live audio feedback
+    // and finalized on drag end.
+    @State private var dragValue: Float?
+    @State private var lastCommitUptime: TimeInterval = 0
 
     private var clampedValue: Float {
-        min(1, max(0, value))
+        min(1, max(0, dragValue ?? value))
     }
 
     private var percent: Int {
@@ -658,9 +663,20 @@ private struct StrengthSlider: View {
                 DragGesture(minimumDistance: 0)
                     .onChanged { drag in
                         let v = max(0, min(1, drag.location.x / max(1, geo.size.width)))
-                        setValue(Float(v), feedback: true)
+                        dragValue = Float(v)
+                        playStepFeedback(for: Float(v))
+                        let now = ProcessInfo.processInfo.systemUptime
+                        if now - lastCommitUptime >= 0.1 {
+                            lastCommitUptime = now
+                            commitValue(Float(v))
+                        }
                     }
                     .onEnded { _ in
+                        if let final = dragValue {
+                            commitValue(final)
+                        }
+                        dragValue = nil
+                        lastCommitUptime = 0
                         lastFeedbackStep = nil
                     }
             )
@@ -689,6 +705,12 @@ private struct StrengthSlider: View {
         if feedback {
             playStepFeedback(for: clamped)
         }
+    }
+
+    private func commitValue(_ newValue: Float) {
+        let clamped = min(1, max(0, newValue))
+        guard abs(clamped - value) > 0.001 else { return }
+        value = clamped
     }
 
     private func playStepFeedback(for value: Float) {
@@ -778,9 +800,14 @@ private struct EqualizerBand: View {
 
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var lastFeedbackStep: Int?
+    // In-drag value is local so per-frame drag updates don't rewrite the whole
+    // eqGainsDB array (UserDefaults + engine gains) every frame; commits are
+    // throttled to ~10Hz for live audio feedback and finalized on drag end.
+    @State private var dragValue: Float?
+    @State private var lastCommitUptime: TimeInterval = 0
 
     private var clampedValue: Float {
-        min(range.upperBound, max(range.lowerBound, value))
+        min(range.upperBound, max(range.lowerBound, dragValue ?? value))
     }
 
     private var valueText: String {
@@ -826,9 +853,21 @@ private struct EqualizerBand: View {
                     .onChanged { drag in
                         let y = max(0, min(trackHeight, drag.location.y))
                         let n = 1 - (y / max(1, trackHeight))
-                        setValue(range.lowerBound + Float(n) * span, feedback: true)
+                        let next = range.lowerBound + Float(n) * span
+                        dragValue = next
+                        playStepFeedback(for: next)
+                        let now = ProcessInfo.processInfo.systemUptime
+                        if now - lastCommitUptime >= 0.1 {
+                            lastCommitUptime = now
+                            commitValue(next)
+                        }
                     }
                     .onEnded { _ in
+                        if let final = dragValue {
+                            commitValue(final)
+                        }
+                        dragValue = nil
+                        lastCommitUptime = 0
                         lastFeedbackStep = nil
                     }
             )
@@ -856,6 +895,12 @@ private struct EqualizerBand: View {
         if feedback {
             playStepFeedback(for: clamped)
         }
+    }
+
+    private func commitValue(_ newValue: Float) {
+        let clamped = min(range.upperBound, max(range.lowerBound, newValue))
+        guard abs(clamped - value) > 0.001 else { return }
+        value = clamped
     }
 
     private func playStepFeedback(for value: Float) {

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -203,9 +203,6 @@ struct DownloadedSongsView: View {
     private func refresh() {
         let cached = recentlyPlayed.playlists.flatMap { $0.songListDTOs ?? [] }
         let songs = downloads.downloadedSongs(knownSongs: cached)
-        let localAudioCandidates = songs.reduce(into: [String: URL]()) { urls, song in
-            urls[song.id] = downloads.localURL(for: song.id)
-        }
         ArtworkPrefetcher.shared.prefetchSongs(
             Array(songs.prefix(18)),
             limit: 18,
@@ -216,11 +213,16 @@ struct DownloadedSongsView: View {
 
         durationTask?.cancel()
         durationTask = Task { @MainActor in
-            // File-existence checks hit the disk once per song; keep them off
-            // the main actor so refresh/onAppear stays responsive.
+            // Resolving each song's local URL reads its per-song source file
+            // and may enumerate the download directory; together with the
+            // file-existence checks that is disk I/O per song, so keep the
+            // whole scan off the main actor.
             let scanTask = Task.detached(priority: .utility) {
-                localAudioCandidates.filter {
-                    !Task.isCancelled && FileManager.default.fileExists(atPath: $0.value.path)
+                songs.reduce(into: [String: URL]()) { urls, song in
+                    guard !Task.isCancelled else { return }
+                    let url = downloads.localURL(for: song.id)
+                    guard FileManager.default.fileExists(atPath: url.path) else { return }
+                    urls[song.id] = url
                 }
             }
             let localAudioURLs = await withTaskCancellationHandler {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -45,7 +45,6 @@ struct LibraryView: View {
     @StateObject var viewModel = PlaylistsViewModel()
     @StateObject private var recentSongsViewModel = LibrarySongsViewModel()
     @ObservedObject private var savedStore = SavedPlaylistsStore.shared
-    @ObservedObject private var addedTracker = RecentlyAddedTracker.shared
     @ObservedObject private var favorites = FavoritesManager.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showCreateSheet = false
@@ -378,6 +377,7 @@ private struct WideLibraryHero: View {
 struct LibrarySongsView: View {
     @StateObject private var viewModel = LibrarySongsViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
+    @State private var prefetchedIDs: [String] = []
 
     var body: some View {
         let songs = viewModel.displayedSongs
@@ -456,9 +456,15 @@ struct LibrarySongsView: View {
         .task {
             viewModel.loadIfNeeded()
         }
-        .onChange(of: Array(songs.prefix(18)).map(\.id)) { _, _ in
+        // Diffing on displayedSongs (Equatable) avoids allocating the prefix
+        // id array on every body eval; it only builds when the list changes.
+        .onChange(of: viewModel.displayedSongs) { _, newSongs in
+            let visible = Array(newSongs.prefix(18))
+            let ids = visible.map(\.id)
+            guard ids != prefetchedIDs else { return }
+            prefetchedIDs = ids
             ArtworkPrefetcher.shared.prefetchSongs(
-                Array(songs.prefix(18)),
+                visible,
                 limit: 18,
                 reason: "library visible songs",
                 variant: .row
@@ -636,17 +642,12 @@ struct PlaylistsGridScreen: View {
         return uniqueUser + all
     }
 
-    private var displayedPlaylists: [Playlist] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return combinedPlaylists }
-        return combinedPlaylists.filter { playlist in
-            playlist.name.localizedCaseInsensitiveContains(query)
-        }
-    }
-
     var body: some View {
         let all = combinedPlaylists
-        let displayed = displayedPlaylists
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayed = query.isEmpty ? all : all.filter { playlist in
+            playlist.name.localizedCaseInsensitiveContains(query)
+        }
         ScrollView {
             Group {
                 if viewModel.isLoading, userManager.isLoading, all.isEmpty {

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -131,7 +131,11 @@ struct PlaylistDetailView: View {
             filterTask = Task {
                 try? await Task.sleep(for: .milliseconds(200))
                 guard !Task.isCancelled else { return }
-                filteredSongs = PlaylistSongSearch.filter(songs, matching: newValue)
+                // Resolve the source list now, not at body-eval time, so a
+                // loader.$songs update during the debounce isn't overwritten
+                // by a filter of the stale snapshot.
+                let currentSongs = loader.songs ?? playlist.songListDTOs ?? []
+                filteredSongs = PlaylistSongSearch.filter(currentSongs, matching: newValue)
             }
         }
         .onReceive(loader.$songs) { newSongs in

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -21,6 +21,8 @@ struct PlaylistDetailView: View {
     @State private var isActivelyPulling = false
     @State private var shouldActivateSearchAfterPull = false
     @State private var searchRevealState = PlaylistSearchRevealState()
+    @State private var filterTask: Task<Void, Never>?
+    @State private var favoritesRefreshTask: Task<Void, Never>?
     @FocusState private var isSearchFocused: Bool
 
     init(playlist: Playlist) {
@@ -122,8 +124,15 @@ struct PlaylistDetailView: View {
             }
             prefetchArtwork(songs: displayedSongs)
         }
-        .onChange(of: searchText) { _, _ in
-            filteredSongs = PlaylistSongSearch.filter(songs, matching: searchText)
+        .onChange(of: searchText) { _, newValue in
+            // Filtering a large playlist runs 3 localized comparisons per song;
+            // debounce so typing doesn't stall the main thread per keystroke.
+            filterTask?.cancel()
+            filterTask = Task {
+                try? await Task.sleep(for: .milliseconds(200))
+                guard !Task.isCancelled else { return }
+                filteredSongs = PlaylistSongSearch.filter(songs, matching: newValue)
+            }
         }
         .onReceive(loader.$songs) { newSongs in
             let next = PlaylistSongSearch.filter(
@@ -139,7 +148,15 @@ struct PlaylistDetailView: View {
         }
         .onChange(of: favorites.favoriteIDs) { _, _ in
             guard playlist.isFavorites else { return }
-            loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
+            // Every star tap anywhere in the app fires this; coalesce rapid
+            // toggles into a single refetch instead of reloading the whole
+            // playlist per tap.
+            favoritesRefreshTask?.cancel()
+            favoritesRefreshTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
+            }
         }
         .onChange(of: isSearchFocused) { _, isFocused in
             guard isFocused, !isSearchModeActive else { return }

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -4,10 +4,6 @@ struct UploadedSongsView: View {
     @StateObject private var viewModel = UploadedSongsViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
 
-    private var listAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.quick
-    }
-
     var body: some View {
         let songs = viewModel.displayedSongs
         let isSearching = !viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -83,8 +79,6 @@ struct UploadedSongsView: View {
         .onDisappear {
             ArtworkPrefetcher.shared.cancel(reason: "uploaded visible songs")
         }
-        .animation(listAnimation, value: songs.map(\.id))
-        .animation(listAnimation, value: viewModel.sort)
         .accessibilityIdentifier("Library.UploadedSongs")
     }
 

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -5,6 +5,7 @@ struct QueueView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showCurrentAddToPlaylist = false
+    @State private var upNextSongs: [Song] = []
 
     private var queueToggleAnimation: Animation? {
         reduceMotion ? nil : AppMotion.quick
@@ -146,6 +147,11 @@ struct QueueView: View {
                 AddToPlaylistSheet(song: current)
             }
         }
+        // Snapshot up-next only when the queue or current song changes, so
+        // unrelated AudioPlayerManager publishes don't redo the O(n) slice.
+        .onAppear { refreshUpNextSongs() }
+        .onChange(of: audioManager.queue) { _, _ in refreshUpNextSongs() }
+        .onChange(of: audioManager.currentSong?.id) { _, _ in refreshUpNextSongs() }
     }
 
     private func header(upNextCount: Int) -> some View {
@@ -280,13 +286,16 @@ struct QueueView: View {
         audioManager.play(song: song, context: audioManager.queue)
     }
 
-    private var upNextSongs: [Song] {
+    private func refreshUpNextSongs() {
         // Match by id: applyEnrichedMetadata replaces currentSong with a fresh
         // instance that no longer == the queue copy.
         guard let current = audioManager.currentSong,
               let idx = audioManager.queue.firstIndex(where: { $0.id == current.id }),
               idx + 1 < audioManager.queue.count
-        else { return [] }
-        return Array(audioManager.queue[(idx + 1)...])
+        else {
+            upNextSongs = []
+            return
+        }
+        upNextSongs = Array(audioManager.queue[(idx + 1)...])
     }
 }

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -3,15 +3,15 @@ import Foundation
 
 @MainActor
 final class LibrarySongsViewModel: ObservableObject {
-    @Published var songs: [Song] = []
+    @Published var songs: [Song] = [] {
+        didSet { songsGeneration &+= 1 }
+    }
     @Published var isLoading = false
     @Published var isLoadingMore = false
     @Published var sort: LibrarySongSort = .recentlyAdded {
         didSet { rebuildDisplayedSongs() }
     }
-    @Published var searchText = "" {
-        didSet { rebuildDisplayedSongs() }
-    }
+    @Published var searchText = ""
     @Published private(set) var displayedSongs: [Song] = []
     @Published private(set) var loadFailed = false
     private var hasLoaded = false
@@ -20,9 +20,28 @@ final class LibrarySongsViewModel: ObservableObject {
     private var requestToken = 0
     private var isReplacing = false
     private var activeTask: URLSessionDataTask?
+    private var cancellables = Set<AnyCancellable>()
+    private var songsGeneration: UInt64 = 0
+    private var sortCache: (sort: LibrarySongSort, generation: UInt64, songs: [Song])?
     private let pageSize = 40
 
-    private func rebuildDisplayedSongs() {
+    init() {
+        $searchText
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.rebuildDisplayedSongs() }
+            .store(in: &cancellables)
+    }
+
+    // Sorting is the expensive half of a rebuild; cache it per (sort, songs)
+    // so search keystrokes only pay for the filter pass.
+    private var sortedSongs: [Song] {
+        if let sortCache,
+           sortCache.sort == sort,
+           sortCache.generation == songsGeneration
+        {
+            return sortCache.songs
+        }
         let sorted: [Song] = switch sort {
         case .recentlyAdded:
             songs
@@ -35,6 +54,12 @@ final class LibrarySongsViewModel: ObservableObject {
         case .duration:
             songs.sorted { $0.duration < $1.duration }
         }
+        sortCache = (sort, songsGeneration, sorted)
+        return sorted
+    }
+
+    private func rebuildDisplayedSongs() {
+        let sorted = sortedSongs
 
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {

--- a/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
@@ -4,7 +4,9 @@ import Foundation
 
 @MainActor
 final class UploadedSongsViewModel: ObservableObject {
-    @Published private(set) var songs: [Song] = []
+    @Published private(set) var songs: [Song] = [] {
+        didSet { songsGeneration &+= 1 }
+    }
     @Published private(set) var displayedSongs: [Song] = []
     @Published private(set) var isLoading = false
     @Published private(set) var requiresSignIn = false
@@ -12,13 +14,22 @@ final class UploadedSongsViewModel: ObservableObject {
     @Published var sort: LibrarySongSort = .recentlyAdded {
         didSet { rebuildDisplayedSongs() }
     }
-    @Published var searchText = "" {
-        didSet { rebuildDisplayedSongs() }
-    }
+    @Published var searchText = ""
 
     private var hasLoaded = false
     private var loadTask: Task<Void, Never>?
     private var requestGeneration = 0
+    private var cancellables = Set<AnyCancellable>()
+    private var songsGeneration: UInt64 = 0
+    private var sortCache: (sort: LibrarySongSort, generation: UInt64, songs: [Song])?
+
+    init() {
+        $searchText
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.rebuildDisplayedSongs() }
+            .store(in: &cancellables)
+    }
 
     func loadIfNeeded() {
         guard !hasLoaded else { return }
@@ -84,7 +95,15 @@ final class UploadedSongsViewModel: ObservableObject {
         }
     }
 
-    private func rebuildDisplayedSongs() {
+    // Sorting is the expensive half of a rebuild; cache it per (sort, songs)
+    // so search keystrokes only pay for the filter pass.
+    private var sortedSongs: [Song] {
+        if let sortCache,
+           sortCache.sort == sort,
+           sortCache.generation == songsGeneration
+        {
+            return sortCache.songs
+        }
         let sorted: [Song] = switch sort {
         case .recentlyAdded:
             songs
@@ -97,6 +116,12 @@ final class UploadedSongsViewModel: ObservableObject {
         case .duration:
             songs.sorted { $0.duration < $1.duration }
         }
+        sortCache = (sort, songsGeneration, sorted)
+        return sorted
+    }
+
+    private func rebuildDisplayedSongs() {
+        let sorted = sortedSongs
 
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {

--- a/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
+++ b/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
@@ -22,22 +22,14 @@ final class PlaylistCoverLoader: ObservableObject {
         artworkURLs = Self.extractArtworkURLs(fromSongs: fallbackSongs)
         loadTask?.cancel()
 
-        guard let request = try? KaraokeAPIClient.request(
-            pathSegments: ["api", "playlist", playlistID]
-        ) else {
-            loadedID = nil
-            return
-        }
-
-        loadTask = Task { [weak self, request] in
-            guard let (data, response) = try? await URLSession.shared.data(for: request),
-                  let httpResponse = response as? HTTPURLResponse,
-                  (200..<300).contains(httpResponse.statusCode) else {
+        loadTask = Task { [weak self] in
+            guard let data = try? await KaraokeAPIClient.playlistDetailData(id: playlistID) else {
                 self?.handleLoadFailure(playlistID: playlistID)
                 return
             }
+            let decoded = await Self.decodeArtworkPayload(data)
             guard !Task.isCancelled else { return }
-            self?.applyLoadedPlaylistData(data, playlistID: playlistID)
+            self?.applyDecodedArtwork(decoded, playlistID: playlistID)
         }
     }
 
@@ -50,10 +42,22 @@ final class PlaylistCoverLoader: ObservableObject {
         loadedID = nil
     }
 
-    private func applyLoadedPlaylistData(_ data: Data, playlistID: String) {
+    private struct DecodedArtworkPayload: Sendable {
+        let playlist: Playlist?
+        let songs: [Song]?
+    }
+
+    /// Decodes off the main actor; callers hop back to main only to assign results.
+    nonisolated private static func decodeArtworkPayload(_ data: Data) async -> DecodedArtworkPayload {
+        let playlist = try? JSONDecoder().decode(Playlist.self, from: data)
+        let songs = playlist?.songListDTOs ?? SongPayloadDecoder.decodeSongs(from: data)
+        return DecodedArtworkPayload(playlist: playlist, songs: songs)
+    }
+
+    private func applyDecodedArtwork(_ decoded: DecodedArtworkPayload, playlistID: String) {
         guard loadedID == playlistID else { return }
-        loadedPlaylist = try? JSONDecoder().decode(Playlist.self, from: data)
-        fallbackSongs = loadedPlaylist?.songListDTOs ?? SongPayloadDecoder.decodeSongs(from: data) ?? fallbackSongs
+        loadedPlaylist = decoded.playlist
+        fallbackSongs = decoded.songs ?? fallbackSongs
         refreshFallbackArtwork()
     }
 

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -813,6 +813,12 @@ final class AVEnginePlayback {
         aiStartOffset = 0
         mode = .single
         resetInstrumentalEQ()
+        // Auto-shutdown is disabled, so without this the engine would keep
+        // rendering silence for the app's lifetime (radio/stream playback uses
+        // AVPlayer and never touches the engine). Every engine playback path
+        // (play/playStems/switchToStems/revertToMain/resume/beginCrossfade)
+        // restarts it through startEngineIfNeeded().
+        engine.pause()
     }
 
     @discardableResult

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -9,7 +9,7 @@ import SwiftUI
     import UIKit
 #endif
 
-/// Tick counter for fade timers; only mutated on the main run loop, but lives
+/// Tick counter for fade timers; only mutated on the main actor, but lives
 /// in a @Sendable timer closure so it needs an unchecked-Sendable box.
 private final class TimerStepCounter: @unchecked Sendable {
     var step = 0
@@ -352,7 +352,18 @@ class AudioPlayerManager: ObservableObject {
     private var cacheRecoverySongID: String?
     private var lastKnownPlaybackTime: TimeInterval = 0
     private var pollTimer: Timer?
-    private var streamFadeTimer: Timer?
+    // Volume ramps run on a background DispatchSourceTimer (like the engine
+    // crossfade ramp) so they don't fire on RunLoop.main during scroll
+    // tracking; per-tick work is dispatched back to the main actor.
+    private nonisolated static let volumeRampQueue = DispatchQueue(
+        label: "com.Mag1cByt3s.Twinskaraoke.volume-ramp",
+        qos: .userInteractive
+    )
+    private var streamFadeTimer: DispatchSourceTimer?
+    // Bumped whenever the fade timer is cancelled so a tick already dispatched
+    // to the main actor by the background timer no-ops instead of applying a
+    // stale volume step.
+    private var streamFadeGeneration: UInt64 = 0
     private var streamStartedAt: Date?
 
     private var _suppressModeSwitch = false
@@ -369,7 +380,7 @@ class AudioPlayerManager: ObservableObject {
     private var backgroundAnalysisRetryTask: Task<Void, Never>?
     private var cacheCompressionTask: Task<Void, Never>?
     private var aiStemSwitchInFlightSongID: String?
-    private var quickCutTimer: Timer?
+    private var quickCutTimer: DispatchSourceTimer?
     private var quickCutGeneration: UInt64 = 0
     private var separationGeneration: UInt64 = 0
     private var transitionTimeoutGeneration: UInt64 = 0
@@ -634,8 +645,8 @@ class AudioPlayerManager: ObservableObject {
         // down, the last reference is released on the main thread.
         MainActor.assumeIsolated {
             pollTimer?.invalidate()
-            quickCutTimer?.invalidate()
-            streamFadeTimer?.invalidate()
+            quickCutTimer?.cancel()
+            streamFadeTimer?.cancel()
             transitionStartTask?.cancel()
             instrumentalTask?.cancel()
             preparedStemTask?.cancel()
@@ -1072,7 +1083,8 @@ class AudioPlayerManager: ObservableObject {
     }
 
     private func cancelQuickCutTimer(resetVolume: Bool = true) {
-        quickCutTimer?.invalidate()
+        quickCutGeneration &+= 1
+        quickCutTimer?.cancel()
         quickCutTimer = nil
         if resetVolume {
             avEngine.setMasterVolume(1.0)
@@ -1087,7 +1099,8 @@ class AudioPlayerManager: ObservableObject {
         activeCrossfadePlan = nil
         cancelQuickCutTimer(resetVolume: resetVolume)
         avEngine.cancelCrossfade()
-        streamFadeTimer?.invalidate()
+        streamFadeGeneration &+= 1
+        streamFadeTimer?.cancel()
         streamFadeTimer = nil
         if resetVolume { streamPlayer?.volume = 1.0 }
         transitionCoordinator.reset()
@@ -2339,7 +2352,8 @@ class AudioPlayerManager: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
             streamEndObserver = nil
         }
-        streamFadeTimer?.invalidate()
+        streamFadeGeneration &+= 1
+        streamFadeTimer?.cancel()
         streamFadeTimer = nil
         streamPlayer?.pause()
         streamPlayer?.replaceCurrentItem(with: nil)
@@ -2349,27 +2363,31 @@ class AudioPlayerManager: ObservableObject {
 
     private func fadeOutStreamPlayer(duration: TimeInterval) {
         guard streamPlayer != nil else { return }
-        streamFadeTimer?.invalidate()
+        streamFadeGeneration &+= 1
+        let gen = streamFadeGeneration
+        streamFadeTimer?.cancel()
         let interval = AVEnginePlayback.transitionTimerInterval
         let steps = max(1, Int((duration / interval).rounded(.up)))
         let counter = TimerStepCounter()
-        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] timer in
-            guard self != nil else { timer.invalidate(); return }
-            let finished = MainActor.assumeIsolated { () -> Bool in
-                guard let self else { return true }
-                counter.step += 1
-                let t = Float(counter.step) / Float(max(1, steps))
-                self.streamPlayer?.volume = max(0, 1.0 - t)
-                if t >= 1.0 {
-                    self.streamFadeTimer = nil
-                    return true
+        let timer = DispatchSource.makeTimerSource(queue: Self.volumeRampQueue)
+        timer.schedule(deadline: .now() + interval, repeating: interval, leeway: .milliseconds(2))
+        timer.setEventHandler { [weak self] in
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    guard let self else { timer.cancel(); return }
+                    guard self.streamFadeGeneration == gen else { return }
+                    counter.step += 1
+                    let t = Float(counter.step) / Float(max(1, steps))
+                    self.streamPlayer?.volume = max(0, 1.0 - t)
+                    if t >= 1.0 {
+                        self.streamFadeTimer = nil
+                        timer.cancel()
+                    }
                 }
-                return false
             }
-            if finished { timer.invalidate() }
         }
         streamFadeTimer = timer
-        RunLoop.main.add(timer, forMode: .common)
+        timer.resume()
     }
 
     func updateRadioMetadata(song: Song, artworkURL: URL?) {
@@ -3372,37 +3390,35 @@ class AudioPlayerManager: ObservableObject {
         let interval = AVEnginePlayback.transitionTimerInterval
         let steps = max(1, Int((fadeDuration / interval).rounded(.up)))
         let counter = TimerStepCounter()
-        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] timer in
-            guard self != nil else {
-                timer.invalidate()
-                return
-            }
-            let finished = MainActor.assumeIsolated { () -> Bool in
-                guard let self else { return true }
-                guard self.quickCutGeneration == gen else { return false }
-                guard self.transitionCoordinator.state.isCrossfading, !self.isRadioMode else {
-                    self.cancelPendingTransitionWork()
-                    return false
+        let timer = DispatchSource.makeTimerSource(queue: Self.volumeRampQueue)
+        timer.schedule(deadline: .now() + interval, repeating: interval, leeway: .milliseconds(2))
+        timer.setEventHandler { [weak self] in
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    guard let self else { timer.cancel(); return }
+                    guard self.quickCutGeneration == gen else { return }
+                    guard self.transitionCoordinator.state.isCrossfading, !self.isRadioMode else {
+                        self.cancelPendingTransitionWork()
+                        return
+                    }
+                    counter.step += 1
+                    let t = Float(counter.step) / Float(max(1, steps))
+                    self.avEngine.setMasterVolume(1.0 - t)
+                    if t >= 1.0 {
+                        self.quickCutTimer = nil
+                        DebugLogger.log("Quick cut transition complete -> play(\(song.id))", category: .playback)
+                        self.activeCrossfadePlan = nil
+                        self.transitionCoordinator.reset()
+                        self.avEngine.setMasterVolume(0)
+                        self.play(song: song, resetTransitionVolume: false)
+                        self.avEngine.setMasterVolume(1.0)
+                        timer.cancel()
+                    }
                 }
-                counter.step += 1
-                let t = Float(counter.step) / Float(max(1, steps))
-                self.avEngine.setMasterVolume(1.0 - t)
-                if t >= 1.0 {
-                    self.quickCutTimer = nil
-                    DebugLogger.log("Quick cut transition complete -> play(\(song.id))", category: .playback)
-                    self.activeCrossfadePlan = nil
-                    self.transitionCoordinator.reset()
-                    self.avEngine.setMasterVolume(0)
-                    self.play(song: song, resetTransitionVolume: false)
-                    self.avEngine.setMasterVolume(1.0)
-                    return true
-                }
-                return false
             }
-            if finished { timer.invalidate() }
         }
         quickCutTimer = timer
-        RunLoop.main.add(timer, forMode: .common)
+        timer.resume()
     }
 
     private func transitionCoordinatorDidFinish() {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2380,6 +2380,10 @@ class AudioPlayerManager: ObservableObject {
                     let t = Float(counter.step) / Float(max(1, steps))
                     self.streamPlayer?.volume = max(0, 1.0 - t)
                     if t >= 1.0 {
+                        // Bump the generation so a tick already enqueued on
+                        // main before the cancel can't re-enter and force the
+                        // volume back to 0 after the fade completed.
+                        self.streamFadeGeneration &+= 1
                         self.streamFadeTimer = nil
                         timer.cancel()
                     }
@@ -3405,6 +3409,10 @@ class AudioPlayerManager: ObservableObject {
                     let t = Float(counter.step) / Float(max(1, steps))
                     self.avEngine.setMasterVolume(1.0 - t)
                     if t >= 1.0 {
+                        // Bump the generation so a tick already enqueued on
+                        // main before the cancel can't re-enter and tear down
+                        // the transition state for the song play() just started.
+                        self.quickCutGeneration &+= 1
                         self.quickCutTimer = nil
                         DebugLogger.log("Quick cut transition complete -> play(\(song.id))", category: .playback)
                         self.activeCrossfadePlan = nil

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -361,12 +361,22 @@ final class TransitionCoordinator {
         }
     }
 
+    private var bpmPersistTask: Task<Void, Never>?
+
     private func persistBPMCache() {
-        let defaults = UserDefaults.standard
-        if let data = try? JSONEncoder().encode(bpmCache) {
-            defaults.set(data, forKey: Self.bpmCacheKey)
-        } else {
-            defaults.removeObject(forKey: Self.bpmCacheKey)
+        // Encoding + UserDefaults write run off-main; tasks chain so writes
+        // stay ordered, with each task snapshotting the latest cache.
+        let snapshot = bpmCache
+        let key = Self.bpmCacheKey
+        let previous = bpmPersistTask
+        bpmPersistTask = Task.detached(priority: .utility) {
+            await previous?.value
+            let defaults = UserDefaults.standard
+            if let data = try? JSONEncoder().encode(snapshot) {
+                defaults.set(data, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
         }
     }
 }

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -76,6 +76,10 @@ final class VocalSeparator: ObservableObject {
 
     @Published private(set) var processingSongID: String?
     @Published private(set) var progressFraction: Float = 0
+    // progressFraction fans out to the whole player tree; only publish >=1%
+    // deltas (plus exact completion) so minute-long analyses don't publish
+    // hundreds of times.
+    private var lastPublishedProgressFraction: Float = -1
     @Published private(set) var isBackgroundAnalyzing: Bool = false
 
     let isAvailable: Bool
@@ -230,6 +234,7 @@ final class VocalSeparator: ObservableObject {
             activeTaskKind = nil
             processingSongID = nil
             progressFraction = 0
+            lastPublishedProgressFraction = -1
             jobOwnership.cancelCurrent()
         }
         try Task.checkCancellation()
@@ -296,6 +301,7 @@ final class VocalSeparator: ObservableObject {
             activeTaskKind = nil
             processingSongID = nil
             progressFraction = 0
+            lastPublishedProgressFraction = -1
             jobOwnership.cancelCurrent()
         }
 
@@ -325,7 +331,7 @@ final class VocalSeparator: ObservableObject {
             let trimmedTemp: URL?
             if normalizedStart > 1.0 {
                 let tmp = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("\(jobID.uuidString).rt.trim.m4a")
+                    .appendingPathComponent("\(jobID.uuidString).rt.trim.wav")
                 try await Self.trim(source: sourceURL, from: normalizedStart, to: tmp)
                 trimmedSource = tmp
                 trimmedTemp = tmp
@@ -430,6 +436,7 @@ final class VocalSeparator: ObservableObject {
             activeTaskKind = nil
             processingSongID = nil
             progressFraction = 0
+            lastPublishedProgressFraction = -1
             jobOwnership.cancelCurrent()
             old?.cancel()
         }
@@ -446,6 +453,7 @@ final class VocalSeparator: ObservableObject {
         activeTaskKind = nil
         processingSongID = nil
         progressFraction = 0
+        lastPublishedProgressFraction = -1
         jobOwnership.cancelCurrent()
         old?.cancel()
         if hadWork {
@@ -510,15 +518,19 @@ final class VocalSeparator: ObservableObject {
     }
 
     private func updateProgress(jobID: UUID, songID: String, fraction: Float) {
-        if jobOwnership.owns(jobID), processingSongID == songID {
-            progressFraction = fraction
+        guard jobOwnership.owns(jobID), processingSongID == songID else { return }
+        guard fraction >= 1.0 || abs(fraction - lastPublishedProgressFraction) >= 0.01 else {
+            return
         }
+        lastPublishedProgressFraction = fraction
+        progressFraction = fraction
     }
 
     private func finishJob(jobID: UUID) {
         guard jobOwnership.finish(jobID) else { return }
         processingSongID = nil
         progressFraction = 0
+        lastPublishedProgressFraction = -1
         activeTask = nil
         activeTaskKind = nil
     }
@@ -539,6 +551,7 @@ final class VocalSeparator: ObservableObject {
             instrumentsDestination: destinations.instruments
         )
         AudioCacheStore.clearMainOffset(for: songID)
+        CacheManager.noteMusicCacheCommit()
         finishJob(jobID: jobID)
         NotificationCenter.default.post(
             name: .vocalSeparatorDidCacheStems,
@@ -546,27 +559,95 @@ final class VocalSeparator: ObservableObject {
         )
     }
 
+    private nonisolated static let trimWriteQueue = DispatchQueue(
+        label: "com.Mag1cByt3s.Twinskaraoke.vocal-separator-trim",
+        qos: .utility
+    )
+
     private static func trim(source: URL, from startSeconds: TimeInterval, to output: URL)
         async throws
     {
         try? FileManager.default.removeItem(at: output)
         let asset = AVURLAsset(url: source)
-        guard let export = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A)
-        else { throw VocalSeparatorError.trimFailed }
-        let start = CMTime(seconds: startSeconds, preferredTimescale: 600)
         let duration = try await asset.load(.duration)
+        guard let track = try await asset.loadTracks(withMediaType: .audio).first else {
+            throw VocalSeparatorError.trimFailed
+        }
+        let start = CMTime(seconds: startSeconds, preferredTimescale: 600)
         let safeStartSeconds = min(startSeconds, max(0, duration.seconds - 0.5))
         let safeStart = safeStartSeconds < startSeconds
             ? CMTime(seconds: safeStartSeconds, preferredTimescale: 600) : start
-        export.timeRange = CMTimeRange(start: safeStart, end: duration)
-        export.outputURL = output
-        export.outputFileType = .m4a
-        if #available(iOS 18.0, *) {
-            try await export.export(to: output, as: .m4a)
-        } else {
-            await export.export()
-            guard export.status == .completed else {
-                throw export.error ?? VocalSeparatorError.trimFailed
+
+        // Decode once into uncompressed LPCM/WAV instead of a full AAC
+        // re-encode: ML inference decodes the trimmed file again, and a WAV
+        // passthrough is far cheaper than an AAC encode + decode round-trip.
+        var sampleRate = 44100.0
+        var channels = 2
+        if let formatDescription = try await track.load(.formatDescriptions).first,
+           let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription)
+        {
+            if asbd.pointee.mSampleRate > 0 { sampleRate = asbd.pointee.mSampleRate }
+            if asbd.pointee.mChannelsPerFrame > 0 { channels = Int(asbd.pointee.mChannelsPerFrame) }
+        }
+        let pcmSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: channels,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        guard let reader = try? AVAssetReader(asset: asset) else {
+            throw VocalSeparatorError.trimFailed
+        }
+        reader.timeRange = CMTimeRange(start: safeStart, end: duration)
+        let readerOutput = AVAssetReaderTrackOutput(track: track, outputSettings: pcmSettings)
+        guard reader.canAdd(readerOutput) else { throw VocalSeparatorError.trimFailed }
+        reader.add(readerOutput)
+        guard let writer = try? AVAssetWriter(outputURL: output, fileType: .wav) else {
+            throw VocalSeparatorError.trimFailed
+        }
+        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: pcmSettings)
+        guard writer.canAdd(writerInput) else { throw VocalSeparatorError.trimFailed }
+        writer.add(writerInput)
+        guard reader.startReading(), writer.startWriting() else {
+            throw reader.error ?? writer.error ?? VocalSeparatorError.trimFailed
+        }
+        writer.startSession(atSourceTime: safeStart)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            writerInput.requestMediaDataWhenReady(on: Self.trimWriteQueue) {
+                while writerInput.isReadyForMoreMediaData {
+                    guard reader.status != .failed else {
+                        writerInput.markAsFinished()
+                        writer.cancelWriting()
+                        continuation.resume(
+                            throwing: reader.error ?? VocalSeparatorError.trimFailed
+                        )
+                        return
+                    }
+                    guard let buffer = readerOutput.copyNextSampleBuffer() else {
+                        writerInput.markAsFinished()
+                        writer.finishWriting {
+                            if writer.status == .completed {
+                                continuation.resume()
+                            } else {
+                                continuation.resume(
+                                    throwing: writer.error ?? VocalSeparatorError.trimFailed
+                                )
+                            }
+                        }
+                        return
+                    }
+                    if !writerInput.append(buffer) {
+                        writerInput.markAsFinished()
+                        writer.cancelWriting()
+                        continuation.resume(
+                            throwing: writer.error ?? VocalSeparatorError.trimFailed
+                        )
+                        return
+                    }
+                }
             }
         }
     }

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -618,6 +618,16 @@ final class VocalSeparator: ObservableObject {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             writerInput.requestMediaDataWhenReady(on: Self.trimWriteQueue) {
                 while writerInput.isReadyForMoreMediaData {
+                    // Bail promptly on job cancellation instead of writing the
+                    // remaining LPCM; cancelReading() alone can't interrupt an
+                    // in-flight copyNextSampleBuffer().
+                    if Task.isCancelled {
+                        reader.cancelReading()
+                        writerInput.markAsFinished()
+                        writer.cancelWriting()
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    }
                     guard reader.status != .failed else {
                         writerInput.markAsFinished()
                         writer.cancelWriting()

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -18,6 +18,14 @@ nonisolated enum AudioCacheStore {
     private nonisolated(unsafe) static let compressionAlgorithm: Algorithm = .lzfse
     private static let chunkSize = 64 * 1024
     private static let maximumPlayableFileSize: Int64 = 256 * 1024 * 1024
+    // Track-start paths probe the same cached file several times per song
+    // (header validation + duration), each opening a fresh AVAudioFile. Memoize
+    // per (path, modificationDate); `touch` bumps the modification date, so
+    // entries invalidate conservatively whenever the file changes.
+    private static let probeMemoLock = NSLock()
+    private static let probeMemoLimit = 256
+    private nonisolated(unsafe) static var durationMemo: [String: (modified: Date, duration: TimeInterval)] = [:]
+    private nonisolated(unsafe) static var validityMemo: [String: (modified: Date, valid: Bool)] = [:]
     static let supportedMainAudioExtensions: Set<String> = [
         "aac", "aif", "aiff", "caf", "flac", "m4a", "m4b", "mp3", "mp4", "wav",
     ]
@@ -70,6 +78,7 @@ nonisolated enum AudioCacheStore {
         // and alternate legacy-extension variants.
         try? fm.removeItem(at: compressedURL(for: finalURL))
         removeMainAudioFiles(for: songID, excluding: finalURL)
+        CacheManager.noteMusicCacheCommit()
     }
 
     private static func songFiles(in directory: URL) -> SongFiles {
@@ -212,18 +221,6 @@ nonisolated enum AudioCacheStore {
         touch(vocals)
         touch(instruments)
         return CachedStems(vocals: vocals, instruments: instruments, startOffset: startOffset)
-    }
-
-    static func hasCachedMainAudio(for songID: String, expectedRemoteURL: URL? = nil, expectedDuration: TimeInterval? = nil) -> Bool {
-        playableMainURL(
-            for: songID,
-            expectedRemoteURL: expectedRemoteURL,
-            expectedDuration: expectedDuration
-        ) != nil
-    }
-
-    static func hasCachedStems(for songID: String) -> Bool {
-        playableStems(for: songID, startOffset: readStartOffset(for: songID)) != nil
     }
 
     static func compressedURL(for playableURL: URL) -> URL {
@@ -419,7 +416,13 @@ nonisolated enum AudioCacheStore {
         let standardizedURL = url.standardizedFileURL
         let standardizedCacheDirectory = cacheDirectory.standardizedFileURL
         let cachePathPrefix = standardizedCacheDirectory.path + "/"
-        guard standardizedURL.path.hasPrefix(cachePathPrefix) else { return }
+        // Lyrics cache files live outside AudioCache but share the same
+        // access-date LRU bookkeeping.
+        let standardizedLyricsDirectory = LyricsCacheStore.cacheDirectory.standardizedFileURL
+        let lyricsPathPrefix = standardizedLyricsDirectory.path + "/"
+        guard standardizedURL.path.hasPrefix(cachePathPrefix)
+            || standardizedURL.path.hasPrefix(lyricsPathPrefix)
+        else { return }
 
         let now = Date()
         try? fm.setAttributes([.modificationDate: now], ofItemAtPath: standardizedURL.path)
@@ -427,7 +430,9 @@ nonisolated enum AudioCacheStore {
         let songDirectory = standardizedURL.hasDirectoryPath
             ? standardizedURL
             : standardizedURL.deletingLastPathComponent()
-        if songDirectory != standardizedCacheDirectory {
+        if songDirectory != standardizedCacheDirectory,
+           songDirectory != standardizedLyricsDirectory
+        {
             try? fm.setAttributes([.modificationDate: now], ofItemAtPath: songDirectory.path)
         }
     }
@@ -508,20 +513,53 @@ nonisolated enum AudioCacheStore {
     }
 
     private static func isValidAudioFile(at url: URL) -> Bool {
-        guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-              size >= minimumPlayableFileSize else { return false }
-        return AVEnginePlayback.hasValidAudioHeader(at: url)
+        let path = url.path
+        let modified = modificationDate(of: url)
+        probeMemoLock.lock()
+        if let entry = validityMemo[path], entry.modified == modified {
+            probeMemoLock.unlock()
+            return entry.valid
+        }
+        probeMemoLock.unlock()
+        let valid: Bool = {
+            guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+                  size >= minimumPlayableFileSize else { return false }
+            return AVEnginePlayback.hasValidAudioHeader(at: url)
+        }()
+        probeMemoLock.lock()
+        if validityMemo.count >= probeMemoLimit { validityMemo.removeAll() }
+        validityMemo[path] = (modified, valid)
+        probeMemoLock.unlock()
+        return valid
     }
 
     static func audioDuration(at url: URL) -> TimeInterval {
+        let path = url.path
+        let modified = modificationDate(of: url)
+        probeMemoLock.lock()
+        if let entry = durationMemo[path], entry.modified == modified {
+            probeMemoLock.unlock()
+            return entry.duration
+        }
+        probeMemoLock.unlock()
+        var duration: TimeInterval = 0
         if let file = try? AVAudioFile(forReading: url) {
             let sampleRate = file.fileFormat.sampleRate
             if sampleRate > 0 {
-                let duration = Double(file.length) / sampleRate
-                if duration.isFinite, duration > 0 { return duration }
+                let candidate = Double(file.length) / sampleRate
+                if candidate.isFinite, candidate > 0 { duration = candidate }
             }
         }
-        return 0
+        probeMemoLock.lock()
+        if durationMemo.count >= probeMemoLimit { durationMemo.removeAll() }
+        durationMemo[path] = (modified, duration)
+        probeMemoLock.unlock()
+        return duration
+    }
+
+    private static func modificationDate(of url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+            ?? .distantPast
     }
 
     static func acceptsAudioResponse(_ response: URLResponse?) -> Bool {

--- a/Twinskaraoke/Services/Storage/CacheManager.swift
+++ b/Twinskaraoke/Services/Storage/CacheManager.swift
@@ -25,16 +25,27 @@ final class CacheManager: ObservableObject {
         label: "nk.cacheMaintenance", qos: .utility
     )
 
+    // Debounce state for the per-transition/per-save enforcement passes.
+    // Only touched on the serial maintenanceQueue.
+    private nonisolated static let enforcementDebounceInterval: TimeInterval = 60
+    private nonisolated(unsafe) var lastMusicEnforcementAt: Date?
+    private nonisolated(unsafe) static var lastMusicCommitAt: Date?
+    private nonisolated(unsafe) var lastMusicCacheSize: UInt64?
+    private nonisolated(unsafe) var lastLyricsEnforcementAt: Date?
+    private nonisolated(unsafe) var lastLyricsCacheSize: UInt64?
+
     private init() {
         let directories = Self.directories
         Self.maintenanceQueue.async { [weak self] in
             guard let self else { return }
             let pruned = pruneExpiredEntriesBlocking(directories: directories)
             DebugLogger.log("Pruned \(pruned) expired cache entries", category: .cache)
-            _ = enforceImageCacheLimitsBlocking(imageDirectory: directories.image)
-            _ = enforceMusicCacheLimitsBlocking(musicDirectory: directories.music, excluding: [])
-            _ = enforceLyricsCacheLimitsBlocking(lyricsDirectory: directories.lyrics)
-            publishSizes(computeSizesBlocking(directories: directories))
+            // The enforcement passes already measure each tree; reuse their
+            // sizes instead of walking every cache directory a second time.
+            let image = enforceImageCacheLimitsBlocking(imageDirectory: directories.image)
+            let music = enforceMusicCacheLimitsBlocking(musicDirectory: directories.music, excluding: [])
+            let lyrics = enforceLyricsCacheLimitsBlocking(lyricsDirectory: directories.lyrics)
+            publishSizes((image: image, music: music, lyrics: lyrics))
             DebugLogger.log("CacheManager initialized", category: .cache)
         }
     }
@@ -110,7 +121,19 @@ final class CacheManager: ObservableObject {
     }
 
     func recordAccess(for url: URL) {
-        AudioCacheStore.touch(url)
+        // touch() performs two synchronous setAttributes calls; keep them off
+        // the caller's thread (usually main, once per play).
+        Self.maintenanceQueue.async {
+            AudioCacheStore.touch(url)
+        }
+    }
+
+    /// Marks that a file was committed to the music cache, so the debounced
+    /// enforcement pass knows the tree changed since its last run.
+    nonisolated static func noteMusicCacheCommit() {
+        maintenanceQueue.async {
+            lastMusicCommitAt = Date()
+        }
     }
 
     func totalImageCacheSize() -> UInt64 {
@@ -240,7 +263,7 @@ final class CacheManager: ObservableObject {
             sdCache.deleteOldFiles(completionBlock: nil)
         }
 
-        evictOldestFiles(in: imageDirectory, limit: Self.imageCacheLimit, label: "image")
+        _ = evictOldestFiles(in: imageDirectory, limit: Self.imageCacheLimit, label: "image")
         return UInt64(sdCache.totalDiskSize())
     }
 
@@ -248,13 +271,40 @@ final class CacheManager: ObservableObject {
         musicDirectory: URL,
         excluding protectedIDs: Set<String>
     ) -> UInt64 {
-        evictOldestSongDirectories(in: musicDirectory, limit: Self.musicCacheLimit, excluding: protectedIDs)
-        return directorySize(at: musicDirectory)
+        // Runs on every track transition and after every vocal separation;
+        // skip the tree walk when nothing was committed since the last run.
+        let now = Date()
+        if let lastRun = lastMusicEnforcementAt,
+           now.timeIntervalSince(lastRun) < Self.enforcementDebounceInterval,
+           (Self.lastMusicCommitAt ?? .distantPast) <= lastRun,
+           let lastSize = lastMusicCacheSize
+        {
+            return lastSize
+        }
+        lastMusicEnforcementAt = now
+        let size = evictOldestSongDirectories(
+            in: musicDirectory,
+            limit: Self.musicCacheLimit,
+            excluding: protectedIDs
+        )
+        lastMusicCacheSize = size
+        return size
     }
 
     private nonisolated func enforceLyricsCacheLimitsBlocking(lyricsDirectory: URL) -> UInt64 {
-        evictOldestFiles(in: lyricsDirectory, limit: Self.lyricsCacheLimit, label: "lyrics")
-        return directorySize(at: lyricsDirectory)
+        // Lyrics saves trigger this per save; the files are tiny, so a light
+        // debounce avoids a full enumeration for every cached lyric.
+        let now = Date()
+        if let lastRun = lastLyricsEnforcementAt,
+           now.timeIntervalSince(lastRun) < Self.enforcementDebounceInterval,
+           let lastSize = lastLyricsCacheSize
+        {
+            return lastSize
+        }
+        lastLyricsEnforcementAt = now
+        let size = evictOldestFiles(in: lyricsDirectory, limit: Self.lyricsCacheLimit, label: "lyrics")
+        lastLyricsCacheSize = size
+        return size
     }
 
     private nonisolated func pruneExpiredEntriesBlocking(
@@ -297,12 +347,12 @@ final class CacheManager: ObservableObject {
         return total
     }
 
-    private nonisolated func evictOldestFiles(in directory: URL, limit: UInt64, label: String) {
+    private nonisolated func evictOldestFiles(in directory: URL, limit: UInt64, label: String) -> UInt64 {
         let fm = FileManager.default
-        guard fm.fileExists(atPath: directory.path) else { return }
+        guard fm.fileExists(atPath: directory.path) else { return 0 }
 
         var currentSize = directorySize(at: directory)
-        guard currentSize > limit else { return }
+        guard currentSize > limit else { return currentSize }
 
         DebugLogger.log(
             "\(label) cache \(formatBytes(currentSize)) > limit \(formatBytes(limit)), evicting oldest",
@@ -332,18 +382,19 @@ final class CacheManager: ObservableObject {
             "\(label) cache eviction complete: removed \(evicted) files, new size \(formatBytes(currentSize))",
             category: .cache
         )
+        return currentSize
     }
 
     private nonisolated func evictOldestSongDirectories(
         in directory: URL,
         limit: UInt64,
         excluding protectedIDs: Set<String> = []
-    ) {
+    ) -> UInt64 {
         let fm = FileManager.default
-        guard fm.fileExists(atPath: directory.path) else { return }
+        guard fm.fileExists(atPath: directory.path) else { return 0 }
 
         var currentSize = directorySize(at: directory)
-        guard currentSize > limit else { return }
+        guard currentSize > limit else { return currentSize }
 
         DebugLogger.log(
             "music cache \(formatBytes(currentSize)) > limit \(formatBytes(limit)), evicting oldest song folders",
@@ -365,6 +416,7 @@ final class CacheManager: ObservableObject {
                 )
             }
         }
+        return currentSize
     }
 
     private nonisolated func pruneOldFiles(in directory: URL, olderThan cutoff: Date) -> Int {

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -219,7 +219,7 @@ final class DownloadManager: ObservableObject {
         )
     }
 
-    func localURL(for songID: String) -> URL {
+    nonisolated func localURL(for songID: String) -> URL {
         files(for: songID).audio
     }
 
@@ -1085,6 +1085,29 @@ final class DownloadManager: ObservableObject {
     }
 
     func playableURL(for song: Song) -> URL? {
+        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
+        // Fast path: a prewarmed validation entry needs only the
+        // modification-date stat in hasCachedValidation, skipping the
+        // migration and source-file reads below.
+        if let cached = validDownloadCache[song.id],
+           cached.source == song.audioURL?.absoluteString,
+           let source = cached.source,
+           let sourceURL = URL(string: source)
+        {
+            let audio = Self.downloadedAudioURL(
+                in: downloadDirectory(for: song.id),
+                sourceURL: sourceURL
+            )
+            if hasCachedValidation(
+                for: song.id,
+                audioURL: audio,
+                source: source,
+                expectedDuration: expectedDuration
+            ) {
+                downloadedMetadata[song.id] = song
+                return audio
+            }
+        }
         migrateLegacyDownloadIfNeeded(for: song.id)
         migrateMislabeledDownloadedAudioIfNeeded(
             for: song.id,
@@ -1100,7 +1123,6 @@ final class DownloadManager: ObservableObject {
             discardBrokenDownloadAndScheduleRepair(for: song, reason: "audio file is missing")
             return nil
         }
-        let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
         let expectedSource = song.audioURL?.absoluteString
         if let cachedSource, let expectedSource, cachedSource != expectedSource {
             DebugLogger.log(

--- a/Twinskaraoke/Services/User/AuthManager.swift
+++ b/Twinskaraoke/Services/User/AuthManager.swift
@@ -413,6 +413,7 @@ final class AuthManager: NSObject, ObservableObject {
     private func clearAccountScopedState() {
         FavoritesManager.shared.clear()
         UserPlaylistsManager.shared.clear()
+        Task { await KaraokeAPIClient.invalidateAccountScopedCaches() }
     }
 
     private func makeVerifier() -> String {

--- a/Twinskaraoke/Services/User/RecentlyAddedTracker.swift
+++ b/Twinskaraoke/Services/User/RecentlyAddedTracker.swift
@@ -15,13 +15,18 @@ final class RecentlyAddedTracker: ObservableObject {
     }
 
     func registerIfNew(_ ids: [String]) {
+        // Mutate a local copy and assign once so a batch of new IDs publishes
+        // a single dates change instead of one per inserted ID.
+        var updated = dates
         var changed = false
         let now = Date()
-        for id in ids where dates[id] == nil {
-            dates[id] = now
+        for id in ids where updated[id] == nil {
+            updated[id] = now
             changed = true
         }
-        if changed { save() }
+        guard changed else { return }
+        dates = updated
+        save()
     }
 
     func bump(_ id: String) {

--- a/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
+++ b/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
@@ -33,7 +33,21 @@ final class RecentlyPlayedStore: ObservableObject {
     }
 
     private func save() {
-        if let data = try? JSONEncoder().encode(playlists) {
+        // Persist lightweight metadata only: songListDTOs embeds full song
+        // arrays (~1MB for a 900-song playlist) and stays in memory. load()
+        // still decodes older blobs that include the songs.
+        let stripped = playlists.map {
+            Playlist(
+                id: $0.id,
+                name: $0.name,
+                songCount: $0.songCount,
+                media: $0.media,
+                mosaicMedia: $0.mosaicMedia,
+                songListDTOs: nil,
+                isPersonal: $0.isPersonal
+            )
+        }
+        if let data = try? JSONEncoder().encode(stripped) {
             UserDefaults.standard.set(data, forKey: Self.storageKey)
         }
     }

--- a/Twinskaraoke/Services/User/SavedPlaylistsStore.swift
+++ b/Twinskaraoke/Services/User/SavedPlaylistsStore.swift
@@ -7,24 +7,29 @@ final class SavedPlaylistsStore: ObservableObject {
     static let shared = SavedPlaylistsStore()
     private static let storageKey = "nk.savedPlaylists.v1"
     @Published private(set) var playlists: [Playlist] = []
+    // O(1) membership cache for isSaved, which is called per visible
+    // playlist count label on every publish.
+    private var savedIDs: Set<String> = []
     private init() {
         load()
     }
 
     func isSaved(_ playlist: Playlist) -> Bool {
-        playlists.contains { $0.id == playlist.id }
+        savedIDs.contains(playlist.id)
     }
 
     func add(_ playlist: Playlist) {
         guard !playlist.isFavorites else { return }
         if isSaved(playlist) { return }
         playlists.insert(playlist, at: 0)
+        savedIDs.insert(playlist.id)
         RecentlyAddedTracker.shared.bump(playlist.id)
         save()
     }
 
     func remove(id: String) {
         playlists.removeAll { $0.id == id }
+        savedIDs.remove(id)
         save()
     }
 
@@ -36,11 +41,26 @@ final class SavedPlaylistsStore: ObservableObject {
         guard let data = UserDefaults.standard.data(forKey: Self.storageKey) else { return }
         if let decoded = try? JSONDecoder().decode([Playlist].self, from: data) {
             playlists = decoded
+            savedIDs = Set(decoded.map(\.id))
         }
     }
 
     private func save() {
-        if let data = try? JSONEncoder().encode(playlists) {
+        // Persist lightweight metadata only: songListDTOs embeds full song
+        // arrays and stays in memory. load() still decodes older blobs that
+        // include the songs.
+        let stripped = playlists.map {
+            Playlist(
+                id: $0.id,
+                name: $0.name,
+                songCount: $0.songCount,
+                media: $0.media,
+                mosaicMedia: $0.mosaicMedia,
+                songListDTOs: nil,
+                isPersonal: $0.isPersonal
+            )
+        }
+        if let data = try? JSONEncoder().encode(stripped) {
             UserDefaults.standard.set(data, forKey: Self.storageKey)
         }
     }

--- a/Twinskaraoke/Services/User/UserPlaylistsManager.swift
+++ b/Twinskaraoke/Services/User/UserPlaylistsManager.swift
@@ -112,6 +112,7 @@ final class UserPlaylistsManager: ObservableObject {
             if ok {
                 bumpSongCount(forPlaylist: playlistID)
                 PlaylistSongCountStore.shared.invalidate(playlistID: playlistID)
+                await KaraokeAPIClient.invalidatePlaylistDetail(id: playlistID)
             }
             completion?(ok)
         }

--- a/TwinskaraokeShared/Services/CredentialStore.swift
+++ b/TwinskaraokeShared/Services/CredentialStore.swift
@@ -17,6 +17,7 @@ nonisolated enum CredentialStore {
 
   private static let tokenCacheLock = NSLock()
   private nonisolated(unsafe) static var cachedToken: String?
+  private nonisolated(unsafe) static var tokenCacheValid = false
   private nonisolated(unsafe) static var cacheGeneration: UInt64 = 0
 
   static var token: String? {
@@ -24,18 +25,18 @@ nonisolated enum CredentialStore {
       return nil
     }
     tokenCacheLock.lock()
-    let cached = cachedToken
-    let generation = cacheGeneration
-    tokenCacheLock.unlock()
-    if let cached {
+    if tokenCacheValid {
+      let cached = cachedToken
+      tokenCacheLock.unlock()
       return cached
     }
-    guard let resolved = resolveToken() else {
-      return nil
-    }
+    let generation = cacheGeneration
+    tokenCacheLock.unlock()
+    let resolved = resolveToken()
     tokenCacheLock.lock()
     if cacheGeneration == generation {
       cachedToken = resolved
+      tokenCacheValid = true
     }
     tokenCacheLock.unlock()
     return resolved
@@ -103,6 +104,7 @@ nonisolated enum CredentialStore {
   private static func setCachedToken(_ token: String?) {
     tokenCacheLock.lock()
     cachedToken = token
+    tokenCacheValid = true
     cacheGeneration &+= 1
     tokenCacheLock.unlock()
   }

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -79,6 +79,10 @@ actor PlaylistDetailCache {
   private let lifetime: TimeInterval
   private var entries: [String: Entry] = [:]
   private var inFlight: [String: (id: UUID, task: Task<Data, Error>)] = [:]
+  // Guards against stale writes: a fetch that started before an invalidation
+  // must not re-cache its pre-mutation payload when it resolves.
+  private var generations: [String: Int] = [:]
+  private var epoch = 0
 
   init(lifetime: TimeInterval) {
     self.lifetime = lifetime
@@ -89,10 +93,15 @@ actor PlaylistDetailCache {
     at now: Date = Date(),
     loader: @escaping @Sendable () async throws -> Data
   ) async throws -> Data {
-    if let entry = entries[playlistID], entry.expiresAt > now {
+    // Multi-MB payloads: purge expired entries so browsing many playlists
+    // doesn't retain every detail payload for the process lifetime.
+    entries = entries.filter { $0.value.expiresAt > now }
+    if let entry = entries[playlistID] {
       return entry.data
     }
 
+    let startGeneration = generations[playlistID, default: 0]
+    let startEpoch = epoch
     let request: (id: UUID, task: Task<Data, Error>)
     if let existing = inFlight[playlistID] {
       request = existing
@@ -105,7 +114,9 @@ actor PlaylistDetailCache {
 
     do {
       let data = try await request.task.value
-      entries[playlistID] = Entry(data: data, expiresAt: now.addingTimeInterval(lifetime))
+      if epoch == startEpoch, generations[playlistID, default: 0] == startGeneration {
+        entries[playlistID] = Entry(data: data, expiresAt: now.addingTimeInterval(lifetime))
+      }
       if inFlight[playlistID]?.id == request.id {
         inFlight[playlistID] = nil
       }
@@ -120,6 +131,14 @@ actor PlaylistDetailCache {
 
   func invalidate(playlistID: String) {
     entries[playlistID] = nil
+    generations[playlistID, default: 0] &+= 1
+    inFlight[playlistID] = nil
+  }
+
+  func invalidateAll() {
+    entries.removeAll()
+    inFlight.removeAll()
+    epoch &+= 1
   }
 }
 
@@ -135,6 +154,9 @@ actor FavoriteCatalogMetadataCache {
   private let lifetime: TimeInterval
   private var cachedValue: Entry?
   private var inFlight: (key: String, id: UUID, task: Task<[Song], Error>)?
+  // Bumped on invalidate() so a fetch started before signout can't re-cache
+  // the previous user's favorites when it resolves.
+  private var epoch = 0
 
   init(lifetime: TimeInterval) {
     self.lifetime = lifetime
@@ -151,6 +173,7 @@ actor FavoriteCatalogMetadataCache {
       return cachedValue.songs
     }
 
+    let startEpoch = epoch
     let request: (id: UUID, task: Task<[Song], Error>)
     if let inFlight, inFlight.key == key {
       request = (inFlight.id, inFlight.task)
@@ -163,7 +186,9 @@ actor FavoriteCatalogMetadataCache {
 
     do {
       let songs = try await request.task.value
-      cachedValue = Entry(key: key, songs: songs, expiresAt: now.addingTimeInterval(lifetime))
+      if epoch == startEpoch {
+        cachedValue = Entry(key: key, songs: songs, expiresAt: now.addingTimeInterval(lifetime))
+      }
       if inFlight?.id == request.id {
         inFlight = nil
       }
@@ -174,6 +199,12 @@ actor FavoriteCatalogMetadataCache {
       }
       throw error
     }
+  }
+
+  func invalidate() {
+    cachedValue = nil
+    inFlight = nil
+    epoch &+= 1
   }
 }
 
@@ -552,6 +583,13 @@ nonisolated enum KaraokeAPIClient {
   /// without explicit invalidation.
   static func invalidatePlaylistDetail(id: String) async {
     await playlistDetailCache.invalidate(playlistID: id)
+  }
+
+  /// Drop all account-scoped cached payloads on signout so the previous
+  /// user's playlist details and favorites can't leak into the next session.
+  static func invalidateAccountScopedCaches() async {
+    await playlistDetailCache.invalidateAll()
+    await favoriteCatalogMetadataCache.invalidate()
   }
 
   private static func decodeSongSearchResults(from data: Data) throws -> [Song] {

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -66,6 +66,117 @@ actor UploadedSongMetadataCache {
   }
 }
 
+/// TTL + in-flight-dedup cache for full playlist detail payloads (the multi-MB
+/// song-list response shared by cover art, song count, and the detail view).
+/// Playlist content mutations (UserPlaylistsManager.addSong) should call
+/// `KaraokeAPIClient.invalidatePlaylistDetail(id:)`; the 60s TTL bounds staleness otherwise.
+actor PlaylistDetailCache {
+  private struct Entry: Sendable {
+    let data: Data
+    let expiresAt: Date
+  }
+
+  private let lifetime: TimeInterval
+  private var entries: [String: Entry] = [:]
+  private var inFlight: [String: (id: UUID, task: Task<Data, Error>)] = [:]
+
+  init(lifetime: TimeInterval) {
+    self.lifetime = lifetime
+  }
+
+  func data(
+    for playlistID: String,
+    at now: Date = Date(),
+    loader: @escaping @Sendable () async throws -> Data
+  ) async throws -> Data {
+    if let entry = entries[playlistID], entry.expiresAt > now {
+      return entry.data
+    }
+
+    let request: (id: UUID, task: Task<Data, Error>)
+    if let existing = inFlight[playlistID] {
+      request = existing
+    } else {
+      let id = UUID()
+      let task = Task { try await loader() }
+      request = (id, task)
+      inFlight[playlistID] = request
+    }
+
+    do {
+      let data = try await request.task.value
+      entries[playlistID] = Entry(data: data, expiresAt: now.addingTimeInterval(lifetime))
+      if inFlight[playlistID]?.id == request.id {
+        inFlight[playlistID] = nil
+      }
+      return data
+    } catch {
+      if inFlight[playlistID]?.id == request.id {
+        inFlight[playlistID] = nil
+      }
+      throw error
+    }
+  }
+
+  func invalidate(playlistID: String) {
+    entries[playlistID] = nil
+  }
+}
+
+/// Short-TTL cache for the canonical (catalog) half of favorite-song hydration,
+/// keyed by the exact favorite ID set so any favorite change is a cache miss.
+actor FavoriteCatalogMetadataCache {
+  private struct Entry: Sendable {
+    let key: String
+    let songs: [Song]
+    let expiresAt: Date
+  }
+
+  private let lifetime: TimeInterval
+  private var cachedValue: Entry?
+  private var inFlight: (key: String, id: UUID, task: Task<[Song], Error>)?
+
+  init(lifetime: TimeInterval) {
+    self.lifetime = lifetime
+  }
+
+  func value(
+    for ids: [String],
+    at now: Date = Date(),
+    loader: @escaping @Sendable () async throws -> [Song]
+  ) async throws -> [Song] {
+    guard !ids.isEmpty else { return [] }
+    let key = ids.sorted().joined(separator: ",")
+    if let cachedValue, cachedValue.key == key, cachedValue.expiresAt > now {
+      return cachedValue.songs
+    }
+
+    let request: (id: UUID, task: Task<[Song], Error>)
+    if let inFlight, inFlight.key == key {
+      request = (inFlight.id, inFlight.task)
+    } else {
+      let id = UUID()
+      let task = Task { try await loader() }
+      request = (id, task)
+      inFlight = (key, id, task)
+    }
+
+    do {
+      let songs = try await request.task.value
+      cachedValue = Entry(key: key, songs: songs, expiresAt: now.addingTimeInterval(lifetime))
+      if inFlight?.id == request.id {
+        inFlight = nil
+      }
+      return songs
+    } catch {
+      if inFlight?.id == request.id {
+        inFlight = nil
+      }
+      throw error
+    }
+  }
+}
+
 nonisolated enum KaraokeAPIClient {
   enum APIError: Error {
     case invalidURL
@@ -80,6 +191,8 @@ nonisolated enum KaraokeAPIClient {
     category: "Network"
   )
   private static let uploadedSongMetadataCache = UploadedSongMetadataCache(lifetime: 60)
+  private static let playlistDetailCache = PlaylistDetailCache(lifetime: 60)
+  private static let favoriteCatalogMetadataCache = FavoriteCatalogMetadataCache(lifetime: 60)
 
   static func trendingSongs(days: Int = 7, take: Int? = nil) async throws -> [Song] {
     try await trendingSongs(days: String(days), take: take)
@@ -203,7 +316,9 @@ nonisolated enum KaraokeAPIClient {
 
   private static func favoriteCatalogMetadata(ids: [String]) async throws -> [Song] {
     do {
-      return try await fetchSongs(ids: ids)
+      return try await favoriteCatalogMetadataCache.value(for: ids) {
+        try await fetchSongs(ids: ids)
+      }
     } catch {
       try rethrowIfCancelled(error)
       favoriteMetadataLogger.error(
@@ -297,8 +412,8 @@ nonisolated enum KaraokeAPIClient {
     let data = try await data(for: request)
     if let song = try? decode(Song.self, from: data) { return song }
     if let envelope = try? decode(FavoriteSongEnvelope.self, from: data), let song = envelope.song { return song }
-    if let response = try? decode(SearchResponse.self, from: data), let song = response.items.first { return song }
     if let songs = SongPayloadDecoder.decodeSongs(from: data), let song = songs.first { return song }
+    if let response = try? decode(SearchResponse.self, from: data), let song = response.items.first { return song }
     if let songs = try? decode([Song].self, from: data), let song = songs.first { return song }
     if let song = songFromJSONObject(data) { return song }
     throw APIError.decodeFailed
@@ -425,9 +540,18 @@ nonisolated enum KaraokeAPIClient {
     return try await data(for: request, retriesNonIdempotentRequest: true)
   }
 
-  private static func playlistDetailData(id: String) async throws -> Data {
-    let request = try request(pathSegments: ["api", "playlist", id])
-    return try await data(for: request)
+  static func playlistDetailData(id: String) async throws -> Data {
+    try await playlistDetailCache.data(for: id) {
+      let request = try request(pathSegments: ["api", "playlist", id])
+      return try await data(for: request)
+    }
+  }
+
+  /// Drop the cached detail payload for a playlist after its contents change
+  /// (e.g. UserPlaylistsManager.addSong). The 60s TTL bounds staleness even
+  /// without explicit invalidation.
+  static func invalidatePlaylistDetail(id: String) async {
+    await playlistDetailCache.invalidate(playlistID: id)
   }
 
   private static func decodeSongSearchResults(from data: Data) throws -> [Song] {
@@ -442,16 +566,16 @@ nonisolated enum KaraokeAPIClient {
 
   private static func decodePlaylists(from data: Data) -> [Playlist] {
     let decoder = JSONDecoder()
-    if let items = (try? decoder.decode(LossyArray<PlaylistListItem>.self, from: data))?.elements {
-      return items.map { $0.asPlaylist() }
-    }
     if let items = try? decoder.decode([PlaylistListItem].self, from: data) {
       return items.map { $0.asPlaylist() }
     }
-    if let items = (try? decoder.decode(LossyArray<Playlist>.self, from: data))?.elements {
-      return items
+    if let items = (try? decoder.decode(LossyArray<PlaylistListItem>.self, from: data))?.elements {
+      return items.map { $0.asPlaylist() }
     }
     if let items = try? decoder.decode([Playlist].self, from: data) {
+      return items
+    }
+    if let items = (try? decoder.decode(LossyArray<Playlist>.self, from: data))?.elements {
       return items
     }
     return []
@@ -481,6 +605,7 @@ nonisolated enum KaraokeAPIClient {
       throw APIError.invalidURL
     }
     var request = URLRequest(url: url)
+    request.timeoutInterval = 30
     if let token = CredentialStore.token {
       request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }
@@ -509,6 +634,7 @@ nonisolated enum KaraokeAPIClient {
     components.queryItems = queryItems.isEmpty ? nil : queryItems
     guard let url = components.url else { throw APIError.invalidURL }
     var request = URLRequest(url: url)
+    request.timeoutInterval = 30
     if let token = CredentialStore.token {
       request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }

--- a/TwinskaraokeShared/Services/StorageHost.swift
+++ b/TwinskaraokeShared/Services/StorageHost.swift
@@ -17,12 +17,16 @@ nonisolated enum StorageHost {
     isChinaRegion ? "https://idk.neurokaraoke.com.cn" : "https://idk.neurokaraoke.com"
   }
 
-  private static var isChinaRegion: Bool {
+  private static var isChinaRegion: Bool { resolvedIsChinaRegion }
+
+  /// Resolved once per process: the `nk.storageRegion` override is a debug key
+  /// with no in-app settings UI, so a region change requires an app restart.
+  private static let resolvedIsChinaRegion: Bool = {
     if let override = UserDefaults.standard.string(forKey: "nk.storageRegion") {
       return override == "cn"
     }
 
     let region = Locale.current.region?.identifier ?? Locale.current.identifier
     return region.uppercased() == "CN"
-  }
+  }()
 }

--- a/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
+++ b/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
@@ -7,7 +7,9 @@ final class WatchImageCache {
     private let memory = NSCache<NSURL, UIImage>()
     private let disk = URLCache.shared
 
-    private init() {}
+    private init() {
+        memory.countLimit = 200
+    }
 
     /// Synchronous memory-cache lookup used to seed views without a placeholder frame.
     func cachedImage(for url: URL) -> UIImage? {

--- a/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
@@ -284,20 +284,7 @@ struct PlayerView: View {
                 }
             }
             .background(
-                Group {
-                    if let url = audioManager.currentSong?.thumbnailURL {
-                        WatchCachedImage(url: url) { image in
-                            image.resizable().scaledToFill()
-                        } placeholder: {
-                            backgroundBase
-                        }
-                        .blur(radius: 30)
-                        .opacity(0.35)
-                        .ignoresSafeArea()
-                    } else {
-                        backgroundBase.ignoresSafeArea()
-                    }
-                }
+                WatchPlayerBackground(song: audioManager.currentSong, base: backgroundBase)
             )
             .navigationTitle("Now Playing")
             .onAppear {
@@ -394,6 +381,34 @@ struct PlayerView: View {
         guard step != lastVolumeFeedbackStep else { return }
         lastVolumeFeedbackStep = step
         WatchHaptic.play(.click)
+    }
+}
+
+/// Full-screen blurred backdrop. Uses the tiny server-side blurred artwork variant
+/// (32px, upscaled) instead of an on-device .blur to avoid continuous GPU cost.
+private struct WatchPlayerBackground: View {
+    let song: Song?
+    let base: Color
+
+    private var blurURL: URL? {
+        guard let url = song?.thumbnailURL else { return nil }
+        return ArtworkURLBuilder.variantURL(from: url, variant: .blur)
+    }
+
+    var body: some View {
+        Group {
+            if let url = blurURL {
+                WatchCachedImage(url: url) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    base
+                }
+                .opacity(0.35)
+                .ignoresSafeArea()
+            } else {
+                base.ignoresSafeArea()
+            }
+        }
     }
 }
 

--- a/TwinskaraokeWatchApp/Features/Player/QueueView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/QueueView.swift
@@ -25,7 +25,7 @@ struct QueueView: View {
                     isPlaying: audioManager.isPlaying,
                     isLoading: audioManager.isLoading,
                     progress: audioManager.progress,
-                    queueSummary: queueSummaryText(for: upNext),
+                    queueSummary: audioManager.queueSummaryText,
                     playPauseAction: toggleCurrentPlayback,
                     previousAction: {
                         audioManager.playPrevious()
@@ -99,7 +99,6 @@ struct QueueView: View {
         }
         .navigationTitle("Queue")
         .animation(queueAnimation, value: audioManager.currentSong?.id)
-        .animation(queueAnimation, value: audioManager.queue.map(\.id))
     }
 
     private var upNextSongs: [Song] {
@@ -120,27 +119,6 @@ struct QueueView: View {
             return "Up next"
         }
         return "Up next \(offset + 1) of \(total)"
-    }
-
-    private func queueSummaryText(for songs: [Song]) -> String {
-        guard !songs.isEmpty else { return "End of queue" }
-        let countText = songs.count == 1 ? "1 song next" : "\(songs.count) songs next"
-        return "\(countText) - \(queueDurationText(for: songs))"
-    }
-
-    private func queueDurationText(for songs: [Song]) -> String {
-        let totalSeconds = songs.reduce(0) { $0 + max(0, $1.duration) }
-        guard totalSeconds > 0 else { return "0:00" }
-        let hours = totalSeconds / 3600
-        let minutes = (totalSeconds % 3600) / 60
-        let seconds = totalSeconds % 60
-        if hours > 0 {
-            return "\(hours)h \(minutes)m"
-        }
-        if minutes > 0 {
-            return "\(minutes)m \(seconds)s"
-        }
-        return "\(seconds)s"
     }
 }
 

--- a/TwinskaraokeWatchApp/Features/Search/SearchView.swift
+++ b/TwinskaraokeWatchApp/Features/Search/SearchView.swift
@@ -80,19 +80,19 @@ struct SearchView: View {
                     WatchSearchResultsSummary(
                         query: trimmedSearchText,
                         totalCount: viewModel.results.count,
-                        playableCount: playableSongs.count,
+                        playableCount: viewModel.playableSongs.count,
                         isLoading: viewModel.isLoading
                     )
                     .listRowBackground(Color.clear)
-                    ForEach(viewModel.results) { item in
+                    ForEach(viewModel.resolvedResults) { result in
                         Button {
-                            if let song = item.toSong() {
-                                play(song, context: playableSongs)
+                            if let song = result.song {
+                                play(song, context: viewModel.playableSongs)
                             } else {
                                 WatchHaptic.play(.failure)
                             }
                         } label: {
-                            if let song = item.toSong() {
+                            if let song = result.song {
                                 let isCurrent = audioManager.currentSong?.id == song.id
                                 WatchSongRow(
                                     song: song,
@@ -103,6 +103,7 @@ struct SearchView: View {
                                         : nil
                                 )
                             } else {
+                                let item = result.item
                                 HStack(spacing: 10) {
                                     WatchSongArtwork(url: item.rowImageURL, size: 38)
                                         .accessibilityHidden(true)
@@ -125,7 +126,7 @@ struct SearchView: View {
                             }
                         }
                         .buttonStyle(.watchPressable)
-                        .accessibilityHint(accessibilityHint(for: item))
+                        .accessibilityHint(accessibilityHint(for: result))
                     }
                 }
             }
@@ -139,10 +140,6 @@ struct SearchView: View {
             PlayerView()
                 .environmentObject(audioManager)
         }
-    }
-
-    private var playableSongs: [Song] {
-        viewModel.results.compactMap { $0.toSong() }
     }
 
     private var trimmedSearchText: String {
@@ -159,8 +156,8 @@ struct SearchView: View {
         showPlayer = true
     }
 
-    private func accessibilityHint(for item: SearchSongItem) -> String {
-        guard let song = item.toSong() else {
+    private func accessibilityHint(for result: WatchSearchResult) -> String {
+        guard let song = result.song else {
             return "This result cannot be played on Apple Watch."
         }
         if audioManager.currentSong?.id == song.id {

--- a/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
@@ -1,9 +1,24 @@
 import Combine
 import Foundation
 
+/// A search result paired with its playable Song, resolved once per results change
+/// so rows don't re-run toSong() on every body evaluation.
+struct WatchSearchResult: Identifiable {
+    let item: SearchSongItem
+    let song: Song?
+    var id: String { item.id }
+}
+
 @MainActor
 final class SearchViewModel: ObservableObject {
-    @Published var results: [SearchSongItem] = []
+    @Published var results: [SearchSongItem] = [] {
+        didSet {
+            resolvedResults = results.map { WatchSearchResult(item: $0, song: $0.toSong()) }
+            playableSongs = resolvedResults.compactMap(\.song)
+        }
+    }
+    @Published private(set) var resolvedResults: [WatchSearchResult] = []
+    @Published private(set) var playableSongs: [Song] = []
     @Published var isLoading = false
     @Published var searchText = ""
     private var cancellables = Set<AnyCancellable>()

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -18,13 +18,23 @@ enum PlaybackMode {
 @MainActor
 class AudioManager: ObservableObject {
     static let shared = AudioManager()
-    @Published var currentSong: Song?
+    @Published var currentSong: Song? {
+        didSet { refreshUpNext() }
+    }
     @Published var isPlaying = false
     @Published var isLoading = false
     @Published var currentTime: Double = 0
     @Published var duration: Double = 0
-    @Published var queue: [Song] = []
-    @Published var currentIndex: Int = 0
+    @Published var queue: [Song] = [] {
+        didSet { refreshUpNext() }
+    }
+    @Published var currentIndex: Int = 0 {
+        didSet { refreshUpNext() }
+    }
+    /// Up-next slice of the queue plus its summary string, recomputed only when
+    /// the queue or current track changes (views re-evaluate on every 0.5s tick).
+    @Published private(set) var upNextSongs: [Song] = []
+    @Published private(set) var queueSummaryText = "End of queue"
     @Published var playbackMode: PlaybackMode = .listLoop
     @Published var isShuffleOn = false
     @Published var volume: Double = AudioManager.storedVolume()
@@ -36,6 +46,7 @@ class AudioManager: ObservableObject {
     private var downloadToken: UUID?
     private var remoteCommandTargets: [(command: MPRemoteCommand, target: Any)] = []
     private var recoveringFromBrokenCache: Set<String> = []
+    private var volumePersistWorkItem: DispatchWorkItem?
     private var playbackRequested = false
     private var shouldResumeAfterInterruption = false
     private static let audioCacheDir: URL = {
@@ -57,11 +68,37 @@ class AudioManager: ObservableObject {
         return currentTime / duration
     }
 
-    var upNextSongs: [Song] {
-        guard let index = resolvedCurrentQueueIndex else { return [] }
+    private func refreshUpNext() {
+        guard let index = resolvedCurrentQueueIndex else {
+            upNextSongs = []
+            queueSummaryText = "End of queue"
+            return
+        }
         let nextIndex = index + 1
-        guard nextIndex < queue.endIndex else { return [] }
-        return Array(queue[nextIndex...])
+        guard nextIndex < queue.endIndex else {
+            upNextSongs = []
+            queueSummaryText = "End of queue"
+            return
+        }
+        let songs = Array(queue[nextIndex...])
+        upNextSongs = songs
+        let countText = songs.count == 1 ? "1 song next" : "\(songs.count) songs next"
+        queueSummaryText = "\(countText) - \(Self.queueDurationText(for: songs))"
+    }
+
+    private static func queueDurationText(for songs: [Song]) -> String {
+        let totalSeconds = songs.reduce(0) { $0 + max(0, $1.duration) }
+        guard totalSeconds > 0 else { return "0:00" }
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        if minutes > 0 {
+            return "\(minutes)m \(seconds)s"
+        }
+        return "\(seconds)s"
     }
 
     func play(song: Song, context: [Song] = []) {
@@ -339,8 +376,14 @@ class AudioManager: ObservableObject {
     func setVolume(_ value: Double) {
         let clamped = min(max(value, 0), 1)
         volume = clamped
-        UserDefaults.standard.set(clamped, forKey: AudioManager.volumeDefaultsKey)
         player?.volume = Float(clamped)
+        // Crown rotation streams values continuously; persist only the settled value.
+        volumePersistWorkItem?.cancel()
+        let item = DispatchWorkItem {
+            UserDefaults.standard.set(clamped, forKey: AudioManager.volumeDefaultsKey)
+        }
+        volumePersistWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: item)
     }
 
     private static func storedVolume() -> Double {


### PR DESCRIPTION
## Summary

Broad performance pass across the whole app, following up on #63. A six-domain audit (audio, networking, storage/downloads, view models/state, UI, watch) found a set of hot-path issues; this PR fixes all HIGH and MEDIUM findings plus the cheap LOW wins. 32 files, +872/−258.

## Audio

- **Slider publish storms**: volume, karaoke level, EQ bands, and vocal/bass strength sliders now keep in-drag values in local `@State` and commit to the manager throttled (~10Hz) plus once on release, instead of publishing `@Published` updates (UserDefaults writes + engine gain application) at 60–120Hz.
- **AVAudioEngine ran for the app's lifetime**: auto-shutdown is disabled, so the engine rendered silence forever once started. `stop()` now calls `engine.pause()`; every playback path restarts via `startEngineIfNeeded()` (same proven pattern as pause/resume). Helps battery during radio/stream playback, which uses `AVPlayer` and never touches the engine.
- Volume ramps (stream fade-out, quick-cut) moved from `RunLoop.main` timers to a background `DispatchSourceTimer` with generation guards, so they can't fire during scroll tracking and stale ticks no-op.
- `audioDuration`/`isValidAudioFile` probes memoized per (path, mtime) — track starts no longer open the same `AVAudioFile` several times.
- Vocal separation trim now decodes once to LPCM/WAV instead of a full AAC re-encode (which ML inference then decoded again).
- `VocalSeparator` progress only publishes ≥1% deltas; BPM cache persistence moved off the main actor, ordered and coalesced.

## Networking

- New `PlaylistDetailCache` (60s TTL + in-flight dedup): cover art, playlist song counts, and the detail view now share one download per playlist. `UserPlaylistsManager.addSong` invalidates it on mutation; TTL bounds staleness otherwise.
- New `FavoriteCatalogMetadataCache` keyed by the exact favorite ID set — repeat favorites loads skip the `/api/songs/by-ids` POST; any add/remove is a natural cache miss.
- `PlaylistCoverLoader` decodes JSON off the main actor.
- Strict-first decode ordering in `decodePlaylists`/`fetchSong` — the lossy per-element path no longer runs on every success.
- `CredentialStore` negative-caches a missing token (guest mode hit the Keychain twice per request before); storage region resolved once per process; 30s `timeoutInterval` on API requests (worst-case hang ~3min → ~90s).
- `SongRow` blur placeholder uses the 180px row variant instead of the 240px thumbnail.

## Storage / downloads

- Recently-played and saved playlists now persist **metadata only** — `songListDTOs` (full song arrays, ~1MB for a 900-song playlist) stays in memory. Older blobs with embedded songs still decode. Artwork falls back to `media`/`mosaicMedia`, which `Playlist.imageURL` already prefers.
- `SavedPlaylistsStore.isSaved` is O(1) via a synced ID set (was a linear scan per visible playlist label).
- `playableURL` fast path: a prewarmed validation entry now needs a single file stat instead of migrations + source-file reads + directory enumeration (covers the `enqueueDownloads` loop).
- Cache enforcement: eviction returns the size it already computed (no second tree walk), a 60s debounce skips no-op passes, and startup reuses enforcement sizes instead of re-walking every cache tree.
- `recordAccess` touches moved off the caller's thread; lyrics files now get real access dates so lyrics LRU eviction actually works; dead `hasCachedMainAudio`/`hasCachedStems` removed.
- `DownloadedSongsView` per-song local-URL resolution + existence checks moved off the main actor.

## UI / state

- Search filtering debounced 200ms in the library, uploaded-songs, and playlist-detail views; sorted arrays cached per (sort, songs) so keystrokes only pay for the filter pass.
- Favorites-toggle refetches coalesced (1s) in playlist detail — rapid star taps no longer reload the whole playlist per tap.
- Removed whole-list `.animation(value: songs.map(\.id))` container animations (uploaded songs, watch queue) that animated the entire list on any change.
- Queue "up next" snapshots recomputed only on queue/current-song changes (iOS and watch) instead of on every `@Published` tick.
- `RecentlyAddedTracker` publishes once per batch; dead `@ObservedObject` removed; combined playlists / prefetch signatures computed once per change.

## Watch

- Full-screen player backdrop uses the server-side 32px blur variant instead of an on-device `.blur(radius: 30)` — removes continuous GPU cost, and the background is isolated from the 2Hz `currentTime` re-eval path.
- Crown-rotation volume persistence debounced 0.5s; search results resolved to `Song` once per results change instead of per row; `WatchImageCache` capped at 200 entries.

## Behavior notes

- Search results in library/uploaded/playlist views now update after a ~200ms typing pause instead of per keystroke (intended debounce trade-off).
- After a cold launch, recently-played/saved playlists carry no embedded songs; `DownloadedSongsView` known-song metadata covers playlists recorded in the current session, and playlist artwork uses `media`/`mosaicMedia` (already the preferred sources).

## Verification

- `xcodebuild -scheme Twinskaraoke -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:TwinskaraokeTests test` — all tests pass.
- `xcodebuild -scheme TwinskaraokeWatchApp -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)' build` — succeeded.
- Worth a device smoke test: slider drags in the player, play → pause → resume → next track → radio → local (engine pause/restart), playlist open + count labels, downloads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved playlist, library, and favorite updates with smoother search and refresh behavior.
  * Enhanced Watch search results, queue summaries, and Now Playing backgrounds.
  * Improved artwork selection and playlist cover loading.
* **Bug Fixes**
  * Volume and playback controls now respond more smoothly during adjustments.
  * Stopping playback reliably halts audio rendering.
  * Playlist changes update cached details more accurately.
* **Performance**
  * Faster library searches, artwork loading, downloads, audio validation, and cache maintenance.
  * Reduced unnecessary updates while dragging sliders and adjusting volume.
  * More efficient persistence of saved playlists and recently played data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->