### PR TITLE
Stop the player backdrop wiping off screen

### DIFF
--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -11,11 +11,20 @@ struct PlayerAmbientBackground: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var palette: ArtworkPalette = .placeholder
     @State private var paletteSourceURL: URL?
-    @State private var animationPhase: Bool = false
 
     private var shouldAnimateAmbient: Bool {
-        animationPhase && isPlaying && !reduceMotion
+        isPlaying && !reduceMotion
     }
+
+    /// Seconds for one full out-and-back breath.
+    private static let breathingPeriod: TimeInterval = 12
+
+    /// Defence in depth against the backdrop's extent depending on safe-area
+    /// insets. `.ignoresSafeArea()` does not pin a view to the screen, it expands
+    /// it *by the current insets*, so anything that moves those insets moves this
+    /// backdrop's edges with them. Overscanning keeps the painted area past every
+    /// edge whatever the insets do; the host clips the overflow.
+    private static let safeAreaOverscan: CGFloat = 160
 
     var body: some View {
         ZStack {
@@ -24,50 +33,38 @@ struct PlayerAmbientBackground: View {
             colorWashLayer
             vignetteLayer
         }
+        .padding(-Self.safeAreaOverscan)
         .ignoresSafeArea()
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: artworkURL)
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.8), value: palette)
-        .onAppear {
-            loadPalette()
-            if isPlaying { startBreathing() }
-        }
-        .onDisappear(perform: stopBreathing)
+        // A `withAnimation` transaction applies to every animatable change in
+        // the update, not just the state it wraps, so a `repeatForever` started
+        // anywhere in the app could latch onto this backdrop's geometry and
+        // oscillate it forever. This is a decorative full-bleed layer that
+        // should never inherit motion from elsewhere: drop any ambient
+        // animation at the boundary. The `.animation(_:value:)` modifiers above
+        // sit inside it and still drive the backdrop's own transitions.
+        .transaction { $0.animation = nil }
+        .onAppear(perform: loadPalette)
         .onChange(of: artworkURL) { loadPalette() }
-        .onChange(of: isPlaying) { _, playing in
-            if playing {
-                startBreathing()
-            } else {
-                stopBreathing()
-            }
-        }
-        .onChange(of: reduceMotion) { _, reduceMotion in
-            if reduceMotion {
-                withAnimation(nil) {
-                    animationPhase = false
-                }
-            } else if isPlaying {
-                startBreathing()
-            }
-        }
     }
 
-    private func startBreathing() {
-        guard !reduceMotion else {
-            animationPhase = false
-            return
-        }
-        withAnimation(
-            .easeInOut(duration: 6.0)
-                .repeatForever(autoreverses: true)
-        ) {
-            animationPhase = true
-        }
-    }
-
-    private func stopBreathing() {
-        withAnimation(nil) {
-            animationPhase = false
-        }
+    /// Progress through the breath, 0...1 and back, eased at the turns.
+    ///
+    /// Driven off the clock rather than a `repeatForever` animation. An endless
+    /// SwiftUI animation is a transaction, and a transaction applies to every
+    /// animatable change in its subtree — including the safe-area expansion that
+    /// sizes this backdrop. Started that way, the breath latched onto the
+    /// backdrop's top edge and oscillated it between the real inset and zero for
+    /// as long as the view lived, sliding the artwork off screen and exposing the
+    /// layer beneath. Scoping it with `.animation(_:value:)` was not enough:
+    /// that modifier still animates everything in its subtree. A clock produces
+    /// the same motion with no transaction to leak, and `paused:` stops it
+    /// without leaving anything running.
+    private static func breathingPhase(at date: Date) -> Double {
+        let cycle = date.timeIntervalSinceReferenceDate
+            .truncatingRemainder(dividingBy: breathingPeriod) / breathingPeriod
+        return (1 - cos(2 * .pi * cycle)) / 2
     }
 
     @ViewBuilder
@@ -77,32 +74,59 @@ struct PlayerAmbientBackground: View {
             // 32px server-blurred variant instead of the full card image:
             // far less decode, memory and GPU work for the same visual result.
             let backdropURL = ArtworkURLBuilder.variantURL(from: artworkURL, variant: .blur) ?? artworkURL
-            GeometryReader { geo in
-                WebImage(
-                    url: backdropURL,
-                    options: ImageCacheConfig.defaultOptions,
-                    context: ImageCacheConfig.visibleImageContext
-                ) { image in
-                    image
-                        .resizable()
-                        .interpolation(.low)
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: geo.size.width, height: geo.size.height)
-                        .blur(radius: runtimeBlurRadius)
-                        .saturation(1.05)
-                        .drawingGroup()
-                        .scaleEffect(shouldAnimateAmbient ? 1.28 : 1.22)
-                        .offset(
-                            x: shouldAnimateAmbient ? 8 : -8,
-                            y: shouldAnimateAmbient ? -6 : 6
-                        )
-                        .clipped()
+            // The image goes in an `overlay` so it cannot influence the size of
+            // anything above it. `.aspectRatio(.fill)` always resolves to a size
+            // that *covers* the proposal, and `.frame(maxWidth:maxHeight:)` does
+            // not clamp a child that came back larger — it adopts the child's
+            // size. That let the image inflate the frame, the frame inflate the
+            // ZStack, and the backdrop end up laid out at the artwork's aspect
+            // ratio instead of the screen's, so it no longer covered the display.
+            // Overlay content never feeds size back to its parent, which keeps the
+            // clamp without an explicit numeric frame for an animation to
+            // interpolate.
+            Color.clear
+                .overlay {
+                    WebImage(
+                        url: backdropURL,
+                        options: ImageCacheConfig.defaultOptions,
+                        context: ImageCacheConfig.visibleImageContext
+                    ) { image in
+                        TimelineView(
+                            .animation(
+                                minimumInterval: DisplayRefreshRate.decorativeAnimationInterval,
+                                paused: !shouldAnimateAmbient
+                            )
+                        ) { context in
+                            let phase = shouldAnimateAmbient
+                                ? Self.breathingPhase(at: context.date)
+                                : 0
+                            image
+                                .resizable()
+                                .interpolation(.low)
+                                .aspectRatio(contentMode: .fill)
+                                .blur(radius: runtimeBlurRadius)
+                                .saturation(1.05)
+                                // Deliberately no `.drawingGroup()`. It bought
+                                // nothing here — the source is the 32px
+                                // server-blurred variant above, so there is no
+                                // costly rasterization worth caching — while
+                                // forcing a full-screen offscreen pass on every
+                                // re-render, and this view re-renders constantly
+                                // because `audioManager` republishes during
+                                // playback. `.blur` on its own is a hardware
+                                // filter and needs no offscreen buffer.
+                                .scaleEffect(1.22 + 0.06 * phase)
+                                .offset(
+                                    x: -8 + 16 * phase,
+                                    y: 6 - 12 * phase
+                                )
+                        }
                         .transition(.opacity)
-                } placeholder: {
-                    fallbackGradient
-                        .frame(width: geo.size.width, height: geo.size.height)
+                    } placeholder: {
+                        fallbackGradient
+                    }
                 }
-            }
+                .clipped()
         } else {
             fallbackGradient
         }

--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -11,6 +11,10 @@ struct PlayerAmbientBackground: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var palette: ArtworkPalette = .placeholder
     @State private var paletteSourceURL: URL?
+    /// Breath time already run before the current stretch of playback.
+    @State private var breathElapsed: TimeInterval = 0
+    /// When the current stretch of playback began.
+    @State private var breathResumedAt = Date()
 
     private var shouldAnimateAmbient: Bool {
         isPlaying && !reduceMotion
@@ -24,7 +28,13 @@ struct PlayerAmbientBackground: View {
     /// it *by the current insets*, so anything that moves those insets moves this
     /// backdrop's edges with them. Overscanning keeps the painted area past every
     /// edge whatever the insets do; the host clips the overflow.
-    private static let safeAreaOverscan: CGFloat = 160
+    ///
+    /// Sized against the insets themselves rather than the screen: the largest
+    /// this has to clear is one safe-area inset, ~67pt at the extreme on device,
+    /// so this leaves comfortable headroom for taller hardware. Scaling it to the
+    /// display would overscan an iPad far past anything the insets can reach and
+    /// pay for it in blurred area on every frame.
+    private static let safeAreaOverscan: CGFloat = 96
 
     var body: some View {
         ZStack {
@@ -47,6 +57,22 @@ struct PlayerAmbientBackground: View {
         .transaction { $0.animation = nil }
         .onAppear(perform: loadPalette)
         .onChange(of: artworkURL) { loadPalette() }
+        .onChange(of: shouldAnimateAmbient) { _, animating in
+            // Bank the time already breathed when stopping, and restart the
+            // clock when resuming, so the breath picks up where it left off
+            // rather than jumping to wherever wall-clock time has reached.
+            if animating {
+                breathResumedAt = Date()
+            } else {
+                breathElapsed += Date().timeIntervalSince(breathResumedAt)
+            }
+        }
+    }
+
+    /// How far the breath has run, in seconds, across every stretch of playback.
+    private func breathDuration(at date: Date) -> TimeInterval {
+        guard shouldAnimateAmbient else { return breathElapsed }
+        return breathElapsed + max(0, date.timeIntervalSince(breathResumedAt))
     }
 
     /// Progress through the breath, 0...1 and back, eased at the turns.
@@ -58,11 +84,12 @@ struct PlayerAmbientBackground: View {
     /// backdrop's top edge and oscillated it between the real inset and zero for
     /// as long as the view lived, sliding the artwork off screen and exposing the
     /// layer beneath. Scoping it with `.animation(_:value:)` was not enough:
-    /// that modifier still animates everything in its subtree. A clock produces
-    /// the same motion with no transaction to leak, and `paused:` stops it
-    /// without leaving anything running.
-    private static func breathingPhase(at date: Date) -> Double {
-        let cycle = date.timeIntervalSinceReferenceDate
+    /// that modifier still animates everything in its subtree, so keying one on
+    /// the play/pause flag would re-arm the same leak on the same trigger. A
+    /// clock produces the same motion with no transaction to leak, and `paused:`
+    /// stops it without leaving anything running.
+    private static func breathingPhase(elapsed: TimeInterval) -> Double {
+        let cycle = elapsed
             .truncatingRemainder(dividingBy: breathingPeriod) / breathingPeriod
         return (1 - cos(2 * .pi * cycle)) / 2
     }
@@ -97,9 +124,9 @@ struct PlayerAmbientBackground: View {
                                 paused: !shouldAnimateAmbient
                             )
                         ) { context in
-                            let phase = shouldAnimateAmbient
-                                ? Self.breathingPhase(at: context.date)
-                                : 0
+                            let phase = Self.breathingPhase(
+                                elapsed: breathDuration(at: context.date)
+                            )
                             image
                                 .resizable()
                                 .interpolation(.low)


### PR DESCRIPTION
## Problem

With the full-screen player open, the ambient backdrop wiped away and exposed the black system background beneath it. Rapid play/pause and rapid minimise/expand both triggered it, and once started it kept going on its own while paused.

## Cause

The backdrop's breathing effect was started with `withAnimation(.easeInOut(duration: 6.0).repeatForever(autoreverses: true))`.

An endless SwiftUI animation is a transaction, and a transaction applies to every animatable change in its subtree — not only the state it was started for. That subtree included the safe-area expansion that sizes the backdrop: `.ignoresSafeArea()` does not pin a view to the screen, it expands it *by the current insets*.

So the breath latched onto the backdrop's top edge and oscillated it between the real inset and zero for as long as the view lived, sliding the artwork off screen and uncovering the layer beneath.

Nothing stopped it: pausing only reset the flag the breath read, while the runaway animation lived on the geometry. Scoping it with `.animation(_:value:)` is not enough either — that modifier still animates everything in its subtree.

On-device probes confirmed it directly. The top safe-area inset ramped `0 → 67 → 0` on every play/pause tap, autoreversing, while every size probe stayed silent — the geometry was never resized, only the inset-derived expansion moved.

## Fix

Drive the breath from a clock with `TimelineView`, matching the existing `EqualizerBars` pattern. Same motion, no transaction to leak, and `paused:` stops it without leaving anything running.

Three supporting changes from the same investigation:

- **Clamp the artwork layer via an overlay.** `.aspectRatio(.fill)` always resolves larger than the proposal, and `.frame(maxWidth:maxHeight:)` adopts an oversized child rather than clamping it — so the image could inflate its own container to the artwork's aspect ratio instead of the screen's. Overlay content never feeds size back to its parent.
- **Overscan the layers past every edge**, so the backdrop's extent no longer depends on safe-area insets at all. Defence in depth against this class.
- **Refuse inherited transactions at the view boundary**, so a `repeatForever` started anywhere else in the app cannot animate this backdrop's geometry.

Also drops the `drawingGroup()`. The source is the 32px server-blurred variant, so there is no costly rasterization worth caching, and it forced a full-screen offscreen pass on every re-render of a view that re-renders constantly during playback.

## Testing

Verified on device across several builds:

- Rapid play/pause with the full player open — backdrop stays put.
- Rapid minimise/expand of the popup.
- Paused and left idle, which previously started the wipe on its own.
- Breathing still drifts and scales while playing, and stops on pause.
- Song skips still crossfade the backdrop.

`TwinskaraokeTests` passes; the iOS app target builds clean.

## Notes

`Bound preference LNPopupItemPreferenceKey tried to update multiple times per frame` still appears in the console. It is unrelated to this bug and predates the change, but it is a real update loop worth looking at separately.

## Summary by Sourcery

Stabilize the full-screen player’s ambient backdrop so it no longer slides off screen or exposes the system background during playback or layout changes.

Bug Fixes:
- Prevent the ambient backdrop from oscillating with safe-area inset changes, which previously caused the artwork layer to wipe off screen during rapid play/pause or expand/minimize actions.

Enhancements:
- Drive the backdrop breathing motion from a TimelineView-based clock instead of a repeatForever animation, ensuring the effect stops cleanly when paused and does not leak transactions into its geometry.
- Overscan and clip the backdrop layers independently of safe-area insets so the painted area reliably covers the display regardless of inset changes.
- Isolate the backdrop from inheriting ambient animations started elsewhere in the app by clearing incoming transactions at the view boundary.
- Clamp the artwork as an overlay so its aspect ratio cannot inflate the backdrop’s layout, keeping the background aligned to the screen.
- Remove unnecessary drawingGroup usage on the blurred artwork to avoid costly offscreen rasterization during frequent re-renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a smoother ambient breathing animation for the player backdrop.
  * Ambient motion now pauses automatically when playback is paused or reduced-motion settings are enabled.

* **Bug Fixes**
  * Improved artwork rendering to prevent unintended geometry animations and visual clipping issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->