### PR TITLE
iPadOS sidebar fix+sidebar uitest fix

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -216,7 +216,10 @@ private struct PopupHostView: View {
                     Section(group.title) {
                         ForEach(group.sections) { section in
                             SidebarSectionRow(section: section, isSelected: currentSection == section)
-                                .tag(Optional(section))
+                                // `List(selection: Binding<RootSection?>)` matches rows by a tag
+                                // whose type is RootSection — a `RootSection?` tag never matches,
+                                // leaving every row unselectable (taps highlight, nothing happens).
+                                .tag(section)
                                 .accessibilityIdentifier(section.sidebarAccessibilityIdentifier)
                         }
                     }

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -184,7 +184,14 @@ final class TwinskaraokeUITests: XCTestCase {
     // In portrait the balanced split view collapses the sidebar out of the
     // hierarchy, so an iPad would fall through to the compact tab assertions
     // and fail. Landscape is what makes the sidebar branch deterministic.
-    XCUIDevice.shared.orientation = .landscapeLeft
+    // Orientation is process-wide, so restore it rather than leaking landscape
+    // into whichever test runs next.
+    let originalOrientation = XCUIDevice.shared.orientation
+    defer { XCUIDevice.shared.orientation = originalOrientation }
+    if isRunningOnPad {
+      XCUIDevice.shared.orientation = .landscapeLeft
+    }
+
     let app = launchApp()
     XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
 

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -181,6 +181,10 @@ final class TwinskaraokeUITests: XCTestCase {
   }
 
   func testAdaptiveMusicShellShowsSidebarOrTabs() throws {
+    // In portrait the balanced split view collapses the sidebar out of the
+    // hierarchy, so an iPad would fall through to the compact tab assertions
+    // and fail. Landscape is what makes the sidebar branch deterministic.
+    XCUIDevice.shared.orientation = .landscapeLeft
     let app = launchApp()
     XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
 
@@ -195,9 +199,11 @@ final class TwinskaraokeUITests: XCTestCase {
         )
       }
       openRootSection("Search", in: app)
+      // Only the detail column proves the sidebar row actually drove selection:
+      // the sidebar itself always carries a "Search" static text, so matching on
+      // that alone passes even when no row is selectable at all.
       XCTAssertTrue(
-        app.navigationBars["Search"].waitForExistence(timeout: 8)
-          || app.staticTexts["Search"].waitForExistence(timeout: 8),
+        app.navigationBars["Search"].waitForExistence(timeout: 8),
         "Expected Search to open from the Discover sidebar group."
       )
       return


### PR DESCRIPTION
## Summary by Sourcery

Fix sidebar row selection for iPadOS split view and update UI tests to reliably assert sidebar behavior.

Bug Fixes:
- Correct sidebar section row tagging so list selection works on iPadOS split view instead of leaving rows unselectable.

Tests:
- Adjust adaptive music shell UI test orientation and assertion to deterministically validate sidebar-driven navigation on iPad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar navigation selection behavior for a more reliable experience.
  * Enhanced the adaptive music interface’s landscape layout handling.
  * Strengthened Search navigation verification for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->