### PR TITLE
Update dependencies and resolve build warnings

### DIFF
--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -702,6 +702,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LM_ENABLE_LINK_GENERATION = NO;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.evilneuro.Twinskaraoke.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -737,6 +738,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LM_ENABLE_LINK_GENERATION = NO;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.evilneuro.Twinskaraoke.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -781,6 +783,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LM_ENABLE_LINK_GENERATION = NO;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.evilneuro.Twinskaraoke;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -823,6 +826,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LM_ENABLE_LINK_GENERATION = NO;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.evilneuro.Twinskaraoke;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1137,7 +1141,7 @@
 			repositoryURL = "https://github.com/LeoNatan/LNPopupUI";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.0;
+				minimumVersion = 3.1.2;
 			};
 		};
 		D0C385962FB0BD870055284E /* XCRemoteSwiftPackageReference "swift-spleeter" */ = {

--- a/Twinskaraoke.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Twinskaraoke.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LeoNatan/LNPopupController.git",
       "state" : {
-        "revision" : "c13a392bf6f058d80a35b93805a2eaf173e9956e",
-        "version" : "4.5.0"
+        "revision" : "e03a7d6d47f01093b9e08f498603ece7a9376bb2",
+        "version" : "4.5.2"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LeoNatan/LNPopupUI",
       "state" : {
-        "revision" : "619c5ccae6d844cfa02acf01a030b45cfa27ddfb",
-        "version" : "3.1.0"
+        "revision" : "6038c200ae1c66e9a3bd8a2c2a76670e9d1637f5",
+        "version" : "3.1.2"
       }
     },
     {
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "181a95b992f84d99a14c562c86e8ebef3cbcdca9",
         "version" : "1.1.5"
+      }
+    },
+    {
+      "identity" : "lnsystemmarqueelabel",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/LeoNatan/LNSystemMarqueeLabel",
+      "state" : {
+        "revision" : "916ef69a71db627498d007896a0508901d9f9fa3",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -14,6 +14,10 @@ private final class PopupPlaybackState: ObservableObject {
         snapshot.id != nil
     }
 
+    var id: String {
+        snapshot.id ?? "now-playing"
+    }
+
     var title: String {
         snapshot.title
     }
@@ -527,57 +531,40 @@ private struct PopupContent: View {
     var body: some View {
         FullScreenPlayerView()
             .environmentObject(AudioPlayerManager.shared)
-            // The popup bar only picks up title/image modifiers applied directly to the
-            // popup content view; hosting them in a background child leaves the bar blank.
-            .modifier(
-                PopupTitleModifier(
-                    title: popupState.title,
-                    subtitle: popupState.subtitle
-                )
-            )
-            .modifier(PopupImageModifier(artwork: popupState.artwork))
-            .popupBarButtons {
-                PopupBarTrailingItems(
-                    isPlaying: popupState.isPlaying,
-                    isRadioMode: popupState.isRadioMode,
-                    onTogglePlayPause: {
-                        #if canImport(UIKit)
-                            PopupOpenIntentGate.shared.suppressNextOpen()
-                        #endif
-                        AudioPlayerManager.shared.togglePlayPause()
-                    },
-                    onNext: {
-                        #if canImport(UIKit)
-                            PopupOpenIntentGate.shared.suppressNextOpen()
-                        #endif
-                        AudioPlayerManager.shared.playNextOrRandom()
+            .popupItem {
+                PopupItem(
+                    id: popupState.id,
+                    verbatimTitle: popupState.title,
+                    verbatimSubtitle: popupState.subtitle.isEmpty ? nil : popupState.subtitle,
+                    image: popupImage
+                ) {
+                    ToolbarItemGroup(placement: .popupBar) {
+                        PopupBarTrailingItems(
+                            isPlaying: popupState.isPlaying,
+                            isRadioMode: popupState.isRadioMode,
+                            onTogglePlayPause: {
+                                #if canImport(UIKit)
+                                    PopupOpenIntentGate.shared.suppressNextOpen()
+                                #endif
+                                AudioPlayerManager.shared.togglePlayPause()
+                            },
+                            onNext: {
+                                #if canImport(UIKit)
+                                    PopupOpenIntentGate.shared.suppressNextOpen()
+                                #endif
+                                AudioPlayerManager.shared.playNextOrRandom()
+                            }
+                        )
                     }
-                )
+                }
             }
     }
-}
 
-private struct PopupTitleModifier: ViewModifier, Equatable {
-    let title: String
-    let subtitle: String
-
-    func body(content: Content) -> some View {
-        content.popupTitle(verbatim: title, subtitle: subtitle)
-    }
-}
-
-private struct PopupImageModifier: ViewModifier, Equatable {
-    let artwork: UIImage?
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.artwork === rhs.artwork
-    }
-
-    func body(content: Content) -> some View {
-        if let artwork {
-            content.popupImage(Image(uiImage: artwork))
+    private var popupImage: Image {
+        if let artwork = popupState.artwork {
+            Image(uiImage: artwork)
         } else {
-            content.popupImage(Image(systemName: "music.note"))
+            Image(systemName: "music.note")
         }
     }
 }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -213,6 +213,7 @@ struct DownloadedSongsView: View {
 
         durationTask?.cancel()
         durationTask = Task { @MainActor in
+            let downloadManager = downloads
             // Resolving each song's local URL reads its per-song source file
             // and may enumerate the download directory; together with the
             // file-existence checks that is disk I/O per song, so keep the
@@ -220,7 +221,7 @@ struct DownloadedSongsView: View {
             let scanTask = Task.detached(priority: .utility) {
                 songs.reduce(into: [String: URL]()) { urls, song in
                     guard !Task.isCancelled else { return }
-                    let url = downloads.localURL(for: song.id)
+                    let url = downloadManager.localURL(for: song.id)
                     guard FileManager.default.fileExists(atPath: url.path) else { return }
                     urls[song.id] = url
                 }

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -49,19 +49,39 @@ private nonisolated final class TrimWriteContext: @unchecked Sendable {
     let writer: AVAssetWriter
     let writerInput: AVAssetWriterInput
     let continuation: CheckedContinuation<Void, Error>
+    let cancellationState: TrimCancellationState
 
     init(
         reader: AVAssetReader,
         readerOutput: AVAssetReaderTrackOutput,
         writer: AVAssetWriter,
         writerInput: AVAssetWriterInput,
-        continuation: CheckedContinuation<Void, Error>
+        continuation: CheckedContinuation<Void, Error>,
+        cancellationState: TrimCancellationState
     ) {
         self.reader = reader
         self.readerOutput = readerOutput
         self.writer = writer
         self.writerInput = writerInput
         self.continuation = continuation
+        self.cancellationState = cancellationState
+    }
+}
+
+private nonisolated final class TrimCancellationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
     }
 }
 
@@ -592,6 +612,7 @@ final class VocalSeparator: ObservableObject {
     private static func trim(source: URL, from startSeconds: TimeInterval, to output: URL)
         async throws
     {
+        try Task.checkCancellation()
         try? FileManager.default.removeItem(at: output)
         let asset = AVURLAsset(url: source)
         let duration = try await asset.load(.duration)
@@ -640,57 +661,64 @@ final class VocalSeparator: ObservableObject {
             throw reader.error ?? writer.error ?? VocalSeparatorError.trimFailed
         }
         writer.startSession(atSourceTime: safeStart)
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            let context = TrimWriteContext(
-                reader: reader,
-                readerOutput: readerOutput,
-                writer: writer,
-                writerInput: writerInput,
-                continuation: continuation
-            )
-            context.writerInput.requestMediaDataWhenReady(on: Self.trimWriteQueue) {
-                while context.writerInput.isReadyForMoreMediaData {
-                    // Bail promptly on job cancellation instead of writing the
-                    // remaining LPCM; cancelReading() alone can't interrupt an
-                    // in-flight copyNextSampleBuffer().
-                    if Task.isCancelled {
-                        context.reader.cancelReading()
-                        context.writerInput.markAsFinished()
-                        context.writer.cancelWriting()
-                        context.continuation.resume(throwing: CancellationError())
-                        return
-                    }
-                    guard context.reader.status != .failed else {
-                        context.writerInput.markAsFinished()
-                        context.writer.cancelWriting()
-                        context.continuation.resume(
-                            throwing: context.reader.error ?? VocalSeparatorError.trimFailed
-                        )
-                        return
-                    }
-                    guard let buffer = context.readerOutput.copyNextSampleBuffer() else {
-                        context.writerInput.markAsFinished()
-                        context.writer.finishWriting {
-                            if context.writer.status == .completed {
-                                context.continuation.resume()
-                            } else {
-                                context.continuation.resume(
-                                    throwing: context.writer.error ?? VocalSeparatorError.trimFailed
-                                )
-                            }
+        let cancellationState = TrimCancellationState()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                let context = TrimWriteContext(
+                    reader: reader,
+                    readerOutput: readerOutput,
+                    writer: writer,
+                    writerInput: writerInput,
+                    continuation: continuation,
+                    cancellationState: cancellationState
+                )
+                context.writerInput.requestMediaDataWhenReady(on: Self.trimWriteQueue) {
+                    while context.writerInput.isReadyForMoreMediaData {
+                        if context.cancellationState.isCancelled {
+                            context.reader.cancelReading()
+                            context.writerInput.markAsFinished()
+                            context.writer.cancelWriting()
+                            context.continuation.resume(throwing: CancellationError())
+                            return
                         }
-                        return
-                    }
-                    if !context.writerInput.append(buffer) {
-                        context.writerInput.markAsFinished()
-                        context.writer.cancelWriting()
-                        context.continuation.resume(
-                            throwing: context.writer.error ?? VocalSeparatorError.trimFailed
-                        )
-                        return
+                        guard context.reader.status != .failed else {
+                            context.writerInput.markAsFinished()
+                            context.writer.cancelWriting()
+                            context.continuation.resume(
+                                throwing: context.reader.error ?? VocalSeparatorError.trimFailed
+                            )
+                            return
+                        }
+                        guard let buffer = context.readerOutput.copyNextSampleBuffer() else {
+                            context.writerInput.markAsFinished()
+                            context.writer.finishWriting {
+                                if context.cancellationState.isCancelled {
+                                    context.continuation.resume(throwing: CancellationError())
+                                } else if context.writer.status == .completed {
+                                    context.continuation.resume()
+                                } else {
+                                    context.continuation.resume(
+                                        throwing: context.writer.error
+                                            ?? VocalSeparatorError.trimFailed
+                                    )
+                                }
+                            }
+                            return
+                        }
+                        if !context.writerInput.append(buffer) {
+                            context.writerInput.markAsFinished()
+                            context.writer.cancelWriting()
+                            context.continuation.resume(
+                                throwing: context.writer.error ?? VocalSeparatorError.trimFailed
+                            )
+                            return
+                        }
                     }
                 }
             }
+        } onCancel: {
+            cancellationState.cancel()
         }
     }
 

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -40,6 +40,31 @@ nonisolated struct CachedStems {
     }
 }
 
+/// Owns one AVFoundation trim pipeline after it moves onto `trimWriteQueue`.
+/// The referenced AVFoundation objects are not `Sendable`, but every mutation
+/// after setup is serialized by that queue and its completion callback.
+private nonisolated final class TrimWriteContext: @unchecked Sendable {
+    let reader: AVAssetReader
+    let readerOutput: AVAssetReaderTrackOutput
+    let writer: AVAssetWriter
+    let writerInput: AVAssetWriterInput
+    let continuation: CheckedContinuation<Void, Error>
+
+    init(
+        reader: AVAssetReader,
+        readerOutput: AVAssetReaderTrackOutput,
+        writer: AVAssetWriter,
+        writerInput: AVAssetWriterInput,
+        continuation: CheckedContinuation<Void, Error>
+    ) {
+        self.reader = reader
+        self.readerOutput = readerOutput
+        self.writer = writer
+        self.writerInput = writerInput
+        self.continuation = continuation
+    }
+}
+
 struct SeparationJobOwnership {
     private(set) var activeID: UUID?
 
@@ -616,44 +641,51 @@ final class VocalSeparator: ObservableObject {
         }
         writer.startSession(atSourceTime: safeStart)
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            writerInput.requestMediaDataWhenReady(on: Self.trimWriteQueue) {
-                while writerInput.isReadyForMoreMediaData {
+            let context = TrimWriteContext(
+                reader: reader,
+                readerOutput: readerOutput,
+                writer: writer,
+                writerInput: writerInput,
+                continuation: continuation
+            )
+            context.writerInput.requestMediaDataWhenReady(on: Self.trimWriteQueue) {
+                while context.writerInput.isReadyForMoreMediaData {
                     // Bail promptly on job cancellation instead of writing the
                     // remaining LPCM; cancelReading() alone can't interrupt an
                     // in-flight copyNextSampleBuffer().
                     if Task.isCancelled {
-                        reader.cancelReading()
-                        writerInput.markAsFinished()
-                        writer.cancelWriting()
-                        continuation.resume(throwing: CancellationError())
+                        context.reader.cancelReading()
+                        context.writerInput.markAsFinished()
+                        context.writer.cancelWriting()
+                        context.continuation.resume(throwing: CancellationError())
                         return
                     }
-                    guard reader.status != .failed else {
-                        writerInput.markAsFinished()
-                        writer.cancelWriting()
-                        continuation.resume(
-                            throwing: reader.error ?? VocalSeparatorError.trimFailed
+                    guard context.reader.status != .failed else {
+                        context.writerInput.markAsFinished()
+                        context.writer.cancelWriting()
+                        context.continuation.resume(
+                            throwing: context.reader.error ?? VocalSeparatorError.trimFailed
                         )
                         return
                     }
-                    guard let buffer = readerOutput.copyNextSampleBuffer() else {
-                        writerInput.markAsFinished()
-                        writer.finishWriting {
-                            if writer.status == .completed {
-                                continuation.resume()
+                    guard let buffer = context.readerOutput.copyNextSampleBuffer() else {
+                        context.writerInput.markAsFinished()
+                        context.writer.finishWriting {
+                            if context.writer.status == .completed {
+                                context.continuation.resume()
                             } else {
-                                continuation.resume(
-                                    throwing: writer.error ?? VocalSeparatorError.trimFailed
+                                context.continuation.resume(
+                                    throwing: context.writer.error ?? VocalSeparatorError.trimFailed
                                 )
                             }
                         }
                         return
                     }
-                    if !writerInput.append(buffer) {
-                        writerInput.markAsFinished()
-                        writer.cancelWriting()
-                        continuation.resume(
-                            throwing: writer.error ?? VocalSeparatorError.trimFailed
+                    if !context.writerInput.append(buffer) {
+                        context.writerInput.markAsFinished()
+                        context.writer.cancelWriting()
+                        context.continuation.resume(
+                            throwing: context.writer.error ?? VocalSeparatorError.trimFailed
                         )
                         return
                     }

--- a/Twinskaraoke/Services/Storage/LyricsCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/LyricsCacheStore.swift
@@ -8,7 +8,7 @@ enum LyricsCacheVariant: String {
 enum LyricsCacheStore {
     private static let fm = FileManager.default
 
-    static let cacheDirectory: URL = {
+    nonisolated static let cacheDirectory: URL = {
         let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
             .appendingPathComponent("LyricsCache", isDirectory: true)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,16 +60,22 @@
     },
     "node_modules/@docsearch/css": {
       "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
+      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docsearch/js": {
       "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.6.3.tgz",
+      "integrity": "sha512-qUIX2b4Apew3tv4F0qhmgShsl/Lfw4m6mqv/5/5dWNxwTcDdLMp2s3YwZ+NMGh3IKCg0pBaXm7Q5VdyU5Rj+cQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docsearch/sidepanel-js": {
       "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/sidepanel-js/-/sidepanel-js-4.6.3.tgz",
+      "integrity": "sha512-grGSmvXzG0if+mrzdIKykvpIAuEQ9u0sEJ2eLRRCaQfJvsWqh2C2/aY04bIzWvDh7myi5rvl8D+tUNsVrjYQ3A==",
       "dev": true,
       "license": "MIT"
     },
@@ -108,9 +114,9 @@
       }
     },
     "node_modules/@iconify-json/simple-icons": {
-      "version": "1.2.90",
-      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.90.tgz",
-      "integrity": "sha512-zt2o2ZvQpHVvZJARIkZ51RnaHY2oqcPJMvHE+mVnxkSr+c33fnX4gciiXu+wyX5ei+s0qbVX1wD0DWBbaGBYMA==",
+      "version": "1.2.92",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.92.tgz",
+      "integrity": "sha512-hR0ozxR97t1dzWw+esoxFijZ15gagt7EIgF3CNifu2yICXhS7gnun4Y+j+odJQtNSl7wvqMdoLbViIShwe/fdw==",
       "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
@@ -587,11 +593,15 @@
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -611,6 +621,8 @@
     },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
     },
@@ -623,6 +635,8 @@
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "dev": true,
       "license": "MIT"
     },
@@ -651,146 +665,146 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
-      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.5.39",
+        "@vue/shared": "3.5.40",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
-      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.39",
-        "@vue/shared": "3.5.39"
+        "@vue/compiler-core": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
-      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.5.39",
-        "@vue/compiler-dom": "3.5.39",
-        "@vue/compiler-ssr": "3.5.39",
-        "@vue/shared": "3.5.39",
+        "@vue/compiler-core": "3.5.40",
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/shared": "3.5.40",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
-      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.39",
-        "@vue/shared": "3.5.39"
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.5.tgz",
-      "integrity": "sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
+      "integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.5"
+        "@vue/devtools-kit": "^8.2.1"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+      "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
+        "@vue/devtools-shared": "^8.2.1",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
         "perfect-debounce": "^2.0.0"
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+      "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
-      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+      "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.39"
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
-      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+      "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.39",
-        "@vue/shared": "3.5.39"
+        "@vue/reactivity": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
-      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+      "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.39",
-        "@vue/runtime-core": "3.5.39",
-        "@vue/shared": "3.5.39",
+        "@vue/reactivity": "3.5.40",
+        "@vue/runtime-core": "3.5.40",
+        "@vue/shared": "3.5.40",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
-      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.39",
-        "@vue/shared": "3.5.39"
-      },
-      "peerDependencies": {
-        "vue": "3.5.39"
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
-      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
       "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -807,6 +821,8 @@
     },
     "node_modules/@vueuse/integrations": {
       "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-14.3.0.tgz",
+      "integrity": "sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -872,6 +888,8 @@
     },
     "node_modules/@vueuse/metadata": {
       "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -880,6 +898,8 @@
     },
     "node_modules/@vueuse/shared": {
       "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1104,9 +1124,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -1120,23 +1140,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -1155,9 +1175,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -1176,9 +1196,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -1197,9 +1217,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -1218,9 +1238,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -1239,9 +1259,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -1263,9 +1283,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -1287,9 +1307,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -1311,9 +1331,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -1335,9 +1355,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -1356,9 +1376,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -1388,6 +1408,8 @@
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1509,11 +1531,15 @@
     },
     "node_modules/minisearch": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1557,6 +1583,8 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1574,9 +1602,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1594,7 +1622,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1696,6 +1724,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1875,16 +1905,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -1996,17 +2026,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.39",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
-      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+      "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.39",
-        "@vue/compiler-sfc": "3.5.39",
-        "@vue/runtime-dom": "3.5.39",
-        "@vue/server-renderer": "3.5.39",
-        "@vue/shared": "3.5.39"
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-sfc": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/server-renderer": "3.5.40",
+        "@vue/shared": "3.5.40"
       },
       "peerDependencies": {
         "typescript": "*"


### PR DESCRIPTION
## Summary

- update LNPopupUI to 3.1.2 and LNPopupController to 4.5.2, including the new marquee-label dependency
- refresh compatible documentation dependencies in `package-lock.json`
- migrate the mini-player to LNPopupUI's consolidated `PopupItem` API
- resolve Swift concurrency warnings around downloaded-song scanning, lyrics cache access, and AVFoundation trimming
- disable App Intents metadata generation for targets that do not contain App Intents

## Why

The dependency refresh exposed stricter concurrency diagnostics and repeated legacy LNPopupUI preference updates. The AVFoundation trim callback also captured non-Sendable objects without expressing its existing serial-queue ownership. These changes adopt the current popup-item API and make the concurrency boundaries explicit without adding unused framework dependencies or globally suppressing compiler warnings.

## Impact

- warning-free simulator and device-architecture builds
- fewer redundant popup preference updates at runtime
- current compatible SwiftPM and documentation dependency versions
- no intended change to playback, download, or vocal-separation behavior

## Validation

- Debug iOS Simulator build
- Debug generic iOS device build
- full `TwinskaraokeTests` suite
- `npm ci`
- `npm run docs:build`
- npm audit: 0 vulnerabilities
- `git diff --check`

## Summary by Sourcery

Update media popup integration and AVFoundation trimming to align with new dependency versions and stricter Swift concurrency diagnostics while keeping runtime behavior unchanged.

New Features:
- Adopt LNPopupUI's consolidated PopupItem API for the mini-player, including popup bar toolbar items.

Bug Fixes:
- Resolve Swift concurrency warnings in AVFoundation trimming, downloaded-song scanning, and lyrics cache access by making ownership and isolation explicit.

Enhancements:
- Reduce redundant popup preference updates and simplify popup artwork handling with a single computed image property.

Build:
- Refresh SwiftPM and documentation-related dependencies, including new LNPopupUI, LNPopupController, and marquee-label versions, and update package-lock.json.

Chores:
- Disable App Intents metadata generation for Xcode targets that do not contain App Intents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the mini-player and full-screen player to display playback titles, subtitles, artwork, and controls more consistently.
  * Improved playback control behavior for play/pause and next-track actions.
  * Increased reliability when loading downloaded songs and resolving audio durations.
  * Strengthened vocal separation and trimming workflows, including cancellation and error handling.
  * Improved lyrics cache operations for smoother performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->