### PR TITLE
Fix main-actor isolation crash on AVAudioSession route changes

### DIFF
--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -628,10 +628,17 @@ class AudioPlayerManager: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.objectWillChange.send() }
             .store(in: &cancellables)
+        // AVAudioSession posts these off the main thread (route changes are
+        // documented as arriving on a secondary thread). Under Swift 6 these
+        // sink closures are main-actor-isolated, so delivering them on the
+        // posting thread traps. Hop to main first, as the watch and TV
+        // AudioManagers already do for the same handlers.
         NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] note in self?.handleInterruption(note) }
             .store(in: &cancellables)
         NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] note in self?.handleRouteChange(note) }
             .store(in: &cancellables)
         NotificationCenter.default.publisher(for: .vocalSeparatorDidCacheStems)
@@ -648,7 +655,10 @@ class AudioPlayerManager: ObservableObject {
                 self?.syncSystemVolume(sysVol)
             }
             .store(in: &cancellables)
+        // Posted by the audio daemon when the media server restarts; the
+        // delivery thread is undocumented, so don't assume it is main.
         NotificationCenter.default.publisher(for: AVAudioSession.mediaServicesWereResetNotification)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.handleMediaServicesReset() }
             .store(in: &cancellables)
         #if canImport(UIKit)

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -55,7 +55,7 @@ final class PlaybackClock: ObservableObject {
 }
 
 @MainActor
