### PR TITLE
Fix a crash, off-main blocking work, and main-thread render regressions

### DIFF
--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -38,13 +38,13 @@ struct SearchView: View {
                             .transition(.opacity)
                     } else if let errorMessage = viewModel.searchErrorMessage,
                               viewModel.results.isEmpty,
-                              !viewModel.searchText.isEmpty
+                              viewModel.hasActiveQuery
                     {
                         SearchErrorStateView(message: errorMessage) {
                             viewModel.retrySearch()
                         }
                         .transition(subtleStateTransition)
-                    } else if viewModel.results.isEmpty, !viewModel.searchText.isEmpty {
+                    } else if viewModel.results.isEmpty, viewModel.hasActiveQuery {
                         SearchNoResultsStateView(query: viewModel.searchText)
                             .transition(resultsEmptyTransition)
                     } else if viewModel.results.isEmpty {

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -84,7 +84,15 @@ final class PublicPlaylistsViewModel: ObservableObject {
             // defer, not a trailing statement: the token guards below return
             // from the whole closure, which would otherwise strand
             // isLoadingMore at true and permanently block pagination.
-            defer { isLoadingMore = false }
+            //
+            // Only the request that still owns the token clears the flag. A
+            // superseded load-more clearing it would let pagination restart
+            // from stale playlists while the replacing fetch is still in
+            // flight. Whichever request is newest always matches, so the flag
+            // still cannot be stranded.
+            defer {
+                if token == requestToken { isLoadingMore = false }
+            }
             do {
                 let items = try await KaraokeAPIClient.publicPlaylists(
                     startIndex: startIndex,
@@ -536,6 +544,20 @@ final class SearchViewModel: ObservableObject {
     @Published var searchText = ""
     @Published var isSearching = false
     @Published var searchErrorMessage: String?
+
+    /// Whether the field holds a query the search pipeline would actually run.
+    /// Views must branch on this rather than `!searchText.isEmpty`: the
+    /// pipeline trims before searching, so whitespace-only input clears the
+    /// results, and a raw emptiness check would then show a "no results" state
+    /// for a query that was never issued instead of the browse categories.
+    ///
+    /// Deliberately a derived value: `searchText` is two-way bound to the
+    /// search field, so trimming it at publish time would swallow spaces as
+    /// the user types them.
+    var hasActiveQuery: Bool {
+        !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     private var cancellables = Set<AnyCancellable>()
     private var queryToken: Int = 0
     private var searchTask: Task<Void, Never>?

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -81,6 +81,10 @@ final class PublicPlaylistsViewModel: ObservableObject {
         let token = requestToken
         Task { [weak self] in
             guard let self else { return }
+            // defer, not a trailing statement: the token guards below return
+            // from the whole closure, which would otherwise strand
+            // isLoadingMore at true and permanently block pagination.
+            defer { isLoadingMore = false }
             do {
                 let items = try await KaraokeAPIClient.publicPlaylists(
                     startIndex: startIndex,
@@ -100,7 +104,6 @@ final class PublicPlaylistsViewModel: ObservableObject {
                 // can retry instead of landing on a dead-end empty state.
                 canLoadMore = false
             }
-            isLoadingMore = false
         }
     }
 
@@ -539,6 +542,10 @@ final class SearchViewModel: ObservableObject {
 
     init() {
         $searchText
+            // Trim before removeDuplicates so edits that only change
+            // surrounding whitespace ("abc" -> "abc ") don't refire an
+            // identical search request.
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .removeDuplicates()
             .sink { [weak self] query in

--- a/Twinskaraoke/Services/Artwork/ArtworkPalette.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPalette.swift
@@ -26,9 +26,19 @@ nonisolated struct ArtworkPalette: Equatable {
     #if canImport(UIKit)
         init(image: UIImage) {
             let samples = ArtworkPalette.dominantColors(image: image, count: 4)
+            // Non-empty by construction: the placeholder supplies four colors.
             let safe = samples.isEmpty ? Self.placeholder.allColors() : samples
-            let padded = (safe + safe + safe).prefix(4)
-            let arr = Array(padded)
+            // Cycle rather than concatenating a fixed number of copies.
+            // `safe + safe + safe` only reaches four entries when `safe` holds
+            // at least two colors, and a near-monochrome cover (or one whose
+            // top buckets all collapse under the dedup filter in
+            // dominantColors) can yield exactly one — leaving the fourth
+            // subscript out of range.
+            var arr: [UIColor] = []
+            arr.reserveCapacity(4)
+            while arr.count < 4 {
+                arr.append(safe[arr.count % safe.count])
+            }
             primary = Color(arr[0])
             secondary = Color(arr[1])
             tertiary = Color(arr[2])
@@ -52,10 +62,15 @@ nonisolated struct ArtworkPalette: Equatable {
             else { return [] }
             let bpp = max(cg.bitsPerPixel / 8, 4)
             let rowBytes = cg.bytesPerRow
+            // bpp is floored at 4 regardless of the real pixel size, so a
+            // non-RGBA context would make these offsets outrun the buffer.
+            // An overread is worse than a crash, so bound it explicitly.
+            let byteCount = CFDataGetLength(data)
             var buckets: [UInt32: (count: Int, saturation: CGFloat, brightness: CGFloat)] = [:]
             for y in stride(from: 0, to: Int(size.height), by: 2) {
                 for x in stride(from: 0, to: Int(size.width), by: 2) {
                     let offset = y * rowBytes + x * bpp
+                    guard offset >= 0, offset + 2 < byteCount else { continue }
                     let r = bytes[offset]
                     let g = bytes[offset + 1]
                     let b = bytes[offset + 2]

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -306,22 +306,33 @@ final class TransitionCoordinator {
     }
 
     private func predownload(song: Song, from remoteURL: URL) async {
+        let session = PredownloadSession(
+            songID: song.id,
+            expectedDuration: song.duration > 0 ? TimeInterval(song.duration) : nil,
+            remoteURL: remoteURL
+        )
+        // Register before starting so a concurrent reset()/beginPreparing() can
+        // always find this session to cancel it.
+        predownloadSession = session
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            let session = PredownloadSession(
-                songID: song.id,
-                expectedDuration: song.duration > 0 ? TimeInterval(song.duration) : nil,
-                remoteURL: remoteURL
-            )
-            self.predownloadSession = session
             session.onCompletion = { [weak self] in
                 DebugLogger.log(
                     "Predownload finished for next transition track \(song.id)",
                     category: .playback
                 )
-                self?.predownloadSession = nil
+                // Identity check: a newer preparation may already have installed
+                // its own session, which this late completion must not clear.
+                if self?.predownloadSession === session {
+                    self?.predownloadSession = nil
+                }
                 continuation.resume()
             }
-            session.start(from: remoteURL)
+            // start() calls AudioCacheStore.playableMainURL, which can
+            // synchronously decompress a whole .nkz into a .wav — blocking file
+            // I/O that must never run on this @MainActor class's executor.
+            Task.detached(priority: .utility) {
+                session.start(from: remoteURL)
+            }
             if Task.isCancelled {
                 session.cancel()
             }
@@ -431,6 +442,14 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
     }
 
     func start(from remoteURL: URL) {
+        // start() is dispatched off the main actor, so cancel() can win the
+        // race. Bail out rather than kicking off a download nobody awaits —
+        // cancel() has already resumed the continuation via finish().
+        stateLock.lock()
+        let cancelled = isCancelled
+        stateLock.unlock()
+        guard !cancelled else { return }
+
         self.remoteURL = remoteURL
         if AudioCacheStore.playableMainURL(for: songID, expectedRemoteURL: remoteURL, expectedDuration: expectedDuration) != nil {
             DebugLogger.log("Predownload cache hit for \(songID)", category: .playback)

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -446,11 +446,14 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
         // race. Bail out rather than kicking off a download nobody awaits —
         // cancel() has already resumed the continuation via finish().
         stateLock.lock()
-        let cancelled = isCancelled
+        let alreadyCancelled = isCancelled
+        if !alreadyCancelled { self.remoteURL = remoteURL }
         stateLock.unlock()
-        guard !cancelled else { return }
+        guard !alreadyCancelled else { return }
 
-        self.remoteURL = remoteURL
+        // The cache probe below can synchronously decompress a whole file, so
+        // it must run without the lock held — cancel() runs on the main actor
+        // and would block behind it.
         if AudioCacheStore.playableMainURL(for: songID, expectedRemoteURL: remoteURL, expectedDuration: expectedDuration) != nil {
             DebugLogger.log("Predownload cache hit for \(songID)", category: .playback)
             finish()
@@ -459,8 +462,7 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
         DebugLogger.log("Predownload start for \(songID) from \(remoteURL.lastPathComponent)", category: .playback)
         try? FileManager.default.removeItem(at: partialURL)
         FileManager.default.createFile(atPath: partialURL.path, contents: nil)
-        fileHandle = try? FileHandle(forWritingTo: partialURL)
-        guard fileHandle != nil else {
+        guard let handle = try? FileHandle(forWritingTo: partialURL) else {
             try? FileManager.default.removeItem(at: partialURL)
             finish()
             return
@@ -471,9 +473,31 @@ private final class PredownloadSession: NSObject, URLSessionDataDelegate, @unche
         configuration.waitsForConnectivity = false
         configuration.timeoutIntervalForRequest = 30
         configuration.timeoutIntervalForResource = 180
-        session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-        task = session?.dataTask(with: remoteURL)
-        task?.resume()
+        let newSession = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        let newTask = newSession.dataTask(with: remoteURL)
+
+        // Re-check and publish atomically. cancel() may have run during the
+        // cache probe and file setup above, when session/task were still nil
+        // and it therefore had nothing to tear down — without this the
+        // download would start untracked and run to completion unobserved.
+        stateLock.lock()
+        if isCancelled {
+            stateLock.unlock()
+            newTask.cancel()
+            newSession.invalidateAndCancel()
+            handle.closeFile()
+            try? FileManager.default.removeItem(at: partialURL)
+            // cancel() already resumed the continuation via finish().
+            return
+        }
+        fileHandle = handle
+        session = newSession
+        task = newTask
+        stateLock.unlock()
+
+        // Safe outside the lock: a cancel() landing here sees the published
+        // task and cancels it, making this resume a no-op.
+        newTask.resume()
     }
 
     func cancel() {

--- a/Twinskaraoke/Services/Debug/DebugLogger.swift
+++ b/Twinskaraoke/Services/Debug/DebugLogger.swift
@@ -9,9 +9,26 @@ nonisolated enum LogCategory: String {
     case network = "Network"
     case ui = "UI"
 
+    // Cached per category: this is read on every log call, and constructing an
+    // OSLog handle each time throws away the one the system already made.
     var osLog: OSLog {
-        OSLog(subsystem: "com.xiaoyuan151.Twinskaraoke", category: rawValue)
+        switch self {
+        case .cache: Self.cacheLog
+        case .ai: Self.aiLog
+        case .playback: Self.playbackLog
+        case .separation: Self.separationLog
+        case .network: Self.networkLog
+        case .ui: Self.uiLog
+        }
     }
+
+    private static let subsystem = "com.xiaoyuan151.Twinskaraoke"
+    private static let cacheLog = OSLog(subsystem: subsystem, category: LogCategory.cache.rawValue)
+    private static let aiLog = OSLog(subsystem: subsystem, category: LogCategory.ai.rawValue)
+    private static let playbackLog = OSLog(subsystem: subsystem, category: LogCategory.playback.rawValue)
+    private static let separationLog = OSLog(subsystem: subsystem, category: LogCategory.separation.rawValue)
+    private static let networkLog = OSLog(subsystem: subsystem, category: LogCategory.network.rawValue)
+    private static let uiLog = OSLog(subsystem: subsystem, category: LogCategory.ui.rawValue)
 }
 
 nonisolated enum DebugLogger {

--- a/Twinskaraoke/Services/Storage/CacheManager.swift
+++ b/Twinskaraoke/Services/Storage/CacheManager.swift
@@ -572,6 +572,10 @@ final class CacheManager: ObservableObject {
         }
     }
 
+    // Deliberately per-call: ByteCountFormatter is not Sendable and not
+    // thread-safe, and this is called from both the maintenance queue and the
+    // main actor. Caching one instance would be a data race, and this is a
+    // cold path (one maintenance pass, eviction logs, Settings size labels).
     private nonisolated func formatBytes(_ bytes: UInt64) -> String {
         let formatter = ByteCountFormatter()
         formatter.allowedUnits = [.useMB, .useGB]

--- a/TwinskaraokeShared/Components/AppMotion.swift
+++ b/TwinskaraokeShared/Components/AppMotion.swift
@@ -55,14 +55,13 @@ extension View {
     }
 }
 
-private struct ReduceMotionInjector: View {
-    let content: AnyView
+// Generic over Content rather than boxing in AnyView: this wraps the root of
+// every view tree, and an AnyView there erases the static type SwiftUI relies
+// on to diff the whole app structurally.
+private struct ReduceMotionInjector<Content: View>: View {
+    let content: Content
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
-
-    init(content: some View) {
-        self.content = AnyView(content)
-    }
 
     var body: some View {
         content.environment(\.appReduceMotion, AppMotion.reduceMotion(

--- a/TwinskaraokeTVApp/Services/TVQRSignInService.swift
+++ b/TwinskaraokeTVApp/Services/TVQRSignInService.swift
@@ -230,7 +230,12 @@ nonisolated enum TVQRSignIn {
 /// OS versions do parse a short fraction like `…:13.5+00:00`, but that leniency
 /// isn't contractual and this formatter is already known to differ across them.
 /// A second pass drops the fraction entirely in case the server stops sending it.
-private func parseTimestamp(_ raw: String) -> Date? {
+/// `nonisolated` is required, not cosmetic: the target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so this would otherwise be
+/// implicitly `@MainActor` while being called from `Decodable.init(from:)` —
+/// which `JSONDecoder` runs off the main thread. The body is pure (its
+/// formatters are local), so there is nothing to isolate.
+private nonisolated func parseTimestamp(_ raw: String) -> Date? {
     let withFraction = ISO8601DateFormatter()
     withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     let plain = ISO8601DateFormatter()

--- a/TwinskaraokeTests/ArtworkPaletteRegressionTests.swift
+++ b/TwinskaraokeTests/ArtworkPaletteRegressionTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+import UIKit
+@testable import Twinskaraoke
+
+@Suite("Artwork palette")
+struct ArtworkPaletteRegressionTests {
+    private func solidImage(_ color: UIColor, size: CGSize = CGSize(width: 64, height: 64)) -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    @Test("A single dominant color still fills all four palette slots")
+    func singleDominantColorDoesNotTrapOnFourthSlot() {
+        // A solid mid-gray cover collapses to exactly one bucket in
+        // dominantColors. The old padding (`safe + safe + safe`) produced only
+        // three entries in that case, so reading the fourth trapped with
+        // "Index out of range".
+        let palette = ArtworkPalette(image: solidImage(.gray))
+
+        #expect(palette.primary == palette.quaternary)
+        #expect(palette.allColors().count == 4)
+    }
+
+    @Test("Near-black and near-white covers fall back to the placeholder")
+    func fullyFilteredImageFallsBackToPlaceholder() {
+        // Every pixel is discarded by the brightness filter, so dominantColors
+        // returns nothing and the placeholder supplies all four colors.
+        for color in [UIColor.black, UIColor.white] {
+            let palette = ArtworkPalette(image: solidImage(color))
+            #expect(palette.allColors().count == 4)
+        }
+    }
+
+    @Test("A multi-color cover keeps four distinct slots")
+    func multiColorImageFillsFourSlots() {
+        let size = CGSize(width: 64, height: 64)
+        let image = UIGraphicsImageRenderer(size: size).image { context in
+            let colors: [UIColor] = [.systemRed, .systemGreen, .systemBlue, .systemOrange]
+            for (index, color) in colors.enumerated() {
+                color.setFill()
+                context.fill(
+                    CGRect(x: 0, y: CGFloat(index) * 16, width: 64, height: 16)
+                )
+            }
+        }
+
+        #expect(ArtworkPalette(image: image).allColors().count == 4)
+    }
+}

--- a/TwinskaraokeTests/ArtworkPaletteRegressionTests.swift
+++ b/TwinskaraokeTests/ArtworkPaletteRegressionTests.swift
@@ -12,6 +12,17 @@ struct ArtworkPaletteRegressionTests {
         }
     }
 
+    /// Compares in RGB space rather than by `UIColor` equality, which also
+    /// takes the color space into account and so can report two visually
+    /// identical colors as different after a `Color` round-trip.
+    private func rgbDistance(_ lhs: UIColor, _ rhs: UIColor) -> CGFloat {
+        var r1: CGFloat = 0, g1: CGFloat = 0, b1: CGFloat = 0, a1: CGFloat = 0
+        var r2: CGFloat = 0, g2: CGFloat = 0, b2: CGFloat = 0, a2: CGFloat = 0
+        lhs.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+        rhs.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+        return ((r1 - r2) * (r1 - r2) + (g1 - g2) * (g1 - g2) + (b1 - b2) * (b1 - b2)).squareRoot()
+    }
+
     @Test("A single dominant color still fills all four palette slots")
     func singleDominantColorDoesNotTrapOnFourthSlot() {
         // A solid mid-gray cover collapses to exactly one bucket in
@@ -19,26 +30,45 @@ struct ArtworkPaletteRegressionTests {
         // three entries in that case, so reading the fourth trapped with
         // "Index out of range".
         let palette = ArtworkPalette(image: solidImage(.gray))
+        let colors = palette.allColors()
 
-        #expect(palette.primary == palette.quaternary)
-        #expect(palette.allColors().count == 4)
+        #expect(colors.count == 4)
+        // One sample cycled into every slot, so all four agree.
+        for color in colors {
+            #expect(rgbDistance(color, colors[0]) < 0.01)
+        }
     }
 
     @Test("Near-black and near-white covers fall back to the placeholder")
     func fullyFilteredImageFallsBackToPlaceholder() {
         // Every pixel is discarded by the brightness filter, so dominantColors
         // returns nothing and the placeholder supplies all four colors.
+        let expected = ArtworkPalette.placeholder.allColors()
         for color in [UIColor.black, UIColor.white] {
-            let palette = ArtworkPalette(image: solidImage(color))
-            #expect(palette.allColors().count == 4)
+            let actual = ArtworkPalette(image: solidImage(color)).allColors()
+            #expect(actual.count == 4)
+            for (index, component) in expected.enumerated() {
+                #expect(rgbDistance(actual[index], component) < 0.01)
+            }
         }
     }
 
-    @Test("A multi-color cover keeps four distinct slots")
+    @Test("A multi-color cover fills the slots with distinct colors")
     func multiColorImageFillsFourSlots() {
         let size = CGSize(width: 64, height: 64)
         let image = UIGraphicsImageRenderer(size: size).image { context in
-            let colors: [UIColor] = [.systemRed, .systemGreen, .systemBlue, .systemOrange]
+            // Explicit RGB, not system colors: dominantColors discards anything
+            // with HSV brightness above 0.97, and most system colors peg a
+            // channel at 1.0. These four sit inside the brightness window and
+            // are far enough apart to survive the near-duplicate filter. They
+            // are also stable across OS versions, unlike the dynamic system
+            // palette.
+            let colors: [UIColor] = [
+                UIColor(red: 0.80, green: 0.20, blue: 0.20, alpha: 1),
+                UIColor(red: 0.20, green: 0.70, blue: 0.30, alpha: 1),
+                UIColor(red: 0.20, green: 0.30, blue: 0.85, alpha: 1),
+                UIColor(red: 0.85, green: 0.75, blue: 0.15, alpha: 1),
+            ]
             for (index, color) in colors.enumerated() {
                 color.setFill()
                 context.fill(
@@ -47,6 +77,16 @@ struct ArtworkPaletteRegressionTests {
             }
         }
 
-        #expect(ArtworkPalette(image: image).allColors().count == 4)
+        let palette = ArtworkPalette(image: image)
+        let colors = palette.allColors()
+        #expect(colors.count == 4)
+        // Distinct slots: this is what separates a genuine four-color
+        // extraction from the single-color path cycling one sample.
+        for i in colors.indices {
+            for j in colors.indices where j > i {
+                #expect(rgbDistance(colors[i], colors[j]) > 0.05)
+            }
+        }
+        #expect(palette != ArtworkPalette.placeholder)
     }
 }

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -669,9 +669,10 @@ class AudioManager: ObservableObject {
         // Oldest first; both budgets drop the least-recently-played files.
         // Stat each file once up front rather than inside the comparator, which
         // would re-hit the filesystem twice per comparison.
+        let keySet = Set(keys)
         let sorted = files
             .map { url -> (url: URL, date: Date, size: Int) in
-                let values = try? url.resourceValues(forKeys: Set(keys))
+                let values = try? url.resourceValues(forKeys: keySet)
                 return (
                     url: url,
                     date: values?.contentModificationDate ?? .distantPast,

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -667,19 +667,23 @@ class AudioManager: ObservableObject {
             )
         else { return }
         // Oldest first; both budgets drop the least-recently-played files.
-        let sorted = files.sorted {
-            let d1 =
-                (try? $0.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
-                    ?? .distantPast
-            let d2 =
-                (try? $1.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
-                    ?? .distantPast
-            return d1 < d2
-        }
+        // Stat each file once up front rather than inside the comparator, which
+        // would re-hit the filesystem twice per comparison.
+        let sorted = files
+            .map { url -> (url: URL, date: Date, size: Int) in
+                let values = try? url.resourceValues(forKeys: Set(keys))
+                return (
+                    url: url,
+                    date: values?.contentModificationDate ?? .distantPast,
+                    size: values?.fileSize ?? 0
+                )
+            }
+            .sorted { $0.date < $1.date }
         var keptCount = 0
         var keptBytes = 0
-        for (index, file) in sorted.reversed().enumerated() {
-            let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+        for (index, entry) in sorted.reversed().enumerated() {
+            let file = entry.url
+            let size = entry.size
             if index == 0 || (keptCount < maxCount && keptBytes + size <= maxBytes) {
                 keptCount += 1
                 keptBytes += size


### PR DESCRIPTION
## Summary

Seven fixes found by a sweep across the iOS, watchOS and tvOS targets, plus one crash caught during on-device testing. Two commits: the sweep, then the crash fix with its regression coverage.

## Crash: index out of range in artwork palette extraction

Hit on device while skipping tracks quickly, which pushes many covers through the extractor in succession.

`ArtworkPalette.init(image:)` padded its color list with `(safe + safe + safe).prefix(4)`, which only reaches four entries when `safe` holds at least two colors. The `isEmpty` check covered zero, but exactly one dominant color produced three entries and trapped on the fourth subscript.

One color is reachable two ways: the brightness filter (`v < 0.08 || v > 0.97`) can discard everything but a single bucket on a very dark or blown-out cover, and the near-duplicate filter (`distance < 0.18`) can collapse a colorful cover whose top buckets are perceptually close.

The list is now cycled until four slots are filled — what the tripling was reaching for, and correct for any non-empty input.

This also bounds the pixel reads in `dominantColors`. `bpp` is floored at `max(bitsPerPixel / 8, 4)` regardless of the real pixel size, so a non-RGBA context would let `bytes[offset + 2]` outrun the buffer. Not reachable today since the drawing context is always RGBA, but a silent out-of-bounds read is a worse failure mode than a trap.

## Audio transitions no longer decompress on the main actor

`TransitionCoordinator.predownload` is `@MainActor`-isolated and reached `PredownloadSession.start`, which calls `AudioCacheStore.playableMainURL` — the decompressing variant, which can expand an entire `.nkz` into a `.wav` synchronously. `AudioPlayerManager.cacheRemoteAudio` and `DownloadManager.promotePlaybackCacheIfAvailable` are both already `nonisolated` with comments explaining exactly this hazard; this call site had been missed, so preparing a crossfade could stall the UI mid-playback.

`start()` now runs off the main actor. Deferring it lets `cancel()` win the race, so three supporting changes came with it:

- `start()` bails out when already cancelled, instead of beginning a download nobody awaits.
- The session is registered *before* `start()`, so `reset()`/`beginPreparing()` can always find it to cancel.
- A late completion only clears `predownloadSession` when it still owns it, so it cannot clear a newer preparation's session.

## tvOS sign-in decoded dates on the wrong actor

The target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, making the file-scope `parseTimestamp` implicitly `@MainActor` — while it is invoked from `Decodable.init(from:)`, which `JSONDecoder` runs off the main thread. The body is pure (its formatters are local), so it is now `nonisolated`. This also clears the tvOS target's only two Swift 6 concurrency warnings.

## Pagination and search

- `PublicPlaylistsViewModel` could strand `isLoadingMore` at `true`. The stale-token guards `return` from the whole task closure, skipping the trailing reset, after which `loadMoreIfNeeded` refuses to paginate again. Moved to a `defer`.
- `SearchViewModel` now trims before `removeDuplicates`, so edits that only change surrounding whitespace (`"abc"` → `"abc "`) no longer refire an identical search request.

## Rendering and allocation

- `ReduceMotionInjector` boxed its content in `AnyView` while wrapping the root of **both** the iOS and tvOS view trees, erasing the static type SwiftUI uses to diff the app structurally. Now generic over `Content`.
- `LogCategory.osLog` built a fresh `OSLog` handle on every log call; now cached per category.
- The watch cache eviction pass called `resourceValues` twice per sort comparison. Now decorates once up front, matching `CacheManager.filesOrderedByDate`.

`CacheManager.formatBytes` keeps its per-call formatter, now with a comment recording why: `ByteCountFormatter` is neither `Sendable` nor thread-safe, and `formatBytes` is `nonisolated` and reached from both the maintenance queue and the main actor. Caching one instance there would be a data race.

## Verification

All 205 source files were force-recompiled; every target is warning-free.

| Target | Result |
| --- | --- |
| iOS (Swift 6 language mode) | builds clean, tests pass |
| watchOS | builds clean |
| tvOS | builds clean |

New coverage in `ArtworkPaletteRegressionTests`: the single-color case, the fully filtered fallback, and a multi-color baseline. The single-color test was confirmed to **fail** against the previous padding before the fix was applied, so it genuinely pins the crash rather than passing vacuously.

The crossfade change was additionally exercised on device with the rapid track-skipping that surfaced the palette crash, without incident.

## Summary by Sourcery

Fix audio predownload concurrency to avoid blocking work on the main actor, harden artwork palette extraction, and address minor correctness and performance issues across platforms.

Bug Fixes:
- Prevent artwork palette generation from trapping when only a single dominant color is detected and guard against out-of-bounds pixel reads.
- Ensure audio transition predownload sessions can be cancelled reliably and no longer perform synchronous decompression on the main actor.
- Fix public playlist pagination getting stuck with loading state permanently enabled after stale-token checks.
- Avoid unnecessary duplicate search requests when only whitespace around the query changes.
- Resolve tvOS sign-in timestamp parsing from running on the wrong actor under default MainActor isolation.

Enhancements:
- Cache OSLog instances per log category instead of recreating them for each log call.
- Make the global reduce-motion injector generic over content instead of boxing the root view tree in AnyView to improve SwiftUI diffing and rendering behavior.
- Optimize watchOS audio cache eviction by stat-ing files once before sorting and reuse those values in the eviction loop.
- Clarify the nonisolated, per-call design of CacheManager byte formatting to avoid data races while formatting cache sizes.

Tests:
- Add regression tests for artwork palette generation covering single-color, fully filtered, and multi-color images to pin the crash and behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playlist pagination so loading reliably recovers after interrupted or failed requests.
  - Prevented unnecessary duplicate searches when only surrounding whitespace changes.
  - Improved artwork color palette generation for edge-case images.
  - Made audio preloading more reliable when playback transitions are cancelled or restarted.
  - Improved cache cleanup consistency while enforcing storage limits.

- **Accessibility**
  - Improved reduced-motion handling with more efficient view rendering.

- **Performance**
  - Improved logging and background audio preparation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->