### PR TITLE
fix: broad bug-hunt — stale UI, playback races, pagination dead-ends, cache correctness

### DIFF
--- a/Twinskaraoke/Components/Media/ArtThumbnail.swift
+++ b/Twinskaraoke/Components/Media/ArtThumbnail.swift
@@ -6,7 +6,7 @@ struct ArtThumbnail: View {
         Group {
             if let url = art.imageURL {
                 RemoteArtworkImage(
-                    url: url, cornerRadius: 8, showsLoading: false, lowResURL: art.blurPreviewURL,
+                    url: url, cornerRadius: 8, lowResURL: art.blurPreviewURL,
                     transparentBackground: true
                 )
             } else {

--- a/Twinskaraoke/Components/Media/FavoritesArtworkTile.swift
+++ b/Twinskaraoke/Components/Media/FavoritesArtworkTile.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 
 struct FavoritesArtworkTile: View {
@@ -77,7 +76,6 @@ private struct PlaylistCoverWithLoader: View {
     let playlist: Playlist
     let cornerRadius: CGFloat
     @StateObject private var loader = PlaylistCoverLoader()
-    @ObservedObject private var fallbackArt = FallbackArtProvider.shared
 
     var body: some View {
         PlaylistArtworkContent(
@@ -91,16 +89,12 @@ private struct PlaylistCoverWithLoader: View {
         .onChange(of: playlist.id) { _, newID in
             loader.load(playlistID: newID, fallback: playlist.songListDTOs)
         }
-        .onReceive(fallbackArt.objectWillChange) { _ in
-            loader.refreshFallbackArtwork()
-        }
     }
 }
 
 struct PlaylistMosaicArtwork: View {
     let urls: [URL]
     var cornerRadius: CGFloat = 10
-    var showsLoading = false
 
     var body: some View {
         GeometryReader { geo in
@@ -120,7 +114,6 @@ struct PlaylistMosaicArtwork: View {
                         RemoteArtworkImage(
                             url: optimizedURL,
                             cornerRadius: 0,
-                            showsLoading: showsLoading,
                             fixedDisplaySize: CGSize(width: cell, height: cell)
                         )
                             .frame(width: cell, height: cell)

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -199,11 +199,11 @@ final class ArtworkFailureBackoff: ObservableObject {
         lock.lock()
         defer { lock.unlock() }
         guard let until = blockedUntil[url] else { return false }
-        guard until > now else {
-            blockedUntil.removeValue(forKey: url)
-            return false
-        }
-        return true
+        // Don't remove elapsed entries here: expire(_:) removes them and
+        // bumps generation, which is what recomposes blocked views. Removing
+        // here would skip that publish and leave those views on the
+        // placeholder until they are recreated.
+        return until > now
     }
 
     func recordFailure(_ url: URL) {

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -1,3 +1,4 @@
+import Combine
 import SDWebImageSwiftUI
 import SwiftUI
 
@@ -5,13 +6,15 @@ struct RemoteArtworkImage: View {
     let url: URL?
     var cornerRadius: CGFloat = 8
     var contentMode: ContentMode = .fill
-    var showsLoading: Bool = true
     var lowResURL: URL?
     var transparentBackground: Bool = false
     var fullResolution: Bool = false
 
     var fixedDisplaySize: CGSize?
     @ObservedObject private var scrollState = ScrollPerformanceState.shared
+    // Observed so a view composed during a failure-backoff window re-evaluates
+    // isBlocked when the window ends instead of showing the placeholder forever.
+    @ObservedObject private var failureBackoff = ArtworkFailureBackoff.shared
     @State private var fullLoaded: Bool = false
     @State private var loadFailed: Bool = false
     @State private var renderedFullURL: URL?
@@ -175,12 +178,17 @@ struct RemoteArtworkImage: View {
 
 }
 
-final class ArtworkFailureBackoff {
+final class ArtworkFailureBackoff: ObservableObject {
     static let shared = ArtworkFailureBackoff()
 
     private let cooldown: TimeInterval = 300
     private let lock = NSLock()
     private var blockedUntil: [URL: Date] = [:]
+
+    // Bumped whenever the blocked set changes so observing views re-evaluate
+    // isBlocked. Never written from isBlocked itself — that runs during view
+    // body evaluation, where publishing a change is illegal.
+    @Published private(set) var generation = 0
 
     var cooldownNanoseconds: UInt64 {
         UInt64(cooldown * 1_000_000_000)
@@ -206,12 +214,40 @@ final class ArtworkFailureBackoff {
         }
         blockedUntil[url] = Date().addingTimeInterval(cooldown)
         lock.unlock()
+        bumpGeneration()
+        // Views composed while this URL is blocked render no WebImage and
+        // schedule no retry of their own; unblock proactively so they
+        // recompose when the cooldown ends.
+        DispatchQueue.main.asyncAfter(deadline: .now() + cooldown) { [weak self] in
+            self?.expire(url)
+        }
     }
 
     func clear(_ url: URL) {
         lock.lock()
-        blockedUntil.removeValue(forKey: url)
+        let removed = blockedUntil.removeValue(forKey: url) != nil
         lock.unlock()
+        if removed { bumpGeneration() }
+    }
+
+    private func expire(_ url: URL) {
+        lock.lock()
+        // A failure re-recorded after this expiry was scheduled extends the
+        // deadline; only remove entries whose window actually ended.
+        let expired = blockedUntil[url].map { $0 <= Date() } ?? false
+        if expired {
+            blockedUntil.removeValue(forKey: url)
+        }
+        lock.unlock()
+        if expired { bumpGeneration() }
+    }
+
+    private func bumpGeneration() {
+        if Thread.isMainThread {
+            generation += 1
+        } else {
+            DispatchQueue.main.async { self.generation += 1 }
+        }
     }
 }
 

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -87,7 +87,6 @@ struct SongRow: View {
                     RemoteArtworkImage(
                         url: playback.displayImageURL(for: song, variant: .row),
                         cornerRadius: size.cornerRadius,
-                        lowResURL: playback.displayImageURL(for: song, variant: .row),
                         fixedDisplaySize: CGSize(width: size.artSize, height: size.artSize)
                     )
                     .frame(width: size.artSize, height: size.artSize)

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -77,6 +77,13 @@ struct PlaylistListView: View {
             }
             prefetchArtwork()
         }
+        // Page 1 may land after onAppear; bootstrap re-runs only while the
+        // loader is still empty (see PlaylistListLoader.bootstrap).
+        .onChange(of: playlists.map(\.id)) { _, _ in
+            if let apiURL {
+                loader.bootstrap(initial: playlists, urlBuilder: apiURL)
+            }
+        }
         .onChange(of: Array(displayedPlaylists.prefix(12)).map(\.id)) { _, _ in
             prefetchArtwork()
         }

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailAmbientBackground.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailAmbientBackground.swift
@@ -11,7 +11,6 @@ struct ArtworkDetailAmbientBackground: View {
                     url: url,
                     cornerRadius: 0,
                     contentMode: .fill,
-                    showsLoading: false,
                     lowResURL: art.blurPreviewURL,
                     transparentBackground: true
                 )

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailHero.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailHero.swift
@@ -82,7 +82,6 @@ struct ArtworkDetailHero: View {
                 url: url,
                 cornerRadius: 20,
                 contentMode: .fit,
-                showsLoading: false,
                 lowResURL: art.blurPreviewURL,
                 transparentBackground: true
             )

--- a/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
@@ -20,7 +20,7 @@ struct ZoomableImageViewer: View {
             Color.black.ignoresSafeArea()
             if let url {
                 RemoteArtworkImage(
-                    url: url, cornerRadius: 0, contentMode: .fit, showsLoading: true,
+                    url: url, cornerRadius: 0, contentMode: .fit,
                     lowResURL: lowResURL, transparentBackground: true, fullResolution: true
                 )
                 .scaleEffect(scale)

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
@@ -97,7 +97,6 @@ private struct ArtistArtsHero: View {
                         url: imageURL,
                         cornerRadius: 0,
                         contentMode: .fill,
-                        showsLoading: false,
                         lowResURL: lowResURL,
                         transparentBackground: true
                     )
@@ -156,7 +155,6 @@ private struct HeroArtwork: View {
                 RemoteArtworkImage(
                     url: url,
                     cornerRadius: 18,
-                    showsLoading: false,
                     lowResURL: art.blurPreviewURL,
                     transparentBackground: true
                 )

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
@@ -8,7 +8,7 @@ struct ArtistCircleCard: View {
             ZStack {
                 if let art = artist.arts?.first, let url = art.imageURL(variant: .thumbnail) {
                     RemoteArtworkImage(
-                        url: url, cornerRadius: 100, showsLoading: false, lowResURL: art.blurPreviewURL,
+                        url: url, cornerRadius: 100, lowResURL: art.blurPreviewURL,
                         transparentBackground: true
                     )
                 } else {

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistListRow.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistListRow.swift
@@ -8,7 +8,7 @@ struct ArtistListRow: View {
             Group {
                 if let art = artist.arts?.first, let url = art.imageURL(variant: .thumbnail) {
                     RemoteArtworkImage(
-                        url: url, cornerRadius: 100, showsLoading: false, lowResURL: art.blurPreviewURL,
+                        url: url, cornerRadius: 100, lowResURL: art.blurPreviewURL,
                         transparentBackground: true
                     )
                 } else {

--- a/Twinskaraoke/Features/Library/ArtGallery/FeaturedArtCard.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/FeaturedArtCard.swift
@@ -9,7 +9,7 @@ struct FeaturedArtCard: View {
             Group {
                 if let url = art.imageURL {
                     RemoteArtworkImage(
-                        url: url, cornerRadius: 16, showsLoading: false, lowResURL: art.blurPreviewURL,
+                        url: url, cornerRadius: 16, lowResURL: art.blurPreviewURL,
                         transparentBackground: true
                     )
                 } else {

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -123,7 +123,7 @@ private struct ArtistAvatar: View {
     var body: some View {
         Group {
             if let url {
-                RemoteArtworkImage(url: url, cornerRadius: 0, showsLoading: false)
+                RemoteArtworkImage(url: url, cornerRadius: 0)
             } else {
                 ArtistAvatarPlaceholder()
             }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -165,7 +165,7 @@ struct DownloadedSongsView: View {
     private var mosaicArtwork: some View {
         let arts = Playlist.songArtworkURLs(localSongs, limit: 4)
         if arts.count > 1 {
-            PlaylistMosaicArtwork(urls: arts, cornerRadius: 0, showsLoading: true)
+            PlaylistMosaicArtwork(urls: arts, cornerRadius: 0)
         } else if let url = arts.first {
             RemoteArtworkImage(url: url, cornerRadius: 0)
         } else {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -641,7 +641,7 @@ struct PlaylistsGridScreen: View {
         }
         ScrollView {
             Group {
-                if viewModel.isLoading, userManager.isLoading, all.isEmpty {
+                if (viewModel.isLoading || userManager.isLoading), all.isEmpty {
                     PlaylistsSkeletonView()
                 } else if displayed.isEmpty {
                     MusicEmptyState(

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -164,24 +164,24 @@ struct RandomSongsView: View {
                 }
 
                 LazyVStack(spacing: 0) {
-                    ForEach(Array(songs.enumerated()), id: \.offset) { idx, song in
+                    ForEach(songs.enumerated().map { PositionedRandomSong(offset: $0.offset, song: $0.element) }) { item in
                         Button {
-                            play(song, context: songs)
+                            play(item.song, context: songs)
                         } label: {
                             PlaylistRow(
-                                song: song,
+                                song: item.song,
                                 showsArtwork: true,
                                 horizontalPadding: rowHorizontalPadding
                             )
                             .contentShape(Rectangle())
-                            .songRowAccessibility(song: song) {
-                                play(song, context: songs)
+                            .songRowAccessibility(song: item.song) {
+                                play(item.song, context: songs)
                             }
                         }
                         .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.78, haptic: .selection))
                         .accessibilityHint("Starts playback.")
-                        .accessibilityIdentifier("RandomSongs.song.\(song.id)")
-                        if idx < songs.count - 1 {
+                        .accessibilityIdentifier("RandomSongs.song.\(item.offset).\(item.song.id)")
+                        if item.offset < songs.count - 1 {
                             Divider().padding(.leading, rowHorizontalPadding + 60)
                         }
                     }
@@ -256,6 +256,33 @@ struct RandomSongsView: View {
         Task {
             await viewModel.reload()
         }
+    }
+}
+
+/// Row identity for the random songs list. The offset keeps IDs unique when
+/// the same song appears twice (duplicate ForEach IDs can hang
+/// AttributeGraph). The song fields make the ID change when refresh replaces
+/// the whole set at the same offsets: with purely positional identity, an
+/// already-composed row keeps showing the previous random pick, and its
+/// SongDownloadRowState stays subscribed to the old song's downloads.
+private struct PositionedRandomSong: Identifiable {
+    struct ID: Hashable {
+        let offset: Int
+        let songID: String
+        let displayArtist: String
+        let durationText: String
+    }
+
+    let offset: Int
+    let song: Song
+
+    var id: ID {
+        ID(
+            offset: offset,
+            songID: song.id,
+            displayArtist: song.displayArtist,
+            durationText: song.durationText
+        )
     }
 }
 

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct UploadedSongsView: View {
     @StateObject private var viewModel = UploadedSongsViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
+    @State private var prefetchedIDs: [String] = []
 
     var body: some View {
         let songs = viewModel.displayedSongs
@@ -68,9 +69,15 @@ struct UploadedSongsView: View {
         .task {
             viewModel.loadIfNeeded()
         }
-        .onChange(of: Array(songs.prefix(18)).map(\.id)) { _, _ in
+        // Diffing on displayedSongs (Equatable, id-only ==) avoids allocating
+        // the prefix id array on every body eval; it only builds when the list changes.
+        .onChange(of: viewModel.displayedSongs) { _, newSongs in
+            let visible = Array(newSongs.prefix(18))
+            let ids = visible.map(\.id)
+            guard ids != prefetchedIDs else { return }
+            prefetchedIDs = ids
             ArtworkPrefetcher.shared.prefetchSongs(
-                Array(songs.prefix(18)),
+                visible,
                 limit: 18,
                 reason: "uploaded visible songs",
                 variant: .row

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -126,7 +126,7 @@ private struct VideoThumbnail: View {
             .overlay(
                 Group {
                     if let url {
-                        RemoteArtworkImage(url: url, cornerRadius: cornerRadius, showsLoading: false)
+                        RemoteArtworkImage(url: url, cornerRadius: cornerRadius)
                     } else {
                         MusicArtworkPlaceholder(cornerRadius: cornerRadius)
                     }

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -260,9 +260,33 @@ struct FullScreenPlayerView: View {
                         lyrics: upcomingLyricsViewModel.lyrics,
                         hasNoLyrics: upcomingLyricsViewModel.hasNoLyrics
                     )
+                } else if upcomingLyricsViewModel.isLoading {
+                    // Prefetch for this song may still be in flight; the
+                    // isLoading handoff below adopts it (or fetches on
+                    // failure) instead of firing a duplicate GET.
                 } else {
                     lyricsViewModel.fetch(songID: id)
                 }
+            }
+        }
+        .onChange(of: upcomingLyricsViewModel.isLoading) { _, isLoading in
+            // Hand off an in-flight prefetch that just settled: adopt it when
+            // it landed for the current song, otherwise fetch fresh.
+            guard !isLoading, !audioManager.isRadioMode,
+                  let id = audioManager.currentSong?.id,
+                  lyricsViewModel.loadedSongID != id
+            else { return }
+            if upcomingLyricsViewModel.loadedSongID == id,
+               !upcomingLyricsViewModel.didFail,
+               !upcomingLyricsViewModel.lyrics.isEmpty || upcomingLyricsViewModel.hasNoLyrics
+            {
+                lyricsViewModel.adopt(
+                    songID: id,
+                    lyrics: upcomingLyricsViewModel.lyrics,
+                    hasNoLyrics: upcomingLyricsViewModel.hasNoLyrics
+                )
+            } else {
+                lyricsViewModel.fetch(songID: id)
             }
         }
         .onChange(of: audioManager.upcomingSong?.id) { _, upcomingId in
@@ -1029,8 +1053,13 @@ struct FullScreenPlayerView: View {
     }
 
     private func resetCoverArtSaveStatusLater() {
+        // A second save may start within the window; only reset if the status
+        // hasn't moved on since this timer was scheduled.
+        let status = coverArtSaveStatus
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            coverArtSaveStatus = .idle
+            if coverArtSaveStatus == status {
+                coverArtSaveStatus = .idle
+            }
         }
     }
 

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -301,10 +301,24 @@ struct QueueView: View {
             return
         }
         let songs = Array(audioManager.queue[(idx + 1)...])
-        // Fresh stable identities per refresh: rows are reorderable, and
-        // positional ForEach identity mis-tracks rows across a move.
+        // Stable identities across refreshes: match each occurrence to the
+        // previous entry with the same (song id, occurrence index) pair, so
+        // identity follows the song occurrence rather than the position — a
+        // moved row keeps its UUID, and minting fresh UUIDs here would destroy
+        // every row (killing sheets/drags) on each track advance.
+        var previousIDs: [String: UUID] = [:]
+        var previousCounts: [String: Int] = [:]
+        for entry in upNextEntries {
+            let occurrence = previousCounts[entry.song.id, default: 0]
+            previousCounts[entry.song.id] = occurrence + 1
+            previousIDs["\(entry.song.id)#\(occurrence)"] = entry.id
+        }
+        var newCounts: [String: Int] = [:]
         upNextEntries = songs.enumerated().map { offset, song in
-            UpNextEntry(song: song, position: offset + 1)
+            let occurrence = newCounts[song.id, default: 0]
+            newCounts[song.id] = occurrence + 1
+            let id = previousIDs["\(song.id)#\(occurrence)"] ?? UUID()
+            return UpNextEntry(id: id, song: song, position: offset + 1)
         }
         // Rows otherwise rely on the source list having warmed these; the queue
         // can outlive that list, so warm the row variants here too.
@@ -318,9 +332,10 @@ struct QueueView: View {
 }
 
 /// Stable identity for a queue row: positional `ForEach` identity mis-tracks
-/// rows while the user reorders the up-next list.
+/// rows while the user reorders the up-next list, so each queue occurrence
+/// gets a UUID that refreshUpNextSongs carries across refreshes.
 private struct UpNextEntry: Identifiable {
-    let id = UUID()
+    let id: UUID
     let song: Song
     /// 1-based display position; also the index into the up-next slice + 1.
     let position: Int

--- a/Twinskaraoke/Features/Radio/RadioQueueView.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueView.swift
@@ -63,8 +63,8 @@ struct RadioQueueView: View {
                         if !history.isEmpty {
                             section(title: "Recently Played") {
                                 VStack(spacing: 0) {
-                                    ForEach(Array(history.enumerated()), id: \.offset) { _, item in
-                                        row(song: item.song, isCurrent: false)
+                                    ForEach(history.enumerated().map { PositionedRadioQueueHistoryItem(offset: $0.offset, item: $0.element) }) { positioned in
+                                        row(song: positioned.item.song, isCurrent: false)
                                         Rectangle()
                                             .fill(Color.appDivider)
                                             .frame(height: 0.5)
@@ -219,5 +219,24 @@ struct RadioQueueView: View {
 
     private var rowTransition: AnyTransition {
         reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .bottom))
+    }
+}
+
+/// Row identity for the radio queue history list. The offset keeps IDs unique
+/// when the same song appears twice (duplicate ForEach IDs can hang
+/// AttributeGraph). The song ID makes the ID change when a poll prepends new
+/// items: with purely positional identity every row keeps its old view, so
+/// all visible artwork flashes back through placeholders on each track change.
+private struct PositionedRadioQueueHistoryItem: Identifiable {
+    struct ID: Hashable {
+        let offset: Int
+        let songID: String
+    }
+
+    let offset: Int
+    let item: RadioNowPlaying.HistoryItem
+
+    var id: ID {
+        ID(offset: offset, songID: item.song.id)
     }
 }

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -426,7 +426,8 @@ struct RadioView: View {
             RadioSectionHeader("New & Recent")
                 .padding(.horizontal, horizontalPadding)
             LazyVStack(spacing: 0) {
-                ForEach(Array(history.prefix(10).enumerated()), id: \.offset) { _, item in
+                ForEach(history.prefix(10).enumerated().map { PositionedRadioHistoryItem(offset: $0.offset, item: $0.element) }) { positioned in
+                    let item = positioned.item
                     Button {
                         showLiveSchedule()
                     } label: {
@@ -449,6 +450,25 @@ struct RadioView: View {
             }
         }
         .accessibilityIdentifier("Radio.HistorySection")
+    }
+}
+
+/// Row identity for the radio history list. The offset keeps IDs unique when
+/// the same song appears twice (duplicate ForEach IDs can hang
+/// AttributeGraph). The song ID makes the ID change when a poll prepends new
+/// items: with purely positional identity every row keeps its old view, so
+/// all visible artwork flashes back through placeholders on each track change.
+private struct PositionedRadioHistoryItem: Identifiable {
+    struct ID: Hashable {
+        let offset: Int
+        let songID: String
+    }
+
+    let offset: Int
+    let item: RadioNowPlaying.HistoryItem
+
+    var id: ID {
+        ID(offset: offset, songID: item.song.id)
     }
 }
 

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -515,9 +515,10 @@ struct GenreDetailView: View {
                 .transition(.opacity)
             }
         }
-        // Keyed on the cache entry so the load re-fires after a memory-warning
-        // purge flips the view back to its loading branch.
-        .task(id: viewModel.allSongs[genre.id] == nil) {
+        // Keyed on the purge generation, not the cache entry: a memory-warning
+        // purge cancels in-flight detail tasks without changing allSongs, so a
+        // nil-entry key would never change and the load would never restart.
+        .task(id: viewModel.detailGeneration) {
             viewModel.loadDetailIfNeeded(for: genre)
         }
     }

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -515,7 +515,9 @@ struct GenreDetailView: View {
                 .transition(.opacity)
             }
         }
-        .task {
+        // Keyed on the cache entry so the load re-fires after a memory-warning
+        // purge flips the view back to its loading branch.
+        .task(id: viewModel.allSongs[genre.id] == nil) {
             viewModel.loadDetailIfNeeded(for: genre)
         }
     }

--- a/Twinskaraoke/Models/Home/HomeViewModel.swift
+++ b/Twinskaraoke/Models/Home/HomeViewModel.swift
@@ -70,10 +70,13 @@ final class HomeViewModel: ObservableObject {
                 topPicksPage = 1
                 canLoadMoreTopPicks = playlists.count == topPicksPageSize
             }
-            let releases = loadedReleases ?? []
-            newReleases = releases
-            latestSingle = releases.first
-            latestSingleContext = releases
+            // Match the sections above: a failed refresh keeps the existing
+            // New Releases shelf instead of erasing it mid-session.
+            if let loadedReleases {
+                newReleases = loadedReleases
+                latestSingle = loadedReleases.first
+                latestSingleContext = loadedReleases
+            }
             isLoading = false
             homeLoadTask = nil
         }

--- a/Twinskaraoke/Models/Home/PlaylistListLoader.swift
+++ b/Twinskaraoke/Models/Home/PlaylistListLoader.swift
@@ -51,6 +51,12 @@ final class PlaylistListLoader: ObservableObject {
                     return
                 }
                 let items = Self.decode(data: data)
+                // An undecodable payload is a server-side anomaly, not the
+                // last page — keep canLoadMore so scrolling retries.
+                guard let items else {
+                    self.isLoadingMore = false
+                    return
+                }
                 if !items.isEmpty {
                     let existing = Set(self.playlists.map(\.id))
                     self.playlists += items.filter { !existing.contains($0.id) }
@@ -68,8 +74,9 @@ final class PlaylistListLoader: ObservableObject {
         }
     }
 
-    private static func decode(data: Data?) -> [Playlist] {
-        guard let data else { return [] }
+    /// Returns nil when the payload matches no known shape; a genuinely
+    /// empty page decodes fine as an empty array.
+    private static func decode(data: Data) -> [Playlist]? {
         let decoder = JSONDecoder()
         if let items = (try? decoder.decode(LossyArray<PlaylistListItem>.self, from: data))?.elements {
             return items.map { $0.asPlaylist() }
@@ -77,6 +84,6 @@ final class PlaylistListLoader: ObservableObject {
         if let items = try? decoder.decode([PlaylistListItem].self, from: data) {
             return items.map { $0.asPlaylist() }
         }
-        return []
+        return nil
     }
 }

--- a/Twinskaraoke/Models/Home/PlaylistListLoader.swift
+++ b/Twinskaraoke/Models/Home/PlaylistListLoader.swift
@@ -9,7 +9,9 @@ final class PlaylistListLoader: ObservableObject {
     private var urlBuilder: ((Int, Int) -> String)?
 
     func bootstrap(initial: [Playlist], urlBuilder: @escaping (Int, Int) -> String) {
-        guard self.urlBuilder == nil else { return }
+        // Re-bootstrap when the view opened before page 1 arrived: the loader
+        // is still empty and loadMoreIfNeeded can't fire on an empty list.
+        guard self.urlBuilder == nil || (playlists.isEmpty && !initial.isEmpty) else { return }
         self.urlBuilder = urlBuilder
         playlists = initial
         canLoadMore = true
@@ -42,6 +44,12 @@ final class PlaylistListLoader: ObservableObject {
             let data = try? await KaraokeAPIClient.data(for: request)
             DispatchQueue.main.async {
                 guard let self else { return }
+                // A nil response is a transient failure — keep canLoadMore so
+                // the next cell onAppear retries instead of disabling pagination.
+                guard let data else {
+                    self.isLoadingMore = false
+                    return
+                }
                 let items = Self.decode(data: data)
                 if !items.isEmpty {
                     let existing = Set(self.playlists.map(\.id))

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -197,7 +197,9 @@ final class LibrarySongsViewModel: ObservableObject {
         }
         rebuildDisplayedSongs()
 
-        canLoadMore = pageSongs.count == pageSize
+        // The server paginates on the unfiltered count; using the filtered
+        // pageSongs here would stop infinite scroll on a page with filtered items.
+        canLoadMore = decoded.count == pageSize
         if !pageSongs.isEmpty || replace {
             self.page = page
         }

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -216,7 +216,10 @@ final class GenresViewModel: ObservableObject {
     private var pendingDetailOrder: [String] = []
     private var pendingDetails: [String: GenreSummary] = [:]
     private var detailTasks: [String: Task<Void, Never>] = [:]
-    private var detailGeneration: UInt64 = 0
+    // Published so views can key work on it: a purge cancels in-flight detail
+    // tasks, and without a generation-keyed restart those views would spin
+    // forever on their loading branch.
+    @Published private(set) var detailGeneration: UInt64 = 0
     private var pageGeneration: UInt64 = 0
     private var detailFailureDates: [String: Date] = [:]
     private let maxConcurrentDetailRequests = 4

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -96,7 +96,8 @@ final class PublicPlaylistsViewModel: ObservableObject {
                 canLoadMore = items.count >= pageSize
             } catch {
                 guard token == requestToken else { return }
-                if replace { playlists = [] }
+                // Keep the current items on a failed replace fetch so the view
+                // can retry instead of landing on a dead-end empty state.
                 canLoadMore = false
             }
             isLoadingMore = false
@@ -257,6 +258,10 @@ final class GenresViewModel: ObservableObject {
 
     func refresh() {
         hasLoaded = false
+        // Bypass the isLoading guard so a pull-to-refresh during the initial
+        // fetch starts a new replace-fetch; the new pageGeneration token in
+        // fetchPage invalidates the in-flight response.
+        isLoading = false
         loadIfNeeded()
     }
 

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -37,6 +37,11 @@ final class SimpleAudioPlayer {
     private var pausedPosition: TimeInterval?
     private var _isPaused = false
     private var scheduleGeneration: UInt64 = 0
+    // True while the node holds a not-yet-consumed scheduled segment. A pause
+    // after natural playback end leaves the segment fully played out, and
+    // resuming such a node would report isPlaying while rendering silence
+    // with no completion ever firing.
+    private(set) var hasScheduledMedia = false
 
     var volume: Float {
         get { playerNode.volume }
@@ -128,6 +133,7 @@ final class SimpleAudioPlayer {
 
     private func invalidateScheduledPlayback() {
         scheduleGeneration &+= 1
+        hasScheduledMedia = false
         // Completion handlers can run when stop() unschedules media. Incrementing
         // first makes those callbacks stale by construction.
         playerNode.stop()
@@ -148,11 +154,13 @@ final class SimpleAudioPlayer {
                 self?.deliverCompletion(for: generation)
             }
         }
+        hasScheduledMedia = true
         return true
     }
 
     private func deliverCompletion(for generation: UInt64) {
         guard scheduleGeneration == generation else { return }
+        hasScheduledMedia = false
         completionHandler?()
     }
 
@@ -754,6 +762,16 @@ final class AVEnginePlayback {
     var isPlaying: Bool {
         if _paused { return false }
         return mainPlayer.isPlaying
+    }
+
+    /// False when the active deck's scheduled segment has fully played out —
+    /// the state end-of-queue leaves behind when it pauses instead of
+    /// stopping. Resuming then would render silence; callers must reload.
+    var hasScheduledMedia: Bool {
+        if mode == .aiStems {
+            return mainPlayer.hasScheduledMedia && stemInstrumental.hasScheduledMedia
+        }
+        return mainPlayer.hasScheduledMedia
     }
 
     func pause() {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -349,7 +349,12 @@ class AudioPlayerManager: ObservableObject {
     private var streamPlaybackRequested = false
     private var remotePlaybackCacheTask: Task<Void, Never>?
     private var remotePlaybackCacheToken: UUID?
+    private var fetchRandomTrendingToken: UUID?
     private var cacheRecoverySongID: String?
+    // Song IDs already sent through enrichSongMetadataIfNeeded this session;
+    // repeat-one loops would otherwise re-issue the search + trending
+    // fallback requests on every replay.
+    private var enrichmentAttemptedSongIDs = Set<String>()
     private var lastKnownPlaybackTime: TimeInterval = 0
     private var pollTimer: Timer?
     // Volume ramps run on a background DispatchSourceTimer (like the engine
@@ -379,7 +384,15 @@ class AudioPlayerManager: ObservableObject {
     private var preparedStemTask: Task<Void, Never>?
     private var backgroundAnalysisRetryTask: Task<Void, Never>?
     private var cacheCompressionTask: Task<Void, Never>?
+    // Set while a stem-switch load is in flight so its failure can drop the
+    // broken stem cache. Must be cleared on every pause/stop/new-play path:
+    // those bump the engine's suppression token, the load completion then
+    // returns early before clearing this, and a stale ID would make a later
+    // unrelated engine error delete a valid stem cache.
     private var aiStemSwitchInFlightSongID: String?
+    // The isPlaybackRequested snapshot of the in-flight stem switch, so a
+    // load failure for a paused switch can fall back without un-pausing.
+    private var aiStemSwitchInFlightShouldResume = true
     private var quickCutTimer: DispatchSourceTimer?
     private var quickCutGeneration: UInt64 = 0
     private var separationGeneration: UInt64 = 0
@@ -515,6 +528,7 @@ class AudioPlayerManager: ObservableObject {
             guard let self else { return }
             DebugLogger.log("AVEngine playback error: \(error)", category: .playback)
             let failedStemSwitchSongID = aiStemSwitchInFlightSongID
+            let failedStemSwitchShouldResume = aiStemSwitchInFlightShouldResume
             aiStemSwitchInFlightSongID = nil
             let pendingTransitionSong: Song? = if case let .crossfading(plan) = transitionCoordinator.state {
                 plan.nextSong
@@ -546,7 +560,11 @@ class AudioPlayerManager: ObservableObject {
                 vocalEnhanceMode = false
                 instrumentalEnhanceMode = false
                 _suppressModeSwitch = false
-                fallBackToMainPlayback(for: song, startAt: lastKnownPlaybackTime)
+                fallBackToMainPlayback(
+                    for: song,
+                    startAt: lastKnownPlaybackTime,
+                    resume: failedStemSwitchSongID != song.id || failedStemSwitchShouldResume
+                )
                 return
             }
             if let song = currentSong, !self.isRadioMode,
@@ -1043,6 +1061,7 @@ class AudioPlayerManager: ObservableObject {
         let startAt = activePlaybackTime(for: song)
         currentPlaybackURL = sourceURL
         aiStemSwitchInFlightSongID = song.id
+        aiStemSwitchInFlightShouldResume = shouldResume
         configureAudioSessionCategory()
         activateAudioSession()
         if shouldResume {
@@ -1304,7 +1323,8 @@ class AudioPlayerManager: ObservableObject {
         song: Song,
         context: [Song] = [],
         resetTransitionVolume: Bool,
-        preserveCacheRecoveryState: Bool = false
+        preserveCacheRecoveryState: Bool = false,
+        reportsPlayCount: Bool = true
     ) {
         if !preserveCacheRecoveryState {
             cacheRecoverySongID = nil
@@ -1322,6 +1342,7 @@ class AudioPlayerManager: ObservableObject {
         cancelPendingTransitionWork(resetVolume: resetTransitionVolume)
         avEngine.cancelCrossfade()
         avEngine.stop()
+        aiStemSwitchInFlightSongID = nil
         instrumentalTask?.cancel()
         instrumentalTask = nil
         preparedStemTask?.cancel()
@@ -1330,7 +1351,9 @@ class AudioPlayerManager: ObservableObject {
         VocalSeparator.shared.cancel()
         VocalSeparator.shared.cancelBackgroundAnalysis()
         VocalSeparator.shared.cleanupRealtimeTemp()
-        reportPlayCount(for: song.id)
+        if reportsPlayCount {
+            reportPlayCount(for: song.id)
+        }
         enrichSongMetadataIfNeeded(for: song)
         if previousSongID != song.id {
             var excludeIDs = activeSongIDs()
@@ -1474,6 +1497,7 @@ class AudioPlayerManager: ObservableObject {
         }
         streamStartedAt = nil
         currentPlaybackURL = url
+        aiStemSwitchInFlightSongID = nil
         configureAudioSessionCategory()
         activateAudioSession()
         NotificationCenter.default.post(name: MediaPlaybackCoordinator.audioWillPlay, object: nil)
@@ -1529,7 +1553,7 @@ class AudioPlayerManager: ObservableObject {
         playerArtworkWarmupTasks.removeAll()
     }
 
-    private func fallBackToMainPlayback(for song: Song, startAt: TimeInterval) {
+    private func fallBackToMainPlayback(for song: Song, startAt: TimeInterval, resume: Bool = true) {
         suppressPlaybackEndedCallbacks()
         stopRadioPlayer()
         stopStreamPlayer()
@@ -1543,6 +1567,18 @@ class AudioPlayerManager: ObservableObject {
             avEngine.revertToMain()
         }
         let resumeAt = max(0, startAt.isFinite ? startAt : 0)
+        guard resume else {
+            // A paused stem switch whose stem load failed must not un-pause:
+            // leave the deck unloaded and keep the position so the next
+            // explicit resume reloads the main file at the same spot.
+            lastKnownPlaybackTime = resumeAt
+            setPlaybackState(
+                playing: false,
+                buffering: false,
+                reason: "fallBackToMainPlayback.paused"
+            )
+            return
+        }
         if let fileURL = localPlaybackFileURL(for: song) {
             startPlayingFile(fileURL, startAt: resumeAt, resetSeparation: false)
             return
@@ -1653,6 +1689,7 @@ class AudioPlayerManager: ObservableObject {
         cancelPendingTransitionWork()
         lastKnownPlaybackTime = activePlaybackTime()
         avEngine.pause()
+        aiStemSwitchInFlightSongID = nil
         setPlaybackState(playing: false, buffering: false, reason: "pause.file.\(source)")
         return true
     }
@@ -1731,8 +1768,13 @@ class AudioPlayerManager: ObservableObject {
             return true
         }
         guard let song = currentSong else { return false }
-        if !isPlaying, avEngine.currentURL == nil {
-            let resumeAt = preferredStreamResumeTime(for: song) ?? lastKnownPlaybackTime
+        // End-of-queue pauses the engine with the deck's scheduled segment
+        // fully consumed but currentURL still set; resuming that node would
+        // report isPlaying while rendering silence, so reload from the start
+        // through the normal start-playing path instead.
+        let deckExhausted = avEngine.currentURL != nil && !avEngine.hasScheduledMedia
+        if !isPlaying, avEngine.currentURL == nil || deckExhausted {
+            let resumeAt = deckExhausted ? 0 : (preferredStreamResumeTime(for: song) ?? lastKnownPlaybackTime)
             if let fileURL = localPlaybackFileURL(for: song) {
                 clearPreferredStreamResumeTime()
                 startPlayingFile(fileURL, startAt: resumeAt)
@@ -1854,7 +1896,8 @@ class AudioPlayerManager: ObservableObject {
         configureAudioSessionCategory()
         activateAudioSession()
         if repeatMode == .one, let current = currentSong {
-            play(song: current)
+            // Repeat-one replay: not a new listen, so don't count it again.
+            play(song: current, context: [], resetTransitionVolume: true, reportsPlayCount: false)
             return
         }
         if let current = currentSong, !queue.isEmpty,
@@ -2093,6 +2136,7 @@ class AudioPlayerManager: ObservableObject {
         }
         cancelPendingTransitionWork()
         avEngine.stop()
+        aiStemSwitchInFlightSongID = nil
         stopStreamPlayer()
         instrumentalTask?.cancel()
         instrumentalTask = nil
@@ -2161,6 +2205,7 @@ class AudioPlayerManager: ObservableObject {
         stopStreamPlayer()
         stopRadioPlayer()
         avEngine.stop()
+        aiStemSwitchInFlightSongID = nil
         currentPlaybackURL = url
         DebugLogger.log(
             "Starting cached remote playback for \(songID): source=\(playbackSourceDescription(url)), startAt=\(startAt), autoplay=\(autoplay)",
@@ -3259,10 +3304,24 @@ class AudioPlayerManager: ObservableObject {
     }
 
     private func fetchRandomTrending() {
+        // Staleness fence (same idea as remotePlaybackCacheToken): the fetch
+        // is unstructured, so if the user starts other playback while it is
+        // in flight, the completion must not stomp that playback.
+        let fenceSongID = currentSong?.id
+        let requestToken = UUID()
+        fetchRandomTrendingToken = requestToken
         Task {
             guard let songs = try? await KaraokeAPIClient.trendingSongs(days: 7, take: 50),
                   let random = songs.randomElement()
             else {
+                // Only touch state/the background task while this request
+                // still owns the playback flow.
+                guard fetchRandomTrendingToken == requestToken, currentSong?.id == fenceSongID else { return }
+                setPlaybackState(
+                    playing: false,
+                    buffering: false,
+                    reason: "fetchRandomTrending.failed"
+                )
                 #if canImport(UIKit)
                     endTrackTransitionBackgroundTask()
                 #endif
@@ -3273,6 +3332,7 @@ class AudioPlayerManager: ObservableObject {
             } else {
                 songs
             }
+            guard fetchRandomTrendingToken == requestToken, currentSong?.id == fenceSongID else { return }
             play(song: random, context: rotatedQueue)
         }
     }
@@ -3289,6 +3349,7 @@ class AudioPlayerManager: ObservableObject {
 
     private func enrichSongMetadataIfNeeded(for song: Song) {
         guard !song.hasArtistMetadata else { return }
+        guard enrichmentAttemptedSongIDs.insert(song.id).inserted else { return }
         let songID = song.id
         Task { [weak self] in
             guard let self else { return }

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -36,6 +36,11 @@ final class TransitionCoordinator {
     private(set) var state: State = .idle
     private var bpmTask: Task<Void, Never>?
     private var predownloadSession: PredownloadSession?
+    // Retry-storm guard: when preparing the upcoming song fails, poll ticks
+    // would otherwise restart prepare+download every 250 ms for the rest of
+    // the prepare window. The record clears once the current song changes.
+    private var failedPreparationCurrentSongID: String?
+    private var failedPreparationNextSongID: String?
 
     weak var avEngine: AVEnginePlayback?
 
@@ -90,6 +95,10 @@ final class TransitionCoordinator {
         aiEffectActive: Bool
     ) {
         guard totalDuration > 0, let currentSong else { return }
+        if failedPreparationCurrentSongID != nil, failedPreparationCurrentSongID != currentSong.id {
+            failedPreparationCurrentSongID = nil
+            failedPreparationNextSongID = nil
+        }
         guard autoMixEnabled || crossfadeEnabled else {
             if case .idle = state {} else { reset() }
             return
@@ -102,6 +111,7 @@ final class TransitionCoordinator {
         case .idle:
             guard remaining <= prepareAt, remaining > 0 else { return }
             if let nextSong = nextSongInQueue(current: currentSong, queue: queue, repeatMode: repeatMode) {
+                guard failedPreparationNextSongID != nextSong.id else { return }
                 beginPreparing(
                     nextSong: nextSong, currentSong: currentSong,
                     autoMixEnabled: autoMixEnabled, crossfadeSeconds: crossfadeSeconds,
@@ -138,11 +148,15 @@ final class TransitionCoordinator {
         bpmTask?.cancel()
         predownloadSession?.cancel()
         predownloadSession = nil
-        bpmTask = Task { [weak self] in
+        // Detached: audioFileURL can synchronously decompress .wav caches
+        // (AudioCacheStore.playableMainURL), blocking file I/O that must not
+        // run on this @MainActor class's executor; results are applied back
+        // on the main actor below.
+        bpmTask = Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
 
-            let currentURL = audioFileURL(for: currentSong)
-            let nextURL = audioFileURL(for: nextSong)
+            let currentURL = await Self.audioFileURL(for: currentSong)
+            let nextURL = await Self.audioFileURL(for: nextSong)
 
             if nextURL == nil, let remoteURL = nextSong.audioURL {
                 DebugLogger.log(
@@ -152,7 +166,7 @@ final class TransitionCoordinator {
                 await predownload(song: nextSong, from: remoteURL)
             }
 
-            let nextFileURL = audioFileURL(for: nextSong)
+            let nextFileURL = await Self.audioFileURL(for: nextSong)
             let shouldAnalyzeBPM = autoMixEnabled && !aiEffectActive
             let outBPM: Double?
             let inBPM: Double?
@@ -186,8 +200,16 @@ final class TransitionCoordinator {
                 rampStyle = .equalPower
             }
 
-            guard let fileURL = audioFileURL(for: nextSong) else {
-                await MainActor.run { [weak self] in self?.reset() }
+            guard let fileURL = await Self.audioFileURL(for: nextSong) else {
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    // Only record the failure (and reset) if this preparation
+                    // is still the active one.
+                    guard case let .preparing(s) = state, s.id == nextSong.id else { return }
+                    failedPreparationCurrentSongID = currentSong.id
+                    failedPreparationNextSongID = nextSong.id
+                    reset()
+                }
                 return
             }
 
@@ -240,7 +262,7 @@ final class TransitionCoordinator {
         return bpm
     }
 
-    static func computeFade(
+    nonisolated static func computeFade(
         outBPM: Double?, inBPM: Double?
     ) -> (duration: TimeInterval, style: AVEnginePlayback.RampStyle) {
         guard let out = outBPM, let inB = inBPM,
@@ -260,12 +282,16 @@ final class TransitionCoordinator {
         }
     }
 
-    static func harmonicBPMDifference(_ a: Double, _ b: Double) -> Double {
+    nonisolated static func harmonicBPMDifference(_ a: Double, _ b: Double) -> Double {
         [b, b * 2, b / 2].map { abs(a - $0) }.min()!
     }
 
-    private func audioFileURL(for song: Song) -> URL? {
-        if let downloaded = DownloadManager.shared.playableURL(for: song) {
+    // nonisolated: AudioCacheStore.playableMainURL may synchronously run
+    // decompressFileIfNeeded for .wav caches — blocking file I/O that must
+    // stay off the main actor (callers on the main actor use the
+    // non-decompressing immediatelyPlayableMainURL variant instead).
+    private nonisolated static func audioFileURL(for song: Song) async -> URL? {
+        if let downloaded = await DownloadManager.shared.playableURL(for: song) {
             return downloaded
         }
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil

--- a/Twinskaraoke/Services/Storage/AudioCacheStore.swift
+++ b/Twinskaraoke/Services/Storage/AudioCacheStore.swift
@@ -401,7 +401,7 @@ nonisolated enum AudioCacheStore {
 
     static func compressAssets(for songID: String) {
         // Match compressIdleAssets: the wav deletes below must hold the same
-        // lock playableURL try-locks before handing a file out.
+        // lock playableURL holds while decompressing and handing a file out.
         guard compressionLock.try() else { return }
         defer { compressionLock.unlock() }
         compressAssets(in: files(for: songID).directory)
@@ -508,21 +508,21 @@ nonisolated enum AudioCacheStore {
     private static func playableURL(for url: URL) -> URL? {
         // Only wav stems ever get a compressed sibling; the compressor never
         // touches other files, so they skip the lock dance entirely. Taking
-        // the try-lock for them would falsely report a cache miss whenever a
-        // long compressIdleAssets sweep holds the lock.
+        // the lock for them would stall reads whenever a long
+        // compressIdleAssets sweep holds it.
         guard shouldCompressPlayableFile(at: url) else {
             guard fm.fileExists(atPath: url.path) else { return nil }
             return validateAndHandOut(url)
         }
-        // The compressor deletes wav files it has compressed; only hand out an
-        // existing file while holding the same lock so it cannot be deleted
-        // between the existence check and the return. When the lock is busy,
-        // fall through to the compressed copy instead of racing the delete.
-        if compressionLock.try() {
-            defer { compressionLock.unlock() }
-            if fm.fileExists(atPath: url.path) {
-                return validateAndHandOut(url)
-            }
+        // The compressor deletes wav files it has compressed; hold the same
+        // lock across the existence check, decompression, validation, and
+        // handout so the file cannot be deleted or replaced mid-flight.
+        // Blocking acquire is fine: decompressing callers run on background
+        // threads (main-thread paths use the immediatelyPlayable variants).
+        compressionLock.lock()
+        defer { compressionLock.unlock() }
+        if fm.fileExists(atPath: url.path) {
+            return validateAndHandOut(url)
         }
         let compressed = compressedURL(for: url)
         guard fm.fileExists(atPath: compressed.path) else { return nil }
@@ -703,7 +703,11 @@ nonisolated enum AudioCacheStore {
     }
 
     private static func compressFile(from sourceURL: URL, to destinationURL: URL) throws {
-        let tempURL = destinationURL.appendingPathExtension("tmp")
+        // Per-operation temp name: cache operations for the same destination
+        // must never share (and corrupt) a temp file.
+        let tempURL = destinationURL
+            .appendingPathExtension(UUID().uuidString)
+            .appendingPathExtension("tmp")
         try? fm.removeItem(at: tempURL)
         fm.createFile(atPath: tempURL.path, contents: nil)
 
@@ -738,7 +742,11 @@ nonisolated enum AudioCacheStore {
     }
 
     private static func decompressFileIfNeeded(from sourceURL: URL, to destinationURL: URL) throws {
-        let tempURL = destinationURL.appendingPathExtension("tmp")
+        // Per-operation temp name: cache operations for the same destination
+        // must never share (and corrupt) a temp file.
+        let tempURL = destinationURL
+            .appendingPathExtension(UUID().uuidString)
+            .appendingPathExtension("tmp")
         try? fm.removeItem(at: tempURL)
         fm.createFile(atPath: tempURL.path, contents: nil)
 

--- a/Twinskaraoke/Services/User/AuthManager.swift
+++ b/Twinskaraoke/Services/User/AuthManager.swift
@@ -31,6 +31,7 @@ final class AuthManager: NSObject, ObservableObject {
     private let defaults = UserDefaults.standard
     private var webAuthenticationSession: ASWebAuthenticationSession?
     private var webAuthenticationContextProvider: WebAuthenticationPresentationContextProvider?
+    private var sessionExpiredObserver: NSObjectProtocol?
 
     private enum K {
         static let userId = "nk.userId"
@@ -58,7 +59,7 @@ final class AuthManager: NSObject, ObservableObject {
     override init() {
         super.init()
         loadPersisted()
-        NotificationCenter.default.addObserver(
+        sessionExpiredObserver = NotificationCenter.default.addObserver(
             forName: .karaokeSessionExpired,
             object: nil,
             queue: .main
@@ -66,6 +67,14 @@ final class AuthManager: NSObject, ObservableObject {
             Task { @MainActor [weak self] in
                 self?.handleExpiredSession()
             }
+        }
+    }
+
+    deinit {
+        // AccountView mints a fresh AuthManager per visit; without removal
+        // the block-based observer would accumulate for the app's lifetime.
+        if let sessionExpiredObserver {
+            NotificationCenter.default.removeObserver(sessionExpiredObserver)
         }
     }
 

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -315,13 +315,14 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   }
 
   var artistName: String {
-    // decodeArtists can yield a non-nil empty array ("coverArtists": []), so
-    // filter empties and fall back like displayArtist instead of returning "".
-    let originals = originalArtists?.filter { !$0.isEmpty } ?? []
+    // decodeArtists can yield a non-nil empty array ("coverArtists": []), and
+    // directly constructed songs can carry whitespace-only entries, so filter
+    // blanks and fall back like displayArtist instead of returning "".
+    let originals = originalArtists?.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty } ?? []
     if !originals.isEmpty {
       return originals.joined(separator: ", ")
     }
-    let covers = coverArtists?.filter { !$0.isEmpty } ?? []
+    let covers = coverArtists?.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty } ?? []
     return covers.isEmpty ? String(localized: "Unknown Artist") : covers.joined(separator: ", ")
   }
 

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -304,11 +304,10 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   var displayArtist: String {
     let original = originalArtists?.filter { !$0.isEmpty }.joined(separator: ", ") ?? ""
     let cover = coverArtists?.filter { !$0.isEmpty }.joined(separator: ", ") ?? ""
-    let coverBy = String(localized: "Cover by \(cover)")
     switch (original.isEmpty, cover.isEmpty) {
-    case (false, false): return "\(original) · \(coverBy)"
+    case (false, false): return "\(original) · \(String(localized: "Cover by \(cover)"))"
     case (false, true): return original
-    case (true, false): return coverBy
+    case (true, false): return String(localized: "Cover by \(cover)")
     case (true, true):
       let apiProvidedArtists = originalArtists != nil || coverArtists != nil
       return apiProvidedArtists ? String(localized: "Unknown Artist") : ""
@@ -316,10 +315,14 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   }
 
   var artistName: String {
-    if let originals = originalArtists, !originals.isEmpty {
+    // decodeArtists can yield a non-nil empty array ("coverArtists": []), so
+    // filter empties and fall back like displayArtist instead of returning "".
+    let originals = originalArtists?.filter { !$0.isEmpty } ?? []
+    if !originals.isEmpty {
       return originals.joined(separator: ", ")
     }
-    return coverArtists?.joined(separator: ", ") ?? String(localized: "Unknown Artist")
+    let covers = coverArtists?.filter { !$0.isEmpty } ?? []
+    return covers.isEmpty ? String(localized: "Unknown Artist") : covers.joined(separator: ", ")
   }
 
   var hasArtistMetadata: Bool {

--- a/TwinskaraokeShared/Services/ArtworkURLBuilder.swift
+++ b/TwinskaraokeShared/Services/ArtworkURLBuilder.swift
@@ -126,8 +126,10 @@ nonisolated enum ArtworkURLBuilder {
   private static func isResizeOptionsSegment(_ segment: String) -> Bool {
     let options = segment.split(separator: ",")
     return !options.isEmpty && options.allSatisfy { option in
-      let pair = option.split(separator: "=", maxSplits: 1)
-      return pair.count == 2 && resizeOptionKeys.contains(String(pair[0]))
+      // Exactly one '=' with non-empty key and value: "width=300=x.jpg" is a
+      // real filename, not an option list.
+      let pair = option.split(separator: "=", omittingEmptySubsequences: false)
+      return pair.count == 2 && !pair[1].isEmpty && resizeOptionKeys.contains(String(pair[0]))
     }
   }
 

--- a/TwinskaraokeShared/Services/ArtworkURLBuilder.swift
+++ b/TwinskaraokeShared/Services/ArtworkURLBuilder.swift
@@ -102,7 +102,7 @@ nonisolated enum ArtworkURLBuilder {
       path = String(path[..<range.lowerBound])
     } else if !path.hasSuffix("/public") {
       let parts = path.split(separator: "/")
-      if let last = parts.last, last.contains("=") {
+      if let last = parts.last, isResizeOptionsSegment(String(last)) {
         path = "/" + parts.dropLast().joined(separator: "/")
       }
     }
@@ -113,6 +113,22 @@ nonisolated enum ArtworkURLBuilder {
 
     let deliveryPath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
     return deliveryPath.isEmpty ? nil : deliveryPath
+  }
+
+  // Legacy resize URLs end in a cdn-cgi option list (e.g. "width=180,quality=78").
+  // Only a trailing segment of comma-separated key=value pairs with known option
+  // keys counts as resize options, so real filenames containing "=" (e.g.
+  // "cover=final.jpg") are not mangled into 404s.
+  private static let resizeOptionKeys: Set<String> = [
+    "width", "height", "quality", "format", "fit", "blur", "dpr", "gravity",
+  ]
+
+  private static func isResizeOptionsSegment(_ segment: String) -> Bool {
+    let options = segment.split(separator: ",")
+    return !options.isEmpty && options.allSatisfy { option in
+      let pair = option.split(separator: "=", maxSplits: 1)
+      return pair.count == 2 && resizeOptionKeys.contains(String(pair[0]))
+    }
   }
 
   private static func storageDeliveryPath(from rawPath: String) -> String? {

--- a/TwinskaraokeShared/Services/CredentialStore.swift
+++ b/TwinskaraokeShared/Services/CredentialStore.swift
@@ -35,9 +35,14 @@ nonisolated enum CredentialStore {
     if cacheGeneration == generation {
       cachedToken = resolved
       tokenCacheValid = true
+      tokenCacheLock.unlock()
+      return resolved
     }
+    // A save/delete raced the cold read: the resolved value may be a revoked
+    // token, so hand out the current cached value (nil if it was cleared).
+    let current = tokenCacheValid ? cachedToken : nil
     tokenCacheLock.unlock()
-    return resolved
+    return current
   }
 
   private static func resolveToken() -> String? {

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -144,11 +144,18 @@ actor PlaylistDetailCache {
   func invalidate(playlistID: String) {
     entries[playlistID] = nil
     generations[playlistID, default: 0] &+= 1
+    // Cancel the in-flight load so awaiters get CancellationError (and
+    // re-fetch) instead of the pre-mutation payload, and the multi-MB
+    // download stops instead of running to completion.
+    inFlight[playlistID]?.task.cancel()
     inFlight[playlistID] = nil
   }
 
   func invalidateAll() {
     entries.removeAll()
+    // Same as invalidate(playlistID:): cancel in-flight loads so signout
+    // awaiters can't resolve with the previous user's payload.
+    inFlight.values.forEach { $0.task.cancel() }
     inFlight.removeAll()
     epoch &+= 1
   }
@@ -165,7 +172,9 @@ actor FavoriteCatalogMetadataCache {
 
   private let lifetime: TimeInterval
   private var cachedValue: Entry?
-  private var inFlight: (key: String, id: UUID, task: Task<[Song], Error>)?
+  // Keyed like PlaylistDetailCache so a concurrent request with a different
+  // key doesn't clobber the slot and fire a duplicate POST.
+  private var inFlight: [String: (id: UUID, task: Task<[Song], Error>)] = [:]
   // Bumped on invalidate() so a fetch started before signout can't re-cache
   // the previous user's favorites when it resolves.
   private var epoch = 0
@@ -187,13 +196,13 @@ actor FavoriteCatalogMetadataCache {
 
     let startEpoch = epoch
     let request: (id: UUID, task: Task<[Song], Error>)
-    if let inFlight, inFlight.key == key {
-      request = (inFlight.id, inFlight.task)
+    if let existing = inFlight[key] {
+      request = existing
     } else {
       let id = UUID()
       let task = Task { try await loader() }
       request = (id, task)
-      inFlight = (key, id, task)
+      inFlight[key] = request
     }
 
     do {
@@ -201,13 +210,13 @@ actor FavoriteCatalogMetadataCache {
       if epoch == startEpoch {
         cachedValue = Entry(key: key, songs: songs, expiresAt: now.addingTimeInterval(lifetime))
       }
-      if inFlight?.id == request.id {
-        inFlight = nil
+      if inFlight[key]?.id == request.id {
+        inFlight[key] = nil
       }
       return songs
     } catch {
-      if inFlight?.id == request.id {
-        inFlight = nil
+      if inFlight[key]?.id == request.id {
+        inFlight[key] = nil
       }
       throw error
     }
@@ -215,7 +224,7 @@ actor FavoriteCatalogMetadataCache {
 
   func invalidate() {
     cachedValue = nil
-    inFlight = nil
+    inFlight.removeAll()
     epoch &+= 1
   }
 }
@@ -395,7 +404,7 @@ nonisolated enum KaraokeAPIClient {
   static func playlistSongCount(id: String) async throws -> Int? {
     let data = try await playlistDetailData(id: id)
     if let playlist = try? decode(Playlist.self, from: data) {
-      return playlist.songListDTOs?.count ?? (playlist.songCount > 0 ? playlist.songCount : nil)
+      return playlist.songListDTOs?.count ?? max(playlist.songCount, 0)
     }
     return SongPayloadDecoder.decodeSongs(from: data)?.count
   }

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -1025,4 +1025,34 @@ struct SongModelTests {
         )
         #expect(mixedBlanks.artistName == "ABBA")
     }
+
+    @Test("artistName falls back for whitespace-only artist entries")
+    func artistNameFallsBackForWhitespaceOnlyArtists() {
+        // Directly constructed songs skip the decoder's whitespace trimming.
+        let whitespaceCover = Song(
+            id: "song-whitespace-cover",
+            title: "Test Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: ["   "],
+            userUploaded: false
+        )
+        let whitespaceOriginal = Song(
+            id: "song-whitespace-original",
+            title: "Test Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: [" "],
+            coverArtists: nil,
+            userUploaded: false
+        )
+
+        #expect(whitespaceCover.artistName == "Unknown Artist")
+        #expect(whitespaceOriginal.artistName == "Unknown Artist")
+    }
 }

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -967,4 +967,62 @@ struct SongModelTests {
         #expect(song.displayArtist == "Original · Cover by Neuro")
         #expect(song.hasArtistMetadata)
     }
+
+    @Test("artistName falls back to Unknown Artist for empty artist arrays")
+    func artistNameFallsBackForEmptyArtistArrays() {
+        let emptyCoverArtists = Song(
+            id: "song-empty-cover",
+            title: "Test Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: nil,
+            coverArtists: [],
+            userUploaded: false
+        )
+        let emptyOriginalArtists = Song(
+            id: "song-empty-original",
+            title: "Test Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: [],
+            coverArtists: nil,
+            userUploaded: false
+        )
+
+        #expect(emptyCoverArtists.artistName == "Unknown Artist")
+        #expect(emptyOriginalArtists.artistName == "Unknown Artist")
+    }
+
+    @Test("artistName ignores blank artist entries")
+    func artistNameIgnoresBlankArtistEntries() throws {
+        // FlexibleArtistList trims whitespace-only artists, so a blank entry
+        // decodes to a non-nil empty array and must not surface as "".
+        let json = """
+        {
+          "id": "song-blank-artist",
+          "title": "Test Song",
+          "duration": 180,
+          "coverArtists": ["   "]
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Song.self, from: json)
+        #expect(decoded.artistName == "Unknown Artist")
+
+        let mixedBlanks = Song(
+            id: "song-mixed-blanks",
+            title: "Test Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: ["", "ABBA"],
+            coverArtists: nil,
+            userUploaded: false
+        )
+        #expect(mixedBlanks.artistName == "ABBA")
+    }
 }

--- a/TwinskaraokeWatchApp/Features/Library/PlaylistDetailView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/PlaylistDetailView.swift
@@ -69,7 +69,7 @@ struct PlaylistDetailView: View {
                         let song = item.song
                         let isCurrent = audioManager.currentSong?.id == song.id
                         Button {
-                            play(song)
+                            play(item)
                         } label: {
                             WatchSongRow(
                                 song: song,
@@ -127,6 +127,18 @@ struct PlaylistDetailView: View {
             return "\(hours)h \(minutes)m"
         }
         return "\(minutes)m"
+    }
+
+    // Row taps pass the row item so a repeated song starts at the tapped
+    // occurrence; play(song:context:) would resolve the first match instead.
+    private func play(_ item: PlaylistSongRowItem) {
+        if audioManager.currentSong?.id != item.song.id {
+            audioManager.playSong(at: item.offset, context: viewModel.songs)
+            WatchHaptic.play(.start)
+        } else {
+            WatchHaptic.play(.click)
+        }
+        showPlayer = true
     }
 
     private func play(_ song: Song) {

--- a/TwinskaraokeWatchApp/Features/Library/PlaylistDetailView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/PlaylistDetailView.swift
@@ -64,7 +64,9 @@ struct PlaylistDetailView: View {
                 .listRowBackground(Color.clear)
 
                 Section {
-                    ForEach(Array(viewModel.songs.enumerated()), id: \.element.id) { offset, song in
+                    ForEach(indexedSongs) { item in
+                        let offset = item.offset
+                        let song = item.song
                         let isCurrent = audioManager.currentSong?.id == song.id
                         Button {
                             play(song)
@@ -99,6 +101,14 @@ struct PlaylistDetailView: View {
         }
         .onAppear {
             viewModel.fetchSongs()
+        }
+    }
+
+    // Karaoke setlists legitimately repeat a song and Song identity is the id
+    // alone, so rows use a composite id to keep ForEach identifiers unique.
+    private var indexedSongs: [PlaylistSongRowItem] {
+        viewModel.songs.enumerated().map { offset, song in
+            PlaylistSongRowItem(id: "\(song.id)#\(offset)", offset: offset, song: song)
         }
     }
 
@@ -264,4 +274,11 @@ private struct WatchPlaylistHeaderButton: View {
         .buttonStyle(.watchPressable)
         .accessibilityLabel(title)
     }
+}
+
+
+private struct PlaylistSongRowItem: Identifiable {
+    let id: String
+    let offset: Int
+    let song: Song
 }

--- a/TwinskaraokeWatchApp/Features/Player/QueueView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/QueueView.swift
@@ -61,9 +61,11 @@ struct QueueView: View {
             }
             if !upNext.isEmpty {
                 Section("Playing Next") {
-                    ForEach(Array(upNext.enumerated()), id: \.element.id) { offset, song in
+                    ForEach(indexedUpNext) { item in
+                        let offset = item.offset
+                        let song = item.song
                         Button {
-                            audioManager.play(song: song, context: audioManager.queue)
+                            audioManager.playUpNext(at: offset)
                             WatchHaptic.play(.start)
                         } label: {
                             WatchQueuedSongRow(song: song, offset: offset, total: upNext.count)
@@ -117,6 +119,14 @@ struct QueueView: View {
 
     private var upNextSongs: [Song] {
         audioManager.upNextSongs
+    }
+
+    // Karaoke setlists legitimately repeat a song and Song identity is the id
+    // alone, so rows use a composite id to keep ForEach identifiers unique.
+    private var indexedUpNext: [QueuedSongRowItem] {
+        upNextSongs.enumerated().map { offset, song in
+            QueuedSongRowItem(id: "\(song.id)#\(offset)", offset: offset, song: song)
+        }
     }
 
     private func toggleCurrentPlayback() {
@@ -374,4 +384,11 @@ private struct WatchQueueProgressRing: View {
         }
         .frame(width: 28, height: 28)
     }
+}
+
+
+private struct QueuedSongRowItem: Identifiable {
+    let id: String
+    let offset: Int
+    let song: Song
 }

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -117,6 +117,18 @@ class AudioManager: ObservableObject {
         prepareAndPlay()
     }
 
+    /// Plays the up-next row at `offset`. The queue position is picked by
+    /// offset rather than by song lookup so tapping a repeated song targets
+    /// that occurrence instead of the first match in the queue.
+    func playUpNext(at offset: Int) {
+        guard let baseIndex = resolvedCurrentQueueIndex else { return }
+        let index = baseIndex + 1 + offset
+        guard queue.indices.contains(index) else { return }
+        currentIndex = index
+        currentSong = queue[index]
+        prepareAndPlay()
+    }
+
     private func prepareAndPlay() {
         cleanupPlayer()
         currentTime = 0
@@ -180,6 +192,10 @@ class AudioManager: ObservableObject {
     }
 
     private func setupPlayer(with localURL: URL) {
+        // Raced async cache validations can both reach here for one song;
+        // tear down any existing player and its observers so two players
+        // never run at once and no orphaned observer keeps firing.
+        cleanupPlayer()
         do {
             try AVAudioSession.sharedInstance().setCategory(
                 .playback, mode: .default, policy: .longFormAudio
@@ -603,6 +619,10 @@ class AudioManager: ObservableObject {
         recoveringFromBrokenCache.insert(songID)
         try? FileManager.default.removeItem(at: playbackURL)
         cleanupPlayer()
+        // As in prepareAndPlay, drop the dead player's Combine sinks; this
+        // also drops the session handlers, so re-register them.
+        cancellables.removeAll()
+        setupInterruptionHandler()
         isLoading = true
         downloadTask?.cancel()
         downloadToken = nil

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -42,6 +42,9 @@ class AudioManager: ObservableObject {
     private var timeObserver: Any?
     private var endTimeObserver: NSObjectProtocol?
     private var cancellables = Set<AnyCancellable>()
+    // Player-item/player publishers live here so cleanupPlayer can drop them
+    // without touching the audio-session handlers in `cancellables`.
+    private var playerCancellables = Set<AnyCancellable>()
     private var downloadTask: URLSessionDownloadTask?
     private var downloadToken: UUID?
     private var remoteCommandTargets: [(command: MPRemoteCommand, target: Any)] = []
@@ -114,6 +117,17 @@ class AudioManager: ObservableObject {
         }
         queue = playbackQueue
         currentSong = song
+        prepareAndPlay()
+    }
+
+    /// Plays the song at `index` in `context`. The position is picked by
+    /// index rather than by song lookup so tapping a repeated song targets
+    /// that occurrence instead of the first match in the context.
+    func playSong(at index: Int, context: [Song]) {
+        guard context.indices.contains(index) else { return }
+        queue = context
+        currentIndex = index
+        currentSong = context[index]
         prepareAndPlay()
     }
 
@@ -215,7 +229,7 @@ class AudioManager: ObservableObject {
                     self?.duration = seconds
                 }
             }
-            .store(in: &cancellables)
+            .store(in: &playerCancellables)
         playerItem.publisher(for: \.status)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in
@@ -235,13 +249,13 @@ class AudioManager: ObservableObject {
                     }
                 }
             }
-            .store(in: &cancellables)
+            .store(in: &playerCancellables)
         player.publisher(for: \.timeControlStatus, options: [.initial, .new])
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshPlaybackState()
             }
-            .store(in: &cancellables)
+            .store(in: &playerCancellables)
         let interval = CMTime(seconds: 0.5, preferredTimescale: 600)
         timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) {
             [weak self] time in
@@ -440,6 +454,10 @@ class AudioManager: ObservableObject {
     }
 
     private func cleanupPlayer() {
+        // Drop the player's Combine sinks first: a raced second setupPlayer
+        // would otherwise leave the old player's status callbacks firing
+        // against the replacement.
+        playerCancellables.removeAll()
         if let observer = timeObserver {
             player?.removeTimeObserver(observer)
             timeObserver = nil


### PR DESCRIPTION
## What this is

A broad audit of the whole codebase (iOS, watchOS, shared services), fixing 29 verified findings in 7 area-scoped commits. Build succeeds for iOS + embedded watch app; all 91 unit tests pass (including new regression tests).

## Commits

**`fix: content-sensitive row identity in Random Songs and radio lists`**
- `RandomSongsView` had the same positional-`ForEach` bug class fixed in #69: Refresh replaced the song set at identical offsets, so reused rows kept showing the previous song *and* its per-row download state subscription, badge, and VoiceOver actions. Rows now use content-sensitive identity; accessibility identifiers include the offset.
- Radio history lists (`RadioView`, `RadioQueueView`) are wholesale-replaced by the 15 s poll with items prepended; positional identity made every visible row flash through artwork placeholders on each track change. Now keyed by offset + song id.

**`fix: watch double-player race and duplicate list identities`**
- Raced async cache validations could both complete and start two `AVPlayer`s at once (double audio); `setupPlayer` now tears down the existing player and its observers first.
- Playlist/queue lists used id-only `ForEach` identity — duplicate for repeated setlist songs; now composite `song.id#offset`.
- Tapping a repeated song in Up Next played the first copy; taps now target the exact queue occurrence.
- `recoverFromBrokenCache` drops the dead player's Combine sinks (re-registering audio-session handlers).

**`fix: audio engine stale-state and race fixes`**
- Resume after natural end-of-queue no longer produces a silent zombie "playing" state (frozen progress, no completion): an exhausted deck reloads from the start via the normal play path.
- `fetchRandomTrending` is fenced so an in-flight autoplay fetch can't stomp playback the user started manually; its failure path clears the playing state.
- Transition predownload no longer retry-storms for the whole ~30 s prepare window when the next song can't be fetched.
- A failed stem switch initiated while paused no longer starts playing out loud.
- `aiStemSwitchInFlightSongID` is cleared on every suppression-token-bump path, so a later unrelated engine error can't delete a valid stem cache.
- Repeat-one replays no longer re-report play counts or re-fetch metadata every loop.
- The BPM probe task is detached so WAV decompression can't run on the main actor.

**`fix: stem decompression race and artwork retry/cleanup`**
- Stem decompression ran outside the compression lock with a shared temp name; concurrent decompressions could interleave writes, install a corrupt wav, and delete the valid compressed cache. Lock is now held across decompress+validate+handout; temp files are per-operation unique.
- `ArtworkFailureBackoff` is now observable — views composed during the 300 s failure window retry when it expires instead of showing a placeholder forever.
- Removed the dead second `WebImage` layer in `SongRow` (identical `lowResURL`), a dead `FallbackArtProvider` subscription, and the dead `showsLoading` parameter (~13 call sites).

**`fix: pagination and refresh dead-ends in view models`**
- Library songs infinite scroll used the *filtered* page count; one filtered item permanently stopped pagination.
- `PlaylistListLoader` re-bootstraps when the view opened before page 1, and a transient fetch failure no longer permanently disables pagination.
- Pull-to-refresh is no longer silently dropped during in-flight loads (genres), no longer erases New Releases on failure (Home), and no longer wipes the public-playlists list.
- Genre detail reloads after a memory-warning cache purge instead of spinning forever.
- Playlists grid no longer flashes a false "No Playlists" empty state on cold open.
- `UploadedSongsView` prefetch diffing no longer allocates on every body evaluation.

**`fix: shared model and cache correctness`**
- `Song.artistName` fell through to `""` for non-nil empty artist arrays (blank artist on watch Now Playing / accessibility); now falls back to localized "Unknown Artist" (+ regression tests).
- `ArtworkURLBuilder` stripped any path segment containing `=`, mangling real filenames like `cover=final.jpg` into 404s; now only strips actual resize-option segments.
- Empty playlists cache a resolved count of 0 instead of refetching on every row appearance.
- `PlaylistDetailCache.invalidate*` cancels in-flight fetches so stale awaiters don't render pre-mutation payloads.
- `FavoriteCatalogMetadataCache` tracks in-flight requests per key (no more clobbered slots / duplicate POSTs).
- `CredentialStore` no longer returns a just-deleted token when a cold read races `deleteToken()`.

**`fix: queue row identity stability, lyrics dedupe, observer leak`**
- `QueueView` minted fresh row UUIDs on every track advance, destroying rows — dismissing open Add-to-Playlist sheets mid-edit and cancelling drag-reorders. Identities are now carried across refreshes by (song id, occurrence) matching.
- Quick-skipping into a song whose lyrics prefetch is in flight no longer fires a duplicate GET.
- Cover-art save status reset is fenced against a second save starting inside the 2 s window.
- `AuthManager` removes its session-expired observer in `deinit`; every Account tab visit previously leaked one permanent observer.

## Verification

- `xcodebuild build` — iOS app + embedded watch app, clean.
- `xcodebuild test -only-testing:TwinskaraokeTests` on iPhone 17 simulator — **91/91 pass**, including new `artistName` fallback regression tests.
- Debug console reviewed on device: remaining log noise is system/third-party (Gboard keyboard constraints, LNPopupController trait getter, URLSession churn from deliberate prefetch cancellation) — no regressions observed.

## Not included (deliberately)

- 401 handling: any single 401 currently forces logout + Keychain deletion. A fix needs an auth-policy decision (probe-before-logout), not a drive-by.
- Five Settings toggles persist but are not wired to any behavior (Audio Quality, Auto-Download, Sync Library, Add-to-Library toggles) — unimplemented features.
- Dead `streamPlayer` layer in `AudioPlayerManager` — sizable deletion, better as its own PR.
- Captcha easter-egg web view can't close on success (`window.close()` is ignored for natively-created WKWebViews).
- Missing zh-Hans/zh-Hant translations for `"1 song"` and `"Cover by %@"`.

## Summary by Sourcery

Fix multiple playback, queue, artwork, pagination, and caching edge cases across iOS and watchOS to eliminate stale UI, races, and dead-end states.

Bug Fixes:
- Prevent stem-switch failures while paused from unintentionally resuming playback or corrupting stem caches, and avoid zombie playing states by reloading from the start after end-of-queue.
- Guard random autoplay fetching so failures clear playback state and in-flight requests cannot override user-initiated playback.
- Stop repeat-one loops from double-counting plays or re-fetching metadata, and deduplicate lyrics prefetches when quickly skipping tracks.
- Stabilize ForEach row identities for random songs, radio history, queues, and watch playlist/up-next lists so repeated songs and refreshes no longer mis-track or destroy rows.
- Ensure watch playback uses a single AVPlayer instance, retargets taps on repeated up-next songs to the correct occurrence, and correctly re-establishes audio-session handlers after cache recovery.
- Hold the audio cache compression lock across decompression and use per-operation temp files so concurrent cache operations cannot corrupt WAV assets.
- Make artwork failure backoff observable so tiles automatically retry after cooldown instead of showing placeholders forever, and remove unused artwork-loading props and fallback subscriptions.
- Fix pagination and refresh behavior for library songs, playlists, public playlists, genres, and genre detail so transient failures or filtered pages no longer permanently halt loading or wipe existing content.
- Correct playlist song-count handling so empty playlists are cached as zero instead of being repeatedly refetched.
- Tighten shared caches and credential storage so playlist-detail awaiters are cancelled on invalidation, favorite-metadata requests are keyed per query, and racing token deletes don’t leak revoked tokens.
- Ensure playlist grids and home New Releases preserve existing content during loads, avoiding spurious empty states or erasing shelves on failed refreshes.
- Update cover-art save status reset logic so rapid consecutive saves don’t prematurely clear user-visible status.
- Fix AuthManager to remove its session-expired observer on deinit, preventing observer leaks across Account tab visits.
- Normalize artist metadata so empty or blank artist arrays fall back to localized Unknown Artist and non-empty entries are preserved, including new regression tests.
- Update ArtworkURLBuilder to only strip true resize-option segments so filenames containing '=' no longer get mangled into 404s.

Tests:
- Add regression tests covering Song.artistName behavior for empty and blank artist arrays to ensure the Unknown Artist fallback and non-blank names are handled correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artwork loading, retry, fallback, and failure recovery across galleries, playlists, artists, and player screens.
  * Fixed playlist, song, and radio list identity issues to prevent duplicate rows, incorrect updates, and placeholder flashing.
  * Improved pagination, refresh, caching, and retry behavior for playlists, genres, and library content.
  * Preserved home content during failed refreshes and corrected artist-name fallbacks.
  * Improved lyrics synchronization, playback recovery, queue navigation, and cover-art save status handling.
  * Fixed artwork URL handling and audio file concurrency issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->