### PR TITLE
perf: improve image loading and caching across iOS and watchOS

### DIFF
--- a/Twinskaraoke/Components/Account/AccountListRows.swift
+++ b/Twinskaraoke/Components/Account/AccountListRows.swift
@@ -76,11 +76,10 @@ struct ProfileHeaderRow: View {
     @ViewBuilder
     private var avatarView: some View {
         if let urlStr = avatarUrl, let url = URL(string: urlStr), !urlStr.isEmpty {
-            AsyncImage(url: url) { phase in
-                switch phase {
-                case let .success(img): img.resizable().scaledToFill()
-                default: initials
-                }
+            WebImage(url: url, options: ImageCacheConfig.defaultOptions) { image in
+                image.resizable().scaledToFill()
+            } placeholder: {
+                initials
             }
         } else {
             initials

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -44,9 +44,12 @@ struct RemoteArtworkImage: View {
                 MusicArtworkPlaceholder(cornerRadius: cornerRadius)
             }
             if let lowResURL, !fullLoaded, shouldPreferProgressiveArtwork {
+                // The blur variant is a ~1 KB WebP; loading it (not just from
+                // cache) gives every image a progressive preview, even when the
+                // prefetcher hasn't warmed this URL yet.
                 WebImage(
                     url: lowResURL,
-                    options: [.fromCacheOnly],
+                    options: ImageCacheConfig.defaultOptions,
                     context: context
                 ) { image in
                     image

--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -73,9 +73,13 @@ struct PlayerAmbientBackground: View {
     @ViewBuilder
     private var blurredArtworkLayer: some View {
         if let artworkURL {
+            // The backdrop is blurred beyond recognition anyway, so load the
+            // 32px server-blurred variant instead of the full card image:
+            // far less decode, memory and GPU work for the same visual result.
+            let backdropURL = ArtworkURLBuilder.variantURL(from: artworkURL, variant: .blur) ?? artworkURL
             GeometryReader { geo in
                 WebImage(
-                    url: artworkURL,
+                    url: backdropURL,
                     options: ImageCacheConfig.defaultOptions,
                     context: ImageCacheConfig.visibleImageContext
                 ) { image in
@@ -160,7 +164,8 @@ struct PlayerAmbientBackground: View {
 
     private var runtimeBlurRadius: CGFloat {
         guard let artworkURL else { return 0 }
-        let options = Self.imageTransformOptions(from: artworkURL)
+        let backdropURL = ArtworkURLBuilder.variantURL(from: artworkURL, variant: .blur) ?? artworkURL
+        let options = Self.imageTransformOptions(from: backdropURL)
         let sourceBlur = options["blur"].flatMap(Double.init) ?? 0
         let sourceWidth = options["width"].flatMap(Double.init)
         return sourceBlur > 0 || sourceWidth.map { $0 <= 32 } == true ? 12 : 42

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
@@ -105,25 +105,32 @@ struct ArtDetailView: View {
         saveGeneration &+= 1
         let generation = saveGeneration
         #if canImport(UIKit)
-            // RemoteArtworkImage already downloaded this exact URL into the
-            // shared SDWebImage memory cache; reuse it instead of re-downloading.
-            if let cached = SDImageCache.shared.imageFromMemoryCache(forKey: url.absoluteString) {
-                saveLoadedImage(cached, generation: generation)
-                return
-            }
-        #endif
-        URLSession.shared.dataTask(with: url) { data, _, error in
-            DispatchQueue.main.async {
-                #if canImport(UIKit)
-                    if let data, let image = UIImage(data: data) {
+            // Reuse whatever SDWebImage already has (memory first, then disk)
+            // and only hit the network on a real miss — the full-res variant
+            // is usually cached from the detail view's own load.
+            SDWebImageManager.shared.loadImage(
+                with: url,
+                options: [],
+                context: ImageCacheConfig.memoryAndDiskCacheContext,
+                progress: nil
+            ) { image, _, error, _, _, _ in
+                DispatchQueue.main.async {
+                    if let image {
                         saveLoadedImage(image, generation: generation)
                         return
                     }
-                #endif
-                saveStatus = .failed(error?.localizedDescription ?? "Couldn't save")
-                resetSaveStatusLater(generation: generation)
+                    saveStatus = .failed(error?.localizedDescription ?? "Couldn't save")
+                    resetSaveStatusLater(generation: generation)
+                }
             }
-        }.resume()
+        #else
+            URLSession.shared.dataTask(with: url) { data, _, error in
+                DispatchQueue.main.async {
+                    saveStatus = .failed(error?.localizedDescription ?? "Couldn't save")
+                    resetSaveStatusLater(generation: generation)
+                }
+            }.resume()
+        #endif
     }
 
     #if canImport(UIKit)

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -296,6 +296,7 @@ struct QueueView: View {
               let idx = audioManager.queue.firstIndex(where: { $0.id == current.id }),
               idx + 1 < audioManager.queue.count
         else {
+            ArtworkPrefetcher.shared.cancel(reason: "queue up next")
             upNextSongs = []
             return
         }

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -152,6 +152,9 @@ struct QueueView: View {
         .onAppear { refreshUpNextSongs() }
         .onChange(of: audioManager.queue) { _, _ in refreshUpNextSongs() }
         .onChange(of: audioManager.currentSong?.id) { _, _ in refreshUpNextSongs() }
+        .onDisappear {
+            ArtworkPrefetcher.shared.cancel(reason: "queue up next")
+        }
     }
 
     private func header(upNextCount: Int) -> some View {
@@ -297,5 +300,13 @@ struct QueueView: View {
             return
         }
         upNextSongs = Array(audioManager.queue[(idx + 1)...])
+        // Rows otherwise rely on the source list having warmed these; the queue
+        // can outlive that list, so warm the row variants here too.
+        ArtworkPrefetcher.shared.prefetchSongs(
+            Array(upNextSongs.prefix(12)),
+            limit: 12,
+            reason: "queue up next",
+            variant: .row
+        )
     }
 }

--- a/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
+++ b/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
@@ -31,7 +31,9 @@ enum ImageCacheConfig {
         let cfg = SDImageCache.shared.config
         cfg.maxMemoryCost = 128 * 1024 * 1024
         cfg.maxMemoryCount = 240
-        cfg.maxDiskSize = 768 * 1024 * 1024
+        // Keep in sync with CacheManager's 2 GB image limit (and the value the
+        // Settings UI advertises) so the bookkeeping matches what is actually kept.
+        cfg.maxDiskSize = 2 * 1024 * 1024 * 1024
         cfg.shouldCacheImagesInMemory = true
         cfg.shouldUseWeakMemoryCache = true
         cfg.maxDiskAge = 90 * 24 * 60 * 60

--- a/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
+++ b/TwinskaraokeWatchApp/Components/WatchCachedImage.swift
@@ -5,10 +5,12 @@ final class WatchImageCache {
     static let shared = WatchImageCache()
 
     private let memory = NSCache<NSURL, UIImage>()
-    private let disk = URLCache.shared
+    // Dedicated, bounded disk cache instead of the default shared URLCache.
+    private let disk = URLCache(memoryCapacity: 8 * 1024 * 1024, diskCapacity: 64 * 1024 * 1024)
 
     private init() {
         memory.countLimit = 200
+        memory.totalCostLimit = 32 * 1024 * 1024
     }
 
     /// Synchronous memory-cache lookup used to seed views without a placeholder frame.
@@ -23,7 +25,7 @@ final class WatchImageCache {
         let request = URLRequest(url: url)
         if let stored = disk.cachedResponse(for: request),
            let image = UIImage(data: stored.data) {
-            memory.setObject(image, forKey: key)
+            memory.setObject(image, forKey: key, cost: stored.data.count)
             return image
         }
 
@@ -31,7 +33,7 @@ final class WatchImageCache {
               let image = UIImage(data: data)
         else { return nil }
 
-        memory.setObject(image, forKey: key)
+        memory.setObject(image, forKey: key, cost: data.count)
         disk.storeCachedResponse(CachedURLResponse(response: response, data: data), for: request)
         return image
     }

--- a/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
@@ -78,7 +78,19 @@ struct PlaylistsGridView: View {
         .animation(loadingAnimation, value: viewModel.isLoading)
         .onAppear {
             viewModel.fetchMusic()
+            prefetchArtwork()
         }
+        .onChange(of: viewModel.playlists.map(\.id)) {
+            prefetchArtwork()
+        }
+        .onDisappear {
+            WatchArtworkPrefetcher.shared.cancel(reason: "playlistsGrid")
+        }
+    }
+
+    private func prefetchArtwork() {
+        let urls = viewModel.playlists.compactMap { $0.thumbnailURL ?? $0.imageURL }
+        WatchArtworkPrefetcher.shared.prefetch(urls: urls, reason: "playlistsGrid")
     }
 
     private var totalSongCount: Int {

--- a/TwinskaraokeWatchApp/Features/Player/QueueView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/QueueView.swift
@@ -99,6 +99,20 @@ struct QueueView: View {
         }
         .navigationTitle("Queue")
         .animation(queueAnimation, value: audioManager.currentSong?.id)
+        .onAppear {
+            prefetchArtwork()
+        }
+        .onChange(of: audioManager.upNextSongs.map(\.id)) {
+            prefetchArtwork()
+        }
+        .onDisappear {
+            WatchArtworkPrefetcher.shared.cancel(reason: "queue")
+        }
+    }
+
+    private func prefetchArtwork() {
+        let urls = audioManager.upNextSongs.compactMap(\.rowImageURL)
+        WatchArtworkPrefetcher.shared.prefetch(urls: urls, reason: "queue")
     }
 
     private var upNextSongs: [Song] {

--- a/TwinskaraokeWatchApp/Features/Search/SearchView.swift
+++ b/TwinskaraokeWatchApp/Features/Search/SearchView.swift
@@ -140,6 +140,9 @@ struct SearchView: View {
             PlayerView()
                 .environmentObject(audioManager)
         }
+        .onAppear {
+            prefetchArtwork()
+        }
         .onChange(of: viewModel.resolvedResults.map(\.id)) {
             prefetchArtwork()
         }

--- a/TwinskaraokeWatchApp/Features/Search/SearchView.swift
+++ b/TwinskaraokeWatchApp/Features/Search/SearchView.swift
@@ -140,6 +140,17 @@ struct SearchView: View {
             PlayerView()
                 .environmentObject(audioManager)
         }
+        .onChange(of: viewModel.resolvedResults.map(\.id)) {
+            prefetchArtwork()
+        }
+        .onDisappear {
+            WatchArtworkPrefetcher.shared.cancel(reason: "search")
+        }
+    }
+
+    private func prefetchArtwork() {
+        let urls = viewModel.resolvedResults.compactMap { $0.song?.rowImageURL ?? $0.item.rowImageURL }
+        WatchArtworkPrefetcher.shared.prefetch(urls: urls, reason: "search")
     }
 
     private var trimmedSearchText: String {

--- a/TwinskaraokeWatchApp/Services/WatchArtworkPrefetcher.swift
+++ b/TwinskaraokeWatchApp/Services/WatchArtworkPrefetcher.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Warms `WatchImageCache` for artwork that is about to scroll into view.
+/// Mirrors the iOS `ArtworkPrefetcher` pattern: per-reason cancellation,
+/// a short dedup window, and memory-cache-aware skipping.
+@MainActor
+final class WatchArtworkPrefetcher {
+    static let shared = WatchArtworkPrefetcher()
+
+    private let recentWindow: TimeInterval = 45
+    private var recentlyRequested: [URL: Date] = [:]
+    private var tasks: [String: Task<Void, Never>] = [:]
+
+    private init() {}
+
+    /// Prefetches the first `limit` URLs for `reason`, skipping anything already
+    /// in the memory cache or requested recently. Replaces any in-flight
+    /// prefetch for the same reason.
+    func prefetch(urls: [URL], reason: String, limit: Int = 12) {
+        cancel(reason: reason)
+        let now = Date()
+        if recentlyRequested.count > 256 {
+            recentlyRequested = recentlyRequested.filter { now.timeIntervalSince($0.value) < recentWindow }
+        }
+        let targets = urls.prefix(limit).filter { url in
+            if WatchImageCache.shared.cachedImage(for: url) != nil { return false }
+            if let last = recentlyRequested[url], now.timeIntervalSince(last) < recentWindow { return false }
+            recentlyRequested[url] = now
+            return true
+        }
+        guard !targets.isEmpty else { return }
+        // Sequential on purpose: the watch radio and battery matter more than
+        // prefetch throughput, and each thumbnail is only a few KB.
+        tasks[reason] = Task { [weak self] in
+            for url in targets {
+                if Task.isCancelled { return }
+                _ = await WatchImageCache.shared.image(for: url)
+            }
+            self?.tasks[reason] = nil
+        }
+    }
+
+    func cancel(reason: String) {
+        tasks[reason]?.cancel()
+        tasks[reason] = nil
+    }
+}

--- a/TwinskaraokeWatchApp/Services/WatchArtworkPrefetcher.swift
+++ b/TwinskaraokeWatchApp/Services/WatchArtworkPrefetcher.swift
@@ -7,9 +7,14 @@ import Foundation
 final class WatchArtworkPrefetcher {
     static let shared = WatchArtworkPrefetcher()
 
+    private struct ActivePrefetch {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
     private let recentWindow: TimeInterval = 45
     private var recentlyRequested: [URL: Date] = [:]
-    private var tasks: [String: Task<Void, Never>] = [:]
+    private var tasks: [String: ActivePrefetch] = [:]
 
     private init() {}
 
@@ -18,6 +23,7 @@ final class WatchArtworkPrefetcher {
     /// prefetch for the same reason.
     func prefetch(urls: [URL], reason: String, limit: Int = 12) {
         cancel(reason: reason)
+        let requestID = UUID()
         let now = Date()
         if recentlyRequested.count > 256 {
             recentlyRequested = recentlyRequested.filter { now.timeIntervalSince($0.value) < recentWindow }
@@ -31,17 +37,21 @@ final class WatchArtworkPrefetcher {
         guard !targets.isEmpty else { return }
         // Sequential on purpose: the watch radio and battery matter more than
         // prefetch throughput, and each thumbnail is only a few KB.
-        tasks[reason] = Task { [weak self] in
+        let task = Task { [weak self] in
             for url in targets {
                 if Task.isCancelled { return }
                 _ = await WatchImageCache.shared.image(for: url)
             }
-            self?.tasks[reason] = nil
+            // A cancelled predecessor can outlive its replacement; only clear
+            // the entry if this task is still the current one for the reason.
+            guard let self, self.tasks[reason]?.id == requestID else { return }
+            self.tasks[reason] = nil
         }
+        tasks[reason] = ActivePrefetch(id: requestID, task: task)
     }
 
     func cancel(reason: String) {
-        tasks[reason]?.cancel()
+        tasks[reason]?.task.cancel()
         tasks[reason] = nil
     }
 }


### PR DESCRIPTION
## Summary

Builds on the existing SDWebImage + Cloudflare variant infrastructure to close the remaining gaps that caused re-downloads, wasted decode/memory, and missing previews.

**iOS**
- Profile avatar used a bare `AsyncImage`, bypassing the shared cache (and its `URLCache` entries get wiped on player reset) — now uses `WebImage` like the rest of the app
- Low-res blur preview in `RemoteArtworkImage` was `.fromCacheOnly`, so it silently did nothing unless prefetched — the ~1 KB blur variant now loads over the network, making the progressive blur-up work everywhere
- Player ambient backdrop loaded a full 480px image just to blur it — now uses the 32px server-blurred variant (runtime blur radius 42 → 12), cutting decode, memory, and GPU work
- Save-to-photos re-downloaded the 1920px image on a memory-cache miss — now goes through `SDWebImageManager`, so disk hits avoid the network
- SDWebImage disk limit raised 768 MB → 2 GB, matching `CacheManager` and what the Settings UI advertises
- Queue view now prefetches up-next row artwork (previously relied on the source list having warmed it)

**watchOS**
- Watch image cache: bounded dedicated `URLCache` (8 MB memory / 64 MB disk) instead of default `URLCache.shared`, plus a 32 MB `NSCache` cost limit
- New `WatchArtworkPrefetcher` (dedup, per-reason cancel, memory-cache-aware) wired into the playlists grid, queue, and search results to warm the first ~12 thumbnails

## Verification

- iOS and watchOS schemes build clean
- `TwinskaraokeTests` and `Twinskaraoke Watch AppTests` all pass
- Debug build installed and exercised on device (iPhone 17 Pro Max): library/search scrolling, player ambient backdrop, queue, save-to-photos, and profile avatar all confirmed working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved artwork loading with progressive previews and more consistent blurred backgrounds.
  * Added proactive artwork prefetching across queues, playlists, and search results.
  * Prefetching now cancels when leaving screens to avoid unnecessary work.
  * Increased available image cache storage to improve repeat viewing.
  * Improved Watch artwork caching and memory management.

* **Bug Fixes**
  * Improved profile image placeholders and loading behavior.
  * Improved full-resolution image saving reliability, including clearer failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->