-class AudioPlayerManager: ObservableObject {
+final class AudioPlayerManager: ObservableObject {
     static let shared = AudioPlayerManager()
     @Published var currentSong: Song?
     @Published var isPlaying = false
@@ -492,7 +492,9 @@ class AudioPlayerManager: ObservableObject {
         }
     }
 
-    init() {
+    // Private so `shared` stays the only instance: the audio session and the
+    // remote-command centre it configures are process-wide singletons.
+    private init() {
         configureAudioSessionCategory()
         activateAudioSession()
         let cacheCleanupCutoff = Date()
@@ -668,39 +670,40 @@ class AudioPlayerManager: ObservableObject {
         #endif
     }
 
-    deinit {
-        // AudioPlayerManager is a main-actor singleton; if it is ever torn
-        // down, the last reference is released on the main thread.
-        MainActor.assumeIsolated {
-            pollTimer?.invalidate()
-            quickCutTimer?.cancel()
-            streamFadeTimer?.cancel()
-            transitionStartTask?.cancel()
-            instrumentalTask?.cancel()
-            preparedStemTask?.cancel()
-            backgroundAnalysisRetryTask?.cancel()
-            remotePlaybackCacheTask?.cancel()
-            easterEggLyricsTask?.cancel()
-            easterEggSongTask?.cancel()
-            if let existing = radioTimeObserver {
-                existing.player.removeTimeObserver(existing.token)
-            }
-            artworkTask?.cancel()
-            artworkProcessingTask?.cancel()
-            playerArtworkWarmupTasks.values.forEach { $0.cancel() }
-            playerArtworkWarmupTasks.removeAll()
-            cacheCompressionTask?.cancel()
-            radioPlayer?.pause()
-            #if canImport(UIKit)
-                let transitionTaskID = trackTransitionTaskID
-                trackTransitionTaskID = .invalid
-                if transitionTaskID != .invalid {
-                    Task { @MainActor in
-                        UIApplication.shared.endBackgroundTask(transitionTaskID)
-                    }
-                }
-            #endif
+    isolated deinit {
+        // Teardown touches main-actor-bound state: the RunLoop.main poll timer,
+        // the radio time observer, and the AVPlayer. `isolated deinit` runs the
+        // body on the main actor rather than asserting that the last release
+        // happened there, which `MainActor.assumeIsolated` would trap on.
+        pollTimer?.invalidate()
+        quickCutTimer?.cancel()
+        streamFadeTimer?.cancel()
+        transitionStartTask?.cancel()
+        instrumentalTask?.cancel()
+        preparedStemTask?.cancel()
+        backgroundAnalysisRetryTask?.cancel()
+        remotePlaybackCacheTask?.cancel()
+        easterEggLyricsTask?.cancel()
+        easterEggSongTask?.cancel()
+        if let existing = radioTimeObserver {
+            existing.player.removeTimeObserver(existing.token)
         }
+        artworkTask?.cancel()
+        artworkProcessingTask?.cancel()
+        playerArtworkWarmupTasks.values.forEach { $0.cancel() }
+        playerArtworkWarmupTasks.removeAll()
+        cacheCompressionTask?.cancel()
+        radioPlayer?.pause()
+        #if canImport(UIKit)
+            let transitionTaskID = trackTransitionTaskID
+            trackTransitionTaskID = .invalid
+            if transitionTaskID != .invalid {
+                // Already on the main actor, so end the background task
+                // directly instead of deferring it to a Task that could
+                // outlive the deinit.
+                UIApplication.shared.endBackgroundTask(transitionTaskID)
+            }
+        #endif
     }
 
     private func cancelBackgroundAnalysisRetry() {


### PR DESCRIPTION
## Summary

Fixes a Swift 6 main-actor isolation crash in `AudioPlayerManager`, plus a related teardown cleanup.

### 1. AVAudioSession notifications were delivered off the main queue

Three sinks observed `AVAudioSession` notifications without hopping to main first:

```swift
NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)
    .sink { [weak self] note in self?.handleRouteChange(note) }
```

With `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, these sink closures inherit `@MainActor`. Combine delivers on the posting thread, so when that thread isn't main the closure **traps** rather than hopping.

`AVAudioSession` posts `routeChangeNotification` on a secondary thread, so unplugging headphones, connecting Bluetooth, or switching to AirPlay could crash the app. `mediaServicesWereReset` has no documented delivery thread and gets the same treatment. `interruptionNotification` is documented as main-thread, but is guarded too so it can't silently regress.

The watch and TV `AudioManager`s already guard the identical `handleInterruption`/`handleRouteChange` handlers this way — the iOS target was the only one missing it.

**Verification.** A standalone probe built with `swiftc -swift-version 6 -default-isolation MainActor`:

| Probe | Result |
|---|---|
| `.sink` without `.receive(on:)`, posted from a background thread | SIGILL (exit 132) |
| Same, with `.receive(on: DispatchQueue.main)` | sink runs on main, exit 0 |

### 2. `isolated deinit` for teardown

The deinit wrapped its body in `MainActor.assumeIsolated`, which asserts that the last release happened on the main thread rather than ensuring it. The body invalidates a `RunLoop.main` timer, removes an `AVPlayer` time observer, and pauses the radio player — all main-actor work. `isolated deinit` runs the body on the main actor instead, and lets `endBackgroundTask` be called directly rather than deferred to a `Task` that could outlive the deinit.

This restores the pattern already used by `AVEnginePlayback`, `AuthManager`, and the watch/TV `AudioManager`s. It was removed in `0d7308f` because `isolated deinit` needs a Swift 6.1+ compiler while the project was still in Swift 5 language mode; every target is on Swift 6 now, so that constraint is gone.

The class is also marked `final` with a `private init`. The deinit's reasoning depends on `shared` being the only instance, and it already is — this makes the invariant enforced rather than assumed.

## Testing

- iOS unit 95/95, iOS UI 12/12, watch unit 38/38, watch UI 5/5
- Full recompile of iOS, watch, TV and widget targets with no new warnings
- Device-tested on iPhone: playback, route changes and interruptions behave correctly

## Notes

The route-change path is only reachable on a real device, so the crash isn't covered by the test suites. It was latent until the Swift 6 migration, which is what armed the isolation checks.

## Summary by Sourcery

Guard AudioPlayerManager’s AVAudioSession notification handling and teardown against Swift 6 main-actor isolation crashes while enforcing its singleton usage.

New Features:
- None.

Bug Fixes:
- Ensure AVAudioSession interruption, route change, and media service reset notifications are delivered to AudioPlayerManager on the main queue to prevent Swift 6 main-actor isolation traps.
- Run AudioPlayerManager teardown on the main actor via isolated deinit so main-actor-bound resources are cleaned up safely without relying on MainActor.assumeIsolated.

Enhancements:
- Mark AudioPlayerManager as final with a private initializer to enforce its singleton invariant and align with other audio-related managers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio session event handling to ensure interruptions, route changes, and media service resets are processed reliably on the main thread.
  * Enhanced audio player cleanup to stop timers, tasks, observers, and background activity safely during shutdown.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->