### PR TITLE
fix: inactive star on favorited songs — read favorites from the playlist's source

### DIFF
--- a/Twinskaraoke/Services/User/FavoritesManager.swift
+++ b/Twinskaraoke/Services/User/FavoritesManager.swift
@@ -59,14 +59,16 @@ final class FavoritesManager: ObservableObject {
         let generation = stateGeneration
         Task {
             let ok = await send(songID: songID)
+            if ok {
+                // Serialize invalidation ahead of the reload below: a racing
+                // load()/reload() must not read the pre-toggle list from the
+                // cache and commit stale star state as loaded.
+                await KaraokeAPIClient.invalidateFavoriteSongs()
+            }
             await MainActor.run {
                 guard stateGeneration == generation else { return }
                 inFlight.remove(songID)
-                if ok {
-                    // Drop the cached favorite-song list so the next read
-                    // reflects the toggle.
-                    Task { await KaraokeAPIClient.invalidateFavoriteSongs() }
-                } else {
+                if !ok {
                     if wasFavorite {
                         favoriteIDs.insert(songID)
                     } else {
@@ -94,8 +96,14 @@ final class FavoritesManager: ObservableObject {
         // (starred songs showed an inactive star everywhere), while
         // favoriteSongs() returns the complete set and shares the
         // FavoriteSongsCache with the playlist.
-        guard let songs = try? await KaraokeAPIClient.favoriteSongs()
-        else {
+        let songs: [Song]
+        do {
+            songs = try await KaraokeAPIClient.favoriteSongs()
+        } catch {
+            DebugLogger.log(
+                "Favorites load failed: \(error.localizedDescription)",
+                category: .network
+            )
             if stateGeneration == generation {
                 lastLoadFailure = Date()
             }

--- a/Twinskaraoke/Services/User/FavoritesManager.swift
+++ b/Twinskaraoke/Services/User/FavoritesManager.swift
@@ -89,8 +89,12 @@ final class FavoritesManager: ObservableObject {
                 scheduleReloadAfterMutationsIfNeeded()
             }
         }
-        guard let req = try? KaraokeAPIClient.request(path: "/api/user/favorites"),
-              let data = try? await KaraokeAPIClient.data(for: req)
+        // Read from the same source as the Favorites playlist. The old
+        // /api/user/favorites ID list did not match the playlist's songs
+        // (starred songs showed an inactive star everywhere), while
+        // favoriteSongs() returns the complete set and shares the
+        // FavoriteSongsCache with the playlist.
+        guard let songs = try? await KaraokeAPIClient.favoriteSongs()
         else {
             if stateGeneration == generation {
                 lastLoadFailure = Date()
@@ -102,8 +106,7 @@ final class FavoritesManager: ObservableObject {
             reloadAfterMutations = true
             return
         }
-        let ids = Self.parseIDs(from: data)
-        favoriteIDs = Set(ids)
+        favoriteIDs = Set(songs.map(\.id))
         loaded = true
         lastLoadFailure = nil
     }
@@ -123,20 +126,5 @@ final class FavoritesManager: ObservableObject {
         else { return false }
         req.httpMethod = "PUT"
         return (try? await KaraokeAPIClient.data(for: req)) != nil
-    }
-
-    private static func parseIDs(from data: Data) -> [String] {
-        if let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
-            return arr.compactMap { $0["id"] as? String ?? $0["songId"] as? String }
-        }
-        if let arr = try? JSONSerialization.jsonObject(with: data) as? [String] {
-            return arr
-        }
-        if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let arr = (obj["favorites"] ?? obj["items"]) as? [[String: Any]]
-        {
-            return arr.compactMap { $0["id"] as? String ?? $0["songId"] as? String }
-        }
-        return []
     }
 }

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -407,7 +407,12 @@ nonisolated enum KaraokeAPIClient {
         queryItems: [URLQueryItem(name: "type", value: "0")]
       )
       let data = try await data(for: request)
-      let songs = SongPayloadDecoder.decodeSongs(from: data) ?? []
+      // A valid empty list decodes fine; nil means no known shape matched,
+      // which must surface as an error rather than an empty favorites list
+      // (callers treat [] as authoritative star state).
+      guard let songs = SongPayloadDecoder.decodeSongs(from: data) else {
+        throw APIError.decodeFailed
+      }
       return try await hydrateFavoriteSongs(songs)
     }
   }


### PR DESCRIPTION
## Bug

While listening to a large playlist on shuffle, songs that were already starred (and visible in the Favorites playlist) showed an **inactive star** in the player, and their context menu offered "Favorite" instead of "Remove from Favorites". Starring a new song worked fine for the rest of the session.

## Root cause

Star state and the Favorites playlist read from **two different endpoints**:

- The Favorites playlist loads via `GET /api/favorites/type?type=0` (full song list — demonstrably complete, since the songs show up there).
- `FavoritesManager` (the `favoriteIDs` set behind every star icon and menu label) loaded `GET /api/user/favorites` and parsed it with a shape-guessing `parseIDs` helper that prefers `id` over `songId`. Whatever that endpoint returns — favorite records whose `id` is not the song id, or a paginated/envelope shape — the parsed IDs don't match the songs, so `isFavorite(song.id)` is false for songs the user actually starred.

In-session toggles masked the bug: `toggle()` inserts the song ID into the local set optimistically, so stars looked correct until the next cold start reloaded the mismatched set.

## Fix

`FavoritesManager.load()` now builds the ID set from `KaraokeAPIClient.favoriteSongs()` — the exact call that backs the Favorites playlist — so star state and the playlist share one source of truth and can no longer drift. It also shares the 60 s `FavoriteSongsCache` with the playlist (invalidated on every toggle), so this typically adds no extra request. The guess-the-shape `parseIDs` helper is deleted.

One file changed: `Twinskaraoke/Services/User/FavoritesManager.swift` (+15/−28).

## Verification

- Diagnosed against the live app: context menu on an old starred song showed "Favorite (star off)" (set missing the ID), fresh toggle lit the star immediately (writes fine).
- Build succeeds (iOS + watch app).
- On-device check after installing: previously starred songs should show the active star in the player and "Remove from Favorites" in menus without any toggling.

## Summary by Sourcery

Align favorites state with the Favorites playlist by reading favorite song IDs from the same API source instead of a mismatched user favorites endpoint.

Bug Fixes:
- Ensure previously favorited songs correctly show an active star and "Remove from Favorites" in menus by syncing FavoritesManager with the playlist-backed favorites API.

Enhancements:
- Simplify FavoritesManager by removing generic JSON ID parsing and deriving favorite IDs directly from favorite song models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of favorite songs for more consistent results.
  * Favorite song IDs now stay synchronized with the shared favorites playlist and cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->