### PR TITLE
Update LNPopupUI to 3.1.3

### DIFF
--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -1436,7 +1436,7 @@
 			repositoryURL = "https://github.com/LeoNatan/LNPopupUI";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.2;
+				minimumVersion = 3.1.3;
 			};
 		};
 		D0C385962FB0BD870055284E /* XCRemoteSwiftPackageReference "swift-spleeter" */ = {

--- a/Twinskaraoke.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Twinskaraoke.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LeoNatan/LNPopupUI",
       "state" : {
-        "revision" : "6038c200ae1c66e9a3bd8a2c2a76670e9d1637f5",
-        "version" : "3.1.2"
+        "revision" : "8959d01a18f26b715cef97c5f957a4c0a2a97c7d",
+        "version" : "3.1.3"
       }
     },
     {


### PR DESCRIPTION
## Summary

- update LNPopupUI from 3.1.2 to 3.1.3
- refresh the Swift Package Manager lockfile revision

## Why

LNPopupUI 3.1.3 is the latest stable release. Updating the minimum package requirement keeps the project on the current compatible version.

## Impact

No application code or behavior is intentionally changed. The app now builds against LNPopupUI 3.1.3.

## Validation

- Release build for a generic iOS Simulator succeeded with code signing disabled
- tested locally on a physical iPhone

## Summary by Sourcery

Update project dependencies to use LNPopupUI 3.1.3 and refresh the Swift Package Manager lockfile accordingly.

Build:
- Update Xcode project configuration to reference LNPopupUI 3.1.3.
- Refresh Swift Package Manager Package.resolved to lock to the new LNPopupUI version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the LNPopupUI package to version 3.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->