### PR TITLE
Fix crossfade actor isolation crash

### DIFF
--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -236,10 +236,6 @@ final class AVEnginePlayback {
     private nonisolated static let constrainedMemoryThreshold: UInt64 = 4 * 1024 * 1024 * 1024
     private nonisolated static let constrainedTransitionTicksPerSecond: Double = 18
     private nonisolated static let defaultTransitionTicksPerSecond: Double = 24
-    private nonisolated static let crossfadeRampQueue = DispatchQueue(
-        label: "com.Mag1cByt3s.Twinskaraoke.crossfade-ramp",
-        qos: .userInteractive
-    )
 
     init() {
         let outputSampleRate = engine.outputNode.outputFormat(forBus: 0).sampleRate
@@ -1009,7 +1005,9 @@ final class AVEnginePlayback {
                 let startMainVolume = self.crossfadeStartMainVol
                 let startVocalsVolume = self.crossfadeStartVocalsVol
                 let startInstrumentalVolume = self.crossfadeStartInstrumentalVol
-                let timer = DispatchSource.makeTimerSource(queue: Self.crossfadeRampQueue)
+                // AVEnginePlayback and its player nodes are main-actor
+                // isolated. Keep the ramp handler on that executor too.
+                let timer = DispatchSource.makeTimerSource(queue: .main)
                 timer.schedule(
                     deadline: .now() + playbackLeadTime,
                     repeating: Self.transitionTimerInterval,
@@ -1037,15 +1035,11 @@ final class AVEnginePlayback {
                     incomingNode.volume = max(0, inVolume)
                     guard t >= 1, !completionDispatched else { return }
                     completionDispatched = true
-                    DispatchQueue.main.async {
-                        MainActor.assumeIsolated {
-                            guard let self,
-                                  self.crossfadeRampGeneration == rampGeneration,
-                                  self.isCrossfading
-                            else { return }
-                            self.finalizeCrossfade()
-                        }
-                    }
+                    guard let self,
+                          self.crossfadeRampGeneration == rampGeneration,
+                          self.isCrossfading
+                    else { return }
+                    self.finalizeCrossfade()
                 }
                 self.crossfadeTimer = timer
                 timer.resume()

--- a/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
+++ b/Twinskaraoke/Services/Audio/AVEnginePlayback.swift
@@ -1015,6 +1015,11 @@ final class AVEnginePlayback {
                 )
                 var completionDispatched = false
                 timer.setEventHandler { [weak self] in
+                    guard let self,
+                          self.crossfadeRampGeneration == rampGeneration,
+                          self.isCrossfading
+                    else { return }
+
                     let elapsed = max(0, ProcessInfo.processInfo.systemUptime - startUptime)
                     let t = Float(min(1, elapsed / fadeDuration))
                     let outVolume: Float
@@ -1035,10 +1040,6 @@ final class AVEnginePlayback {
                     incomingNode.volume = max(0, inVolume)
                     guard t >= 1, !completionDispatched else { return }
                     completionDispatched = true
-                    guard let self,
-                          self.crossfadeRampGeneration == rampGeneration,
-                          self.isCrossfading
-                    else { return }
                     self.finalizeCrossfade()
                 }
                 self.crossfadeTimer = timer

--- a/TwinskaraokeTests/AVEnginePlaybackRegressionTests.swift
+++ b/TwinskaraokeTests/AVEnginePlaybackRegressionTests.swift
@@ -91,8 +91,8 @@ struct AVEnginePlaybackRegressionTests {
         engine.stop()
     }
 
-    @Test("Crossfade ramp stays on the audio engine actor")
-    func crossfadeRampUsesMainActor() async throws {
+    @Test("Crossfade promotes the incoming track and clears transition state")
+    func crossfadeCompletesHandoff() async throws {
         let sourceURL = try makeSilentWaveFile(duration: 2, sampleRate: 48_000)
         let incomingURL = try makeSilentWaveFile(duration: 2, sampleRate: 48_000)
         defer {
@@ -116,6 +116,8 @@ struct AVEnginePlaybackRegressionTests {
         }
 
         #expect(!engine.isCrossfading)
+        #expect(engine.currentURL == incomingURL)
+        #expect(!engine.isCrossfadePending)
         engine.stop()
     }
 

--- a/TwinskaraokeTests/AVEnginePlaybackRegressionTests.swift
+++ b/TwinskaraokeTests/AVEnginePlaybackRegressionTests.swift
@@ -91,6 +91,34 @@ struct AVEnginePlaybackRegressionTests {
         engine.stop()
     }
 
+    @Test("Crossfade ramp stays on the audio engine actor")
+    func crossfadeRampUsesMainActor() async throws {
+        let sourceURL = try makeSilentWaveFile(duration: 2, sampleRate: 48_000)
+        let incomingURL = try makeSilentWaveFile(duration: 2, sampleRate: 48_000)
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: incomingURL)
+        }
+
+        let engine = AVEnginePlayback()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            engine.play(url: sourceURL, onReady: { continuation.resume() })
+        }
+
+        await confirmation("crossfade completes", expectedCount: 1) { completion in
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                engine.onCrossfadeCompleted = {
+                    completion()
+                    continuation.resume()
+                }
+                engine.beginCrossfade(url: incomingURL, duration: 0.5, ramp: .linear)
+            }
+        }
+
+        #expect(!engine.isCrossfading)
+        engine.stop()
+    }
+
     private func makeSilentWaveFile(duration: TimeInterval, sampleRate: Double) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("playback-regression-\(UUID().uuidString).wav")


### PR DESCRIPTION
## Summary

- run the crossfade volume ramp on the main queue alongside the main-actor-isolated audio engine
- finalize the crossfade directly on the same actor
- add a regression test that plays two generated audio files through the crossfade completion path

## Root cause

Swift 6 detected the main-actor-isolated crossfade timer closure running on the custom `crossfade-ramp` dispatch queue and stopped in `_dispatch_assert_queue_fail` as a song reached the transition point.

## Impact

Songs can now reach the end and crossfade into the next queued song without triggering the Swift executor assertion.

## Validation

- reproduced and identified the crash from the LLDB backtrace
- confirmed the fix on a physical device
- fresh Debug iOS Simulator build
- focused AVEngine playback regression suite: passed
- complete iOS unit suite: passed

## Summary by Sourcery

Ensure crossfade volume ramp execution stays on the main actor to prevent isolation-related crashes when transitioning between songs.

Bug Fixes:
- Prevent Swift 6 executor assertion by running the crossfade timer and completion on the main actor instead of a custom dispatch queue.

Tests:
- Add a regression test that crossfades between two generated audio files and verifies the crossfade ramp and completion occur correctly on the audio engine actor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crossfade completion handling for smoother, more reliable audio transitions.
  * Prevented stale crossfade callbacks from affecting playback.

* **Tests**
  * Added regression coverage to verify crossfade operations complete correctly and leave playback in a stable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->