### PR TITLE
Migrate to Observation and fix artwork scroll placeholders

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -1,13 +1,15 @@
 import Combine
 import LNPopupUI
 import SwiftUI
+import Observation
 
 #if canImport(UIKit)
     import UIKit
 #endif
 
 @MainActor
-private final class PopupPlaybackState: ObservableObject {
+@Observable
+private final class PopupPlaybackState {
     static let shared = PopupPlaybackState()
 
     var hasCurrentSong: Bool {
@@ -38,58 +40,37 @@ private final class PopupPlaybackState: ObservableObject {
         snapshot.isRadioMode
     }
 
-    @Published private var snapshot = PopupPlaybackSnapshot()
-    private var pendingSnapshot = PopupPlaybackSnapshot()
-    private var publishTask: Task<Void, Never>?
-    private var cancellables = Set<AnyCancellable>()
+    private var snapshot = PopupPlaybackSnapshot()
+    @ObservationIgnored private var pendingSnapshot = PopupPlaybackSnapshot()
+    @ObservationIgnored private var publishTask: Task<Void, Never>?
+    @ObservationIgnored private var observation: ObservationToken?
 
     private init() {
-        let manager = AudioPlayerManager.shared
-        manager.$currentSong
-            .removeDuplicates(by: {
-                $0?.id == $1?.id
-                    && $0?.title == $1?.title
-                    && $0?.displayArtist == $1?.displayArtist
-            })
-            .sink { [weak self] song in
-                self?.updatePendingSnapshot { snapshot in
-                    snapshot.id = song?.id
-                    snapshot.title = song?.title ?? ""
-                    snapshot.subtitle = song?.displayArtist ?? ""
-                }
-            }
-            .store(in: &cancellables)
-
-        manager.$nowPlayingArtwork
-            .removeDuplicates(by: { $0 === $1 })
-            .sink { [weak self] artwork in
-                self?.updatePendingSnapshot { snapshot in
-                    snapshot.artwork = artwork
-                }
-            }
-            .store(in: &cancellables)
-
-        manager.$isPlaying
-            .removeDuplicates()
-            .sink { [weak self] isPlaying in
-                self?.updatePendingSnapshot { snapshot in
-                    snapshot.isPlaying = isPlaying
-                }
-            }
-            .store(in: &cancellables)
-
-        manager.$isRadioMode
-            .removeDuplicates()
-            .sink { [weak self] isRadioMode in
-                self?.updatePendingSnapshot { snapshot in
-                    snapshot.isRadioMode = isRadioMode
-                }
-            }
-            .store(in: &cancellables)
+        // Replaces four `$property.sink` pipelines. The per-property
+        // `removeDuplicates` they carried is redundant here: `scheduleSnapshotPublish`
+        // already drops a rebuild that `matches` the published snapshot, so
+        // rebuilding all four fields on any change is equivalent.
+        observation = observeContinuously({
+            let manager = AudioPlayerManager.shared
+            _ = manager.currentSong
+            _ = manager.nowPlayingArtwork
+            _ = manager.isPlaying
+            _ = manager.isRadioMode
+        }, onChange: { [weak self] in
+            self?.rebuildPendingSnapshot()
+        })
+        rebuildPendingSnapshot()
     }
 
-    private func updatePendingSnapshot(_ update: (inout PopupPlaybackSnapshot) -> Void) {
-        update(&pendingSnapshot)
+    private func rebuildPendingSnapshot() {
+        let manager = AudioPlayerManager.shared
+        let song = manager.currentSong
+        pendingSnapshot.id = song?.id
+        pendingSnapshot.title = song?.title ?? ""
+        pendingSnapshot.subtitle = song?.displayArtist ?? ""
+        pendingSnapshot.artwork = manager.nowPlayingArtwork
+        pendingSnapshot.isPlaying = manager.isPlaying
+        pendingSnapshot.isRadioMode = manager.isRadioMode
         scheduleSnapshotPublish()
     }
 
@@ -128,14 +109,14 @@ private struct PopupPlaybackSnapshot {
 struct ContentView: View {
     var body: some View {
         PopupHostView()
-            .environmentObject(AudioPlayerManager.shared)
+            .environment(AudioPlayerManager.shared)
     }
 }
 
 private struct PopupHostView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.appReduceMotion) private var reduceMotion
-    @StateObject private var homeViewModel = HomeViewModel()
+    @State private var homeViewModel = HomeViewModel()
     @State private var selectedSection: RootSection?
     @State private var showCaptcha = false
 
@@ -145,7 +126,7 @@ private struct PopupHostView: View {
 
     var body: some View {
         rootShell
-            .environmentObject(homeViewModel)
+            .environment(homeViewModel)
             .modifier(PopupModifier())
             .onAppear {
                 configureTabBarAppearance()
@@ -404,7 +385,7 @@ private struct SidebarSectionRow: View {
 }
 
 private struct SidebarNowPlayingHint: View {
-    @ObservedObject private var popupState = PopupPlaybackState.shared
+    private let popupState = PopupPlaybackState.shared
 
     var body: some View {
         Group {
@@ -479,8 +460,8 @@ private extension RootSection {
 }
 
 private struct PopupModifier: ViewModifier {
-    @ObservedObject private var popupState = PopupPlaybackState.shared
-    @ObservedObject private var presentationState = PopupPresentationState.shared
+    private let popupState = PopupPlaybackState.shared
+    private let presentationState = PopupPresentationState.shared
 
     func body(content: Content) -> some View {
         content
@@ -524,7 +505,7 @@ private struct PopupModifier: ViewModifier {
 }
 
 private struct PopupContent: View {
-    @ObservedObject private var popupState: PopupPlaybackState
+    private let popupState: PopupPlaybackState
 
     init(popupState: PopupPlaybackState) {
         self.popupState = popupState
@@ -532,7 +513,7 @@ private struct PopupContent: View {
 
     var body: some View {
         FullScreenPlayerView()
-            .environmentObject(AudioPlayerManager.shared)
+            .environment(AudioPlayerManager.shared)
             .popupItem {
                 PopupItem(
                     id: popupState.id,

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -4,7 +4,7 @@ struct AddToPlaylistSheet: View {
     let song: Song
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
-    @ObservedObject private var manager = UserPlaylistsManager.shared
+    private let manager = UserPlaylistsManager.shared
 
     @State private var inFlight: Set<String> = []
     @State private var added: Set<String> = []

--- a/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
+++ b/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
@@ -3,8 +3,8 @@ import SwiftUI
 struct PlaylistActionsMenuItems: View {
     let playlist: Playlist
     let songs: [Song]
-    @ObservedObject private var savedStore = SavedPlaylistsStore.shared
-    @ObservedObject private var downloads = DownloadManager.shared
+    private let savedStore = SavedPlaylistsStore.shared
+    private let downloads = DownloadManager.shared
 
     private var isSaved: Bool {
         savedStore.isSaved(playlist)

--- a/Twinskaraoke/Components/Media/FavoritesArtworkTile.swift
+++ b/Twinskaraoke/Components/Media/FavoritesArtworkTile.swift
@@ -75,7 +75,7 @@ struct PlaylistArtworkContent: View {
 private struct PlaylistCoverWithLoader: View {
     let playlist: Playlist
     let cornerRadius: CGFloat
-    @StateObject private var loader = PlaylistCoverLoader()
+    @State private var loader = PlaylistCoverLoader()
 
     var body: some View {
         PlaylistArtworkContent(

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -1,6 +1,6 @@
-import Combine
 import SDWebImageSwiftUI
 import SwiftUI
+import Observation
 
 struct RemoteArtworkImage: View {
     let url: URL?
@@ -11,15 +11,21 @@ struct RemoteArtworkImage: View {
     var fullResolution: Bool = false
 
     var fixedDisplaySize: CGSize?
-    @ObservedObject private var scrollState = ScrollPerformanceState.shared
+    private let scrollState = ScrollPerformanceState.shared
     // Observed so a view composed during a failure-backoff window re-evaluates
     // isBlocked when the window ends instead of showing the placeholder forever.
-    @ObservedObject private var failureBackoff = ArtworkFailureBackoff.shared
+    private let failureBackoff = ArtworkFailureBackoff.shared
     @State private var fullLoaded: Bool = false
     @State private var loadFailed: Bool = false
     @State private var renderedFullURL: URL?
     var body: some View {
-        Group {
+        // Load-bearing read: `isBlocked(url)` below is a method call over
+        // NSLock-guarded storage and registers nothing with observation.
+        // `generation` is the publish signal, so reading it here is what
+        // recomposes this view when a backoff window ends. Under
+        // @ObservedObject merely holding `failureBackoff` was enough.
+        let _ = failureBackoff.generation
+        return Group {
             if let fixedDisplaySize {
                 imageContent(size: fixedDisplaySize)
                     .frame(width: fixedDisplaySize.width, height: fixedDisplaySize.height)
@@ -42,6 +48,26 @@ struct RemoteArtworkImage: View {
     private func imageContent(size: CGSize) -> some View {
         let displaySize = sanitizedDisplaySize(size)
         let context = fullResolution ? ImageCacheConfig.memoryAndDiskCacheContext : ImageCacheConfig.visibleImageContext
+        // Fast path: the bitmap is already in the memory cache, so paint it in
+        // this very body pass. `WebImage` cannot do this — it decides to show
+        // the placeholder before it starts the load — which costs one grey
+        // frame per row even on a hit. See `ArtworkMemoryCache`.
+        if let cached = ArtworkMemoryCache.image(for: url) {
+            cached
+                .resizable()
+                .aspectRatio(contentMode: contentMode)
+                .frame(width: displaySize.width, height: displaySize.height)
+                .clipped()
+        } else {
+            asyncImageContent(displaySize: displaySize, context: context)
+        }
+    }
+
+    @ViewBuilder
+    private func asyncImageContent(
+        displaySize: CGSize,
+        context: [SDWebImageContextOption: Any]
+    ) -> some View {
         ZStack {
             if !transparentBackground {
                 MusicArtworkPlaceholder(cornerRadius: cornerRadius)
@@ -158,9 +184,20 @@ struct RemoteArtworkImage: View {
         !scrollState.isScrolling && shouldPreferProgressiveArtwork
     }
 
+    /// Whether to show the ~1 KB blurred preview while the real image loads.
+    ///
+    /// This used to require a display size over 96pt, which excluded song rows
+    /// (44–48pt) — precisely where fast scrolling leaves a flat grey
+    /// placeholder on screen the longest. A blurred preview is a far better
+    /// stand-in than grey, and at a few hundred bytes it arrives about as fast
+    /// as the network can answer at all.
+    ///
+    /// The floor stays low rather than disappearing: below ~24pt the preview is
+    /// too small to read as anything, so the extra image layer per row buys
+    /// nothing.
     private var shouldPreferProgressiveArtwork: Bool {
         guard let fixedDisplaySize else { return true }
-        return max(fixedDisplaySize.width, fixedDisplaySize.height) > 96
+        return max(fixedDisplaySize.width, fixedDisplaySize.height) >= 24
     }
 
     private var loadAnimation: Animation? {
@@ -189,17 +226,25 @@ struct RemoteArtworkImage: View {
 
 }
 
-final class ArtworkFailureBackoff: ObservableObject {
+@Observable
+final class ArtworkFailureBackoff {
     static let shared = ArtworkFailureBackoff()
 
     private let cooldown: TimeInterval = 300
     private let lock = NSLock()
-    private var blockedUntil: [URL: Date] = [:]
+    // MUST stay out of the observation graph. It is NSLock-guarded, written off
+    // the main actor, and mutated from `clear(_:)` on the render path. Observing
+    // it publishes on every `removeValue` — even one that removes nothing —
+    // which re-enters the SwiftUI graph synchronously and recurses forever
+    // (markRendered -> clear -> willSet -> flushTransactions -> body -> ...).
+    // `generation` below is the intended publish signal precisely because its
+    // bump is guarded by "did anything actually change".
+    @ObservationIgnored private var blockedUntil: [URL: Date] = [:]
 
     // Bumped whenever the blocked set changes so observing views re-evaluate
     // isBlocked. Never written from isBlocked itself — that runs during view
     // body evaluation, where publishing a change is illegal.
-    @Published private(set) var generation = 0
+    private(set) var generation = 0
 
     var cooldownNanoseconds: UInt64 {
         UInt64(cooldown * 1_000_000_000)
@@ -331,7 +376,7 @@ struct CenteredLoadingView: View {
 struct MusicSkeletonShimmer: ViewModifier {
     var isActive: Bool
     @Environment(\.appReduceMotion) private var reduceMotion
-    @ObservedObject private var scrollState = ScrollPerformanceState.shared
+    private let scrollState = ScrollPerformanceState.shared
     @State private var phase: CGFloat = -0.8
 
     func body(content: Content) -> some View {

--- a/Twinskaraoke/Components/Player/EqualizerBars.swift
+++ b/Twinskaraoke/Components/Player/EqualizerBars.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct EqualizerBars: View {
     let isAnimating: Bool
     @Environment(\.appReduceMotion) private var reduceMotion
-    @ObservedObject private var scrollState = ScrollPerformanceState.shared
+    private let scrollState = ScrollPerformanceState.shared
     @State private var startDate = Date()
     @State private var isVisible: Bool = false
 

--- a/Twinskaraoke/Components/Player/KaraokeRightDock.swift
+++ b/Twinskaraoke/Components/Player/KaraokeRightDock.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct KaraokeRightDock: View {
-    @EnvironmentObject var audioManager: AudioPlayerManager
-    @ObservedObject private var vocalSeparator = VocalSeparator.shared
+    @Environment(AudioPlayerManager.self) var audioManager
+    private let vocalSeparator = VocalSeparator.shared
     @Environment(\.appReduceMotion) private var reduceMotion
     @Binding var showKaraokeControls: Bool
 

--- a/Twinskaraoke/Components/Player/PlayerArtworkView.swift
+++ b/Twinskaraoke/Components/Player/PlayerArtworkView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PlayerArtworkView: View {
-    @EnvironmentObject var audioManager: AudioPlayerManager
+    @Environment(AudioPlayerManager.self) var audioManager
     @Environment(\.appReduceMotion) private var reduceMotion
     let song: Song
     let size: CGFloat

--- a/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
+++ b/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
@@ -5,7 +5,7 @@ import SwiftUI
 #endif
 
 struct PlayerBottomToolbar: View {
-    @EnvironmentObject var audioManager: AudioPlayerManager
+    @Environment(AudioPlayerManager.self) var audioManager
     @Binding var showingQueue: Bool
     let song: Song
     let onLyricsToggle: () -> Void

--- a/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
+++ b/Twinskaraoke/Components/Player/PlayerVolumeRow.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PlayerVolumeRow: View {
-    @EnvironmentObject var audioManager: AudioPlayerManager
+    @Environment(AudioPlayerManager.self) var audioManager
     @Environment(\.scenePhase) private var scenePhase
     @State private var volumeBridgeGeneration = 0
     // In-drag volume lives here so the 60-120Hz drag updates don't publish
@@ -27,6 +27,7 @@ struct PlayerVolumeRow: View {
     }
 
     var body: some View {
+        @Bindable var audioManager = audioManager
         HStack(spacing: 12) {
             Image(systemName: "speaker.fill")
                 .font(.caption)

--- a/Twinskaraoke/Components/Player/QueueComponents.swift
+++ b/Twinskaraoke/Components/Player/QueueComponents.swift
@@ -6,7 +6,7 @@ struct QueueRow: View {
     let isPlayingNext: Bool
     let onPlay: () -> Void
     let onRemove: () -> Void
-    @EnvironmentObject private var audioManager: AudioPlayerManager
+    @Environment(AudioPlayerManager.self) private var audioManager
     @State private var showAddToPlaylist = false
 
     var body: some View {
@@ -58,7 +58,7 @@ struct QueueRow: View {
                 }
             } preview: {
                 SongContextPreview(song: song)
-                    .environmentObject(audioManager)
+                    .environment(audioManager)
             }
             .accessibilityLabel("\(position). \(song.title), \(song.displayArtist)")
             .accessibilityValue(isPlayingNext ? "Playing next" : "Queued")

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -1,4 +1,3 @@
-import Combine
 import SDWebImageSwiftUI
 import SwiftUI
 
@@ -378,7 +377,7 @@ func withOptionalAnimation<Result>(
 }
 
 private struct BottomChromeScrollTrackingModifier: ViewModifier {
-    @ObservedObject private var chromeState = BottomChromeState.shared
+    private let chromeState = BottomChromeState.shared
 
     func body(content: Content) -> some View {
         if #available(iOS 18.0, *) {

--- a/Twinskaraoke/Components/Shared/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/Shared/ScrollOptimization.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 
 extension View {

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -1,19 +1,27 @@
-import Combine
 import SwiftUI
+import Observation
 
 @MainActor
-private final class SongDownloadRowState: ObservableObject {
-    @Published private(set) var status: SongDownloadStatus
-    private var cancellable: AnyCancellable?
+@Observable
+private final class SongDownloadRowState {
+    private(set) var status: SongDownloadStatus
+    @ObservationIgnored private var observation: ObservationToken?
 
     init(songID: String) {
         let manager = DownloadManager.shared
         status = manager.status(for: songID)
-        cancellable = manager.statusPublisher(for: songID)
-            .dropFirst()
-            .sink { [weak self] status in
-                self?.status = status
-            }
+        // Replaces `statusPublisher(for:).dropFirst().removeDuplicates()`:
+        // observation only fires on change (the `dropFirst`), and the guarded
+        // assignment below is the `removeDuplicates` — without it every row in
+        // a list would re-render on any other song's download progress.
+        observation = observeContinuously({
+            _ = DownloadManager.shared.downloadedIDs
+            _ = DownloadManager.shared.inProgress
+        }, onChange: { [weak self] in
+            guard let self else { return }
+            let next = DownloadManager.shared.status(for: songID)
+            if status != next { status = next }
+        })
     }
 }
 
@@ -58,8 +66,8 @@ struct SongRow: View {
 
     var showsArtwork: Bool = true
     var trailing: AnyView?
-    @ObservedObject private var playback = PlaybackRowState.shared
-    @StateObject private var downloadState: SongDownloadRowState
+    private let playback = PlaybackRowState.shared
+    @State private var downloadState: SongDownloadRowState
     @State private var showAddToPlaylist = false
     @Environment(\.appReduceMotion) private var reduceMotion
 
@@ -73,7 +81,7 @@ struct SongRow: View {
         self.size = size
         self.showsArtwork = showsArtwork
         self.trailing = trailing
-        _downloadState = StateObject(wrappedValue: SongDownloadRowState(songID: song.id))
+        _downloadState = State(initialValue: SongDownloadRowState(songID: song.id))
     }
 
     private var isCurrentSong: Bool {
@@ -220,7 +228,7 @@ struct MusicGridCard: View {
     var size: MusicGridCardSize = .regular
     var width: CGFloat?
     var accessibilityIdentifier: String?
-    @ObservedObject private var playback = PlaybackRowState.shared
+    private let playback = PlaybackRowState.shared
     @State private var showAddToPlaylist = false
 
     init(
@@ -312,7 +320,7 @@ struct SongActionsMenuItems: View {
     let onAddToPlaylist: () -> Void
     private let isDownloaded: Bool
     private let isDownloading: Bool
-    @ObservedObject private var favorites = FavoritesManager.shared
+    private let favorites = FavoritesManager.shared
 
     init(song: Song, onAddToPlaylist: @escaping () -> Void) {
         self.song = song
@@ -414,15 +422,15 @@ private struct SongRowAccessibilityModifier: ViewModifier {
     let song: Song
     var isPending = false
     let onPlay: () -> Void
-    @ObservedObject private var playback = PlaybackRowState.shared
-    @StateObject private var downloadState: SongDownloadRowState
-    @ObservedObject private var favorites = FavoritesManager.shared
+    private let playback = PlaybackRowState.shared
+    @State private var downloadState: SongDownloadRowState
+    private let favorites = FavoritesManager.shared
 
     init(song: Song, isPending: Bool, onPlay: @escaping () -> Void) {
         self.song = song
         self.isPending = isPending
         self.onPlay = onPlay
-        _downloadState = StateObject(wrappedValue: SongDownloadRowState(songID: song.id))
+        _downloadState = State(initialValue: SongDownloadRowState(songID: song.id))
     }
 
     func body(content: Content) -> some View {

--- a/Twinskaraoke/Components/Shimeji/ShimejiOverlayWindow.swift
+++ b/Twinskaraoke/Components/Shimeji/ShimejiOverlayWindow.swift
@@ -109,7 +109,7 @@ import SwiftUI
     }
 
     private struct ShimejiOverlayRootView: View {
-        @ObservedObject private var engine = ShimejiEngine.shared
+        private let engine = ShimejiEngine.shared
 
         var body: some View {
             GeometryReader { proxy in

--- a/Twinskaraoke/Components/Shimeji/ShimejiSessionModifier.swift
+++ b/Twinskaraoke/Components/Shimeji/ShimejiSessionModifier.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ShimejiSessionModifier: ViewModifier {
     @AppStorage("nk.experimentsEnabled") private var experimentsEnabled: Bool = false
     @AppStorage("nk.experimentalShimejiEnabled") private var shimejiEnabled: Bool = false
-    @ObservedObject private var resources = ShimejiResourceManager.shared
+    private let resources = ShimejiResourceManager.shared
 
     private var isActive: Bool {
         experimentsEnabled && shimejiEnabled && resources.state == .ready

--- a/Twinskaraoke/Components/Shimeji/ShimejiSpriteView.swift
+++ b/Twinskaraoke/Components/Shimeji/ShimejiSpriteView.swift
@@ -19,8 +19,8 @@ import SwiftUI
     }
 
     struct ShimejiSpriteView: View {
-        @ObservedObject var instance: ShimejiInstance
-        @ObservedObject private var resources = ShimejiResourceManager.shared
+        let instance: ShimejiInstance
+        private let resources = ShimejiResourceManager.shared
         @GestureState private var dragTranslation: CGSize = .zero
 
         private let displaySize: CGFloat = 84

--- a/Twinskaraoke/Features/Account/AccountView.swift
+++ b/Twinskaraoke/Features/Account/AccountView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct AccountView: View {
-    @StateObject private var auth = AuthManager()
+    @State private var auth = AuthManager()
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showLoginSheet = false
     @State private var showQRApprove = false

--- a/Twinskaraoke/Features/Account/LoginSheet.swift
+++ b/Twinskaraoke/Features/Account/LoginSheet.swift
@@ -2,7 +2,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct LoginSheet: View {
-    @ObservedObject var auth: AuthManager
+    let auth: AuthManager
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var username = ""

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -2,7 +2,7 @@ import AVFoundation
 import SwiftUI
 
 struct QRApproveView: View {
-    @ObservedObject var auth: AuthManager
+    let auth: AuthManager
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var phase: Phase = .scanning

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @ObservedObject private var audioManager = AudioPlayerManager.shared
-    @ObservedObject private var cacheManager = CacheManager.shared
+    @Bindable private var audioManager = AudioPlayerManager.shared
+    private let cacheManager = CacheManager.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @AppStorage("nk.addPlaylistSongsToLibrary") private var addPlaylistSongsToLibrary: Bool = false
     @AppStorage("nk.addFavoriteSongsToLibrary") private var addFavoriteSongsToLibrary: Bool = true

--- a/Twinskaraoke/Features/Account/ShimejiSettingsView.swift
+++ b/Twinskaraoke/Features/Account/ShimejiSettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ShimejiSettingsView: View {
-    @ObservedObject private var resources = ShimejiResourceManager.shared
+    private let resources = ShimejiResourceManager.shared
     @State private var spawnSettings = ShimejiSpawnSettings.load()
     @AppStorage("nk.shimeji.canClimb") private var canClimb: Bool = true
 

--- a/Twinskaraoke/Features/CarPlay/CarPlaySceneDelegate.swift
+++ b/Twinskaraoke/Features/CarPlay/CarPlaySceneDelegate.swift
@@ -39,7 +39,10 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     private var openPlaylistTemplates: [String: CPListTemplate] = [:]
     private var openPlaylistSongs: [String: [Song]] = [:]
     private var openPlaylists: [String: Playlist] = [:]
-    private var cancellables = Set<AnyCancellable>()
+    private var contentObservation: ObservationToken?
+    private var favoritesObservation: ObservationToken?
+    private var templateRefreshTask: Task<Void, Never>?
+    private var favoritesRefreshTask: Task<Void, Never>?
 
     func templateApplicationScene(
         _ templateApplicationScene: CPTemplateApplicationScene,
@@ -92,7 +95,12 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         openPlaylistTemplates.removeAll()
         openPlaylistSongs.removeAll()
         openPlaylists.removeAll()
-        cancellables.removeAll()
+        contentObservation?.cancel()
+        contentObservation = nil
+        favoritesObservation?.cancel()
+        favoritesObservation = nil
+        templateRefreshTask?.cancel()
+        favoritesRefreshTask?.cancel()
         self.interfaceController = nil
         if !player.isRadioMode {
             radio.stop()
@@ -125,42 +133,57 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     }
 
     private func observeContentChanges() {
-        cancellables.removeAll()
+        contentObservation?.cancel()
+        favoritesObservation?.cancel()
 
-        let signals: [AnyPublisher<Void, Never>] = [
-            player.$currentSong.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            player.$isPlaying.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            player.$queue.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            radio.$nowPlaying.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            radio.$isRefreshing.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            radio.$refreshErrorMessage.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            radio.$lastUpdated.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            SavedPlaylistsStore.shared.$playlists.dropFirst().map { _ in }.eraseToAnyPublisher(),
-            UserPlaylistsManager.shared.$playlists.dropFirst().map { _ in }.eraseToAnyPublisher(),
-        ]
+        // Replaces `Publishers.MergeMany(...).debounce(150ms)`. `observeContinuously`
+        // only fires on change, which is what the `dropFirst()` on each signal
+        // was for.
+        contentObservation = observeContinuously({
+            _ = self.player.currentSong
+            _ = self.player.isPlaying
+            _ = self.player.queue
+            _ = self.radio.nowPlaying
+            _ = self.radio.isRefreshing
+            _ = self.radio.refreshErrorMessage
+            _ = self.radio.lastUpdated
+            _ = SavedPlaylistsStore.shared.playlists
+            _ = UserPlaylistsManager.shared.playlists
+        }, onChange: { [weak self] in
+            self?.scheduleTemplateRefresh()
+        })
 
-        Publishers.MergeMany(signals)
-            .debounce(for: .milliseconds(150), scheduler: DispatchQueue.main)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                self?.refreshVisibleTemplates()
-            }
-            .store(in: &cancellables)
-
-        // Favourites get their own subscription rather than joining the merge:
+        // Favourites get their own observation rather than joining the merge:
         // the count is only ever shown in the Playlists template, and a live
         // emission means the local set is authoritative — including when a
         // removal takes it below whatever the server last reported. Seeding the
         // count from an unloaded manager would instead read a spurious zero.
-        FavoritesManager.shared.$favoriteIDs
-            .dropFirst()
-            .debounce(for: .milliseconds(150), scheduler: DispatchQueue.main)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] favoriteIDs in
-                self?.favoritesSongCount = favoriteIDs.count
-                self?.rebuildPlaylistsTemplate()
-            }
-            .store(in: &cancellables)
+        favoritesObservation = observeContinuously({
+            _ = FavoritesManager.shared.favoriteIDs
+        }, onChange: { [weak self] in
+            self?.scheduleFavoritesRefresh()
+        })
+    }
+
+    /// Stands in for the former `.debounce(for: .milliseconds(150))`: template
+    /// rebuilds are expensive and a queue edit churns several properties at once.
+    private func scheduleTemplateRefresh() {
+        templateRefreshTask?.cancel()
+        templateRefreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled, let self else { return }
+            refreshVisibleTemplates()
+        }
+    }
+
+    private func scheduleFavoritesRefresh() {
+        favoritesRefreshTask?.cancel()
+        favoritesRefreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled, let self else { return }
+            favoritesSongCount = FavoritesManager.shared.favoriteIDs.count
+            rebuildPlaylistsTemplate()
+        }
     }
 
     private func loadCarPlayContent() {

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Combine
 
 struct BrowseSongCollectionView: View {
     let title: String
@@ -132,7 +131,7 @@ struct BrowseSongCollectionView: View {
             .onAppear {
                 pickFallbackHeroURLIfNeeded()
             }
-            .onReceive(FallbackArtProvider.shared.objectWillChange) { _ in
+            .onChange(of: FallbackArtRevision.shared.revision) { _, _ in
                 fallbackHeroURL = nil
                 pickFallbackHeroURLIfNeeded()
             }

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct HomeView: View {
-    @EnvironmentObject var viewModel: HomeViewModel
-    @ObservedObject private var recentlyPlayed = RecentlyPlayedStore.shared
+    @Environment(HomeViewModel.self) var viewModel
+    private let recentlyPlayed = RecentlyPlayedStore.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var artworkPrefetchTracker = ArtworkPrefetchTracker()
@@ -41,6 +41,7 @@ struct HomeView: View {
                 }
             }
             .refreshable { await viewModel.refreshHomeData() }
+            .task { viewModel.fetchHomeData() }
             .onChange(of: artworkPrefetchSignature) { _, _ in
                 prefetchVisibleArtworkIfNeeded()
             }

--- a/Twinskaraoke/Features/Home/NewView.swift
+++ b/Twinskaraoke/Features/Home/NewView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct NewView: View {
-    @EnvironmentObject var viewModel: HomeViewModel
-    @ObservedObject private var recentlyPlayed = RecentlyPlayedStore.shared
+    @Environment(HomeViewModel.self) var viewModel
+    private let recentlyPlayed = RecentlyPlayedStore.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var artworkPrefetchTracker = ArtworkPrefetchTracker()
@@ -40,6 +40,7 @@ struct NewView: View {
                 }
             }
             .refreshable { await viewModel.refreshHomeData() }
+            .task { viewModel.fetchHomeData() }
             .onChange(of: artworkPrefetchSignature) { _, _ in
                 prefetchVisibleArtworkIfNeeded()
             }

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 
 struct PlaylistListView: View {
@@ -6,7 +5,7 @@ struct PlaylistListView: View {
     let playlists: [Playlist]
     var apiURL: ((Int, Int) -> String)?
     let cols = AM.Layout.playlistGridColumns
-    @StateObject private var loader = PlaylistListLoader()
+    @State private var loader = PlaylistListLoader()
     @State private var searchText = ""
     private var allPlaylists: [Playlist] {
         loader.playlists.isEmpty ? playlists : loader.playlists

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtGalleryView.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtGalleryView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ArtGalleryView: View {
-    @StateObject private var viewModel = ArtGalleryViewModel()
+    @State private var viewModel = ArtGalleryViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
 
     var body: some View {

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -1,9 +1,8 @@
-import Combine
 import Foundation
 import SwiftUI
 
 struct ArtistsView: View {
-    @StateObject private var viewModel = ArtistsViewModel()
+    @State private var viewModel = ArtistsViewModel()
     @State private var searchText = ""
 
 
@@ -154,7 +153,7 @@ private struct ArtistAvatarPlaceholder: View {
 
 struct ArtistDetailView: View {
     let artist: Artist
-    @StateObject private var loader = ArtistDetailViewModel()
+    @State private var loader = ArtistDetailViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showsCollapsedTitle = false
     private var current: Artist {

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct CreatePlaylistSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
-    @ObservedObject private var manager = UserPlaylistsManager.shared
+    private let manager = UserPlaylistsManager.shared
 
     @State private var name = ""
     @State private var playlistDescription = ""

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -6,8 +6,8 @@ private struct DownloadedSongRowIdentity: Hashable {
 }
 
 struct DownloadedSongsView: View {
-    @ObservedObject private var downloads = DownloadManager.shared
-    @ObservedObject private var recentlyPlayed = RecentlyPlayedStore.shared
+    private let downloads = DownloadManager.shared
+    private let recentlyPlayed = RecentlyPlayedStore.shared
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var localSongs: [Song] = []
     @State private var refreshTask: Task<Void, Never>?
@@ -410,7 +410,7 @@ private struct DownloadedEmptyHintRow: View {
 private struct DownloadedSongMenuItems: View {
     let song: Song
     let onRemove: () -> Void
-    @ObservedObject private var favorites = FavoritesManager.shared
+    private let favorites = FavoritesManager.shared
 
     var body: some View {
         Button {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import SwiftUI
 
@@ -7,7 +6,7 @@ struct PlaylistSongCountLabel: View {
     var fallbackText: String?
     var prefersDetailCount = true
 
-    @ObservedObject private var countStore = PlaylistSongCountStore.shared
+    private let countStore = PlaylistSongCountStore.shared
 
     private var labelText: String? {
         if let count = countStore.displayedCount(
@@ -42,10 +41,10 @@ struct PlaylistSongCountLabel: View {
 }
 
 struct LibraryView: View {
-    @StateObject var viewModel = PlaylistsViewModel()
-    @StateObject private var recentSongsViewModel = LibrarySongsViewModel()
-    @ObservedObject private var savedStore = SavedPlaylistsStore.shared
-    @ObservedObject private var favorites = FavoritesManager.shared
+    @State var viewModel = PlaylistsViewModel()
+    @State private var recentSongsViewModel = LibrarySongsViewModel()
+    private let savedStore = SavedPlaylistsStore.shared
+    private let favorites = FavoritesManager.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showCreateSheet = false
     @State private var path = NavigationPath()
@@ -375,7 +374,7 @@ private struct WideLibraryHero: View {
 }
 
 struct LibrarySongsView: View {
-    @StateObject private var viewModel = LibrarySongsViewModel()
+    @State private var viewModel = LibrarySongsViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var prefetchedIDs: [String] = []
 
@@ -619,9 +618,9 @@ struct PlaylistListRow: View {
 }
 
 struct PlaylistsGridScreen: View {
-    @ObservedObject var viewModel: PlaylistsViewModel
-    @ObservedObject private var userManager = UserPlaylistsManager.shared
-    @ObservedObject private var favorites = FavoritesManager.shared
+    let viewModel: PlaylistsViewModel
+    private let userManager = UserPlaylistsManager.shared
+    private let favorites = FavoritesManager.shared
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showCreateSheet = false
     @State private var searchText = ""

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -44,8 +44,14 @@ struct PlaylistDetailView: View {
     var body: some View {
         let _ = fallbackArt.revision
         let songs: [Song] = loader.songs ?? playlist.songListDTOs ?? []
-        let displayedSongs = filteredSongs
         let isSearching = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        // Derive the unfiltered list rather than mirroring it into @State.
+        //
+        // `filteredSongs` is only meaningful while a search is active. Using it
+        // as the sole source made the whole screen depend on a sync that had no
+        // way to self-correct: if it was ever missed, the list stayed empty and
+        // stayed empty. See the `onChange(of: loader.songs)` note below.
+        let displayedSongs = isSearching ? filteredSongs : songs
         GeometryReader { geo in
             ScrollView {
                 playlistScrollContent(
@@ -55,6 +61,17 @@ struct PlaylistDetailView: View {
                     width: geo.size.width
                 )
                     .padding(.bottom, 16)
+                    // Row changes (e.g. unfavouriting) used to animate via the
+                    // `filteredSongs` swap; now that the list is derived, the
+                    // animation attaches to the value instead. Same 300-row
+                    // guard: animating a large structural swap stalls the main
+                    // thread.
+                    .animation(
+                        reduceMotion || displayedSongs.count >= 300
+                            ? nil
+                            : AppMotion.quick,
+                        value: displayedSongs
+                    )
             }
             .smoothScrolling()
             .scrollDismissesKeyboard(.interactively)
@@ -160,6 +177,17 @@ struct PlaylistDetailView: View {
                 filteredSongs = PlaylistSongSearch.filter(currentSongs, matching: newValue)
             }
         }
+        // Keeps the *search* results fresh when the playlist reloads underneath
+        // an active query. It deliberately no longer feeds the unfiltered list.
+        //
+        // This was `.onReceive(loader.$songs)`, and the two are not equivalent.
+        // A `@Published` projected publisher replays its current value to every
+        // new subscriber, so that fired on each appear and re-seeded the list
+        // unconditionally. `onChange` fires neither on install nor when the new
+        // value compares equal to the old. Both gaps bit: a playlist already
+        // loaded when the view appeared never seeded, and Refresh re-fetched an
+        // *equal* array, so nothing fired and the empty list could not recover
+        // until the view was destroyed by popping back to Library.
         .onChange(of: loader.songs) { _, newSongs in
             let next = PlaylistSongSearch.filter(
                 newSongs ?? playlist.songListDTOs ?? [],

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 
 struct PlaylistDetailView: View {
@@ -7,9 +6,11 @@ struct PlaylistDetailView: View {
     let playlist: Playlist
     @Environment(\.appReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @StateObject private var loader = PlaylistDetailViewModel()
-    @ObservedObject private var favorites = FavoritesManager.shared
-    @ObservedObject private var fallbackArt = FallbackArtProvider.shared
+    @State private var loader = PlaylistDetailViewModel()
+    private let favorites = FavoritesManager.shared
+    // Rows derive artwork URLs through `Song`, which consults the fallback
+    // pool; reading the revision in `body` re-renders them when it changes.
+    private let fallbackArt = FallbackArtRevision.shared
     @State private var showsCollapsedTitle = false
     @State private var searchText = ""
     @State private var filteredSongs: [Song]
@@ -41,6 +42,7 @@ struct PlaylistDetailView: View {
 
 
     var body: some View {
+        let _ = fallbackArt.revision
         let songs: [Song] = loader.songs ?? playlist.songListDTOs ?? []
         let displayedSongs = filteredSongs
         let isSearching = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -67,6 +69,13 @@ struct PlaylistDetailView: View {
                 // logs "tried to update multiple times per frame" and drops
                 // the intermediate scroll events. main.async is enough here:
                 // lighter than a Task per scroll event and strictly FIFO.
+                //
+                // Coalescing these to one update per runloop turn *does* silence
+                // that log (and the `<width>x0` offscreen-buffer errors from the
+                // search field animating through zero height), but it visibly
+                // hurt fast-scroll feel: the pull/parallax logic needs the
+                // intermediate offsets, not just the newest one. The log noise
+                // is cosmetic; the scroll feel is not. Left as-is deliberately.
                 DispatchQueue.main.async {
                     updateSearchInteraction(scrollOffset: scrollOffset)
                 }
@@ -151,7 +160,7 @@ struct PlaylistDetailView: View {
                 filteredSongs = PlaylistSongSearch.filter(currentSongs, matching: newValue)
             }
         }
-        .onReceive(loader.$songs) { newSongs in
+        .onChange(of: loader.songs) { _, newSongs in
             let next = PlaylistSongSearch.filter(
                 newSongs ?? playlist.songListDTOs ?? [],
                 matching: searchText
@@ -354,9 +363,16 @@ struct PlaylistDetailView: View {
             variant: .thumbnail
         )
         ArtworkPrefetcher.shared.prefetchSongs(
-            Array(songs.prefix(18)),
-            limit: 18,
+            Array(songs.prefix(ArtworkPrefetcher.songWindow)),
             reason: "playlist songs \(playlist.id)",
+            variant: .row
+        )
+        // The windowed prefetch above only stays just ahead of the visible
+        // rows, which a fast flick outruns. Warm the *whole* playlist onto disk
+        // as well, so a second visit scrolls with no placeholders at all.
+        ArtworkPrefetcher.shared.warmCollection(
+            songs: songs,
+            reason: "playlist warm \(playlist.id)",
             variant: .row
         )
     }

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RandomSongsView: View {
-    @StateObject private var viewModel = RandomSongsViewModel()
+    @State private var viewModel = RandomSongsViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct UploadedSongsView: View {
-    @StateObject private var viewModel = UploadedSongsViewModel()
+    @State private var viewModel = UploadedSongsViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var prefetchedIDs: [String] = []
 

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -28,7 +28,7 @@ import SwiftUI
 #endif
 
 struct VideoGalleryView: View {
-    @StateObject private var viewModel = VideoGalleryViewModel()
+    @State private var viewModel = VideoGalleryViewModel()
     private let cols = AM.Layout.adaptiveGridColumns(minimum: 164, spacing: 16)
     var body: some View {
         ScrollView {
@@ -390,7 +390,7 @@ struct VideoPlayerScreen: View {
     let video: GalleryVideo
     @State private var player: AVPlayer?
     @State private var appeared = false
-    @StateObject private var similar = SimilarVideosViewModel()
+    @State private var similar = SimilarVideosViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
     private let audioWillPlay = NotificationCenter.default.publisher(
         for: MediaPlaybackCoordinator.audioWillPlay

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -235,7 +235,7 @@ private struct PlayerFavoriteButton: View {
     var size: CGFloat = 44
     var showsChrome: Bool = true
 
-    @ObservedObject private var favorites = FavoritesManager.shared
+    private let favorites = FavoritesManager.shared
     @Environment(\.appReduceMotion) private var reduceMotion
 
     var body: some View {
@@ -298,9 +298,9 @@ private struct PlayerMoreMenu: View {
 }
 
 struct FullScreenPlayerView: View {
-    @EnvironmentObject var audioManager: AudioPlayerManager
-    @ObservedObject private var popupPresentation = PopupPresentationState.shared
-    @ObservedObject private var favorites = FavoritesManager.shared
+    @Environment(AudioPlayerManager.self) var audioManager
+    private let popupPresentation = PopupPresentationState.shared
+    private let favorites = FavoritesManager.shared
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showingQueue = false
@@ -317,8 +317,8 @@ struct FullScreenPlayerView: View {
     @State private var easterEggArtistLink: String?
     @State private var coverArtArtistName: String?
     @State private var coverArtArtistLink: String?
-    @StateObject private var lyricsViewModel = LyricsViewModel()
-    @StateObject private var upcomingLyricsViewModel = LyricsViewModel()
+    @State private var lyricsViewModel = LyricsViewModel()
+    @State private var upcomingLyricsViewModel = LyricsViewModel()
 
     var body: some View {
         let song = audioManager.currentSong
@@ -381,10 +381,10 @@ struct FullScreenPlayerView: View {
             Group {
                 if audioManager.isRadioMode {
                     RadioQueueView()
-                        .environmentObject(audioManager)
+                        .environment(audioManager)
                 } else {
                     QueueView()
-                        .environmentObject(audioManager)
+                        .environment(audioManager)
                 }
             }
             .presentationDetents([.medium, .large])
@@ -944,8 +944,8 @@ struct FullScreenPlayerView: View {
 
     private struct PlayerProgressSection: View {
         let metrics: PlayerLayoutMetrics
-        @EnvironmentObject private var audioManager: AudioPlayerManager
-        @ObservedObject private var clock = PlaybackClock.shared
+        @Environment(AudioPlayerManager.self) private var audioManager
+        private let clock = PlaybackClock.shared
         @Environment(\.appReduceMotion) private var reduceMotion
 
         private func formattedTime(_ seconds: Double) -> String {
@@ -954,9 +954,11 @@ struct FullScreenPlayerView: View {
         }
 
         var body: some View {
+            @Bindable var clock = clock
+            @Bindable var audioManager = audioManager
             let duration = max(audioManager.playbackDuration, 0)
             let elapsed = min(max(audioManager.playbackTime, 0), duration)
-            VStack(spacing: 0) {
+            return VStack(spacing: 0) {
                 AppleMusicProgressBar(
                     progress: $clock.progress,
                     isScrubbing: $audioManager.isEditingProgress,
@@ -995,10 +997,17 @@ struct FullScreenPlayerView: View {
         var hasNoLyrics: Bool = false
         let onSeek: (TimeInterval) -> Void
         var onRetry: (() -> Void)?
-        @ObservedObject private var clock = PlaybackClock.shared
-        @EnvironmentObject private var audioManager: AudioPlayerManager
+        private let clock = PlaybackClock.shared
+        @Environment(AudioPlayerManager.self) private var audioManager
 
         var body: some View {
+            // This read is load-bearing. `audioManager.playbackTime` is a
+            // computed property over the AVPlayer, so it registers nothing with
+            // observation — reading `clock.progress`, which ticks with playback,
+            // is what re-evaluates this view and advances the highlighted line.
+            // Under @ObservedObject merely holding `clock` subscribed the view;
+            // @Observable only tracks properties that are actually read.
+            let _ = clock.progress
             LyricsView(
                 lyrics: lyrics,
                 currentTime: audioManager.playbackTime,

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct QueueView: View {
-    @EnvironmentObject var audioManager: AudioPlayerManager
+    @Environment(AudioPlayerManager.self) var audioManager
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showCurrentAddToPlaylist = false
@@ -248,7 +248,7 @@ struct QueueView: View {
             }
         } preview: {
             SongContextPreview(song: current)
-                .environmentObject(audioManager)
+                .environment(audioManager)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Now Playing")

--- a/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
+++ b/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 struct RadioPlayerLayout: View {
-    @EnvironmentObject var audioManager: AudioPlayerManager
-    @ObservedObject var favorites: FavoritesManager
-    @ObservedObject private var radio = RadioController.shared
+    @Environment(AudioPlayerManager.self) var audioManager
+    let favorites: FavoritesManager
+    private let radio = RadioController.shared
     @Environment(\.appReduceMotion) private var reduceMotion
     @Binding var showingQueue: Bool
     let song: Song

--- a/Twinskaraoke/Features/Radio/RadioQueueView.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct RadioQueueView: View {
-    @ObservedObject var radio = RadioController.shared
-    @EnvironmentObject var audioManager: AudioPlayerManager
+    let radio = RadioController.shared
+    @Environment(AudioPlayerManager.self) var audioManager
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appReduceMotion) private var reduceMotion
 

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -1,45 +1,47 @@
 import Combine
 import SwiftUI
+import Observation
 
 @MainActor
-private final class RadioPlaybackState: ObservableObject {
+@Observable
+private final class RadioPlaybackState {
     static let shared = RadioPlaybackState()
 
-    @Published private(set) var currentSongID: String?
-    @Published private(set) var isPlaying = false
-    @Published private(set) var isBuffering = false
-    @Published private(set) var isRadioMode = false
+    private(set) var currentSongID: String?
+    private(set) var isPlaying = false
+    private(set) var isBuffering = false
+    private(set) var isRadioMode = false
 
-    private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var observation: ObservationToken?
 
     private init() {
+        observation = observeContinuously({
+            let manager = AudioPlayerManager.shared
+            _ = manager.currentSong
+            _ = manager.isPlaying
+            _ = manager.isBuffering
+            _ = manager.isRadioMode
+        }, onChange: { [weak self] in
+            self?.syncFromPlayer()
+        })
+        syncFromPlayer()
+    }
+
+    /// See `PlaybackRowState.syncFromPlayer`: the guards stand in for the
+    /// `removeDuplicates` the former `$property.sink` pipelines carried.
+    private func syncFromPlayer() {
         let manager = AudioPlayerManager.shared
-        manager.$currentSong
-            .map(\.?.id)
-            .removeDuplicates()
-            .sink { [weak self] in self?.currentSongID = $0 }
-            .store(in: &cancellables)
-
-        manager.$isPlaying
-            .removeDuplicates()
-            .sink { [weak self] in self?.isPlaying = $0 }
-            .store(in: &cancellables)
-
-        manager.$isBuffering
-            .removeDuplicates()
-            .sink { [weak self] in self?.isBuffering = $0 }
-            .store(in: &cancellables)
-
-        manager.$isRadioMode
-            .removeDuplicates()
-            .sink { [weak self] in self?.isRadioMode = $0 }
-            .store(in: &cancellables)
+        let songID = manager.currentSong?.id
+        if currentSongID != songID { currentSongID = songID }
+        if isPlaying != manager.isPlaying { isPlaying = manager.isPlaying }
+        if isBuffering != manager.isBuffering { isBuffering = manager.isBuffering }
+        if isRadioMode != manager.isRadioMode { isRadioMode = manager.isRadioMode }
     }
 }
 
 struct RadioView: View {
-    @ObservedObject private var radio = RadioController.shared
-    @ObservedObject private var playback = RadioPlaybackState.shared
+    private let radio = RadioController.shared
+    private let playback = RadioPlaybackState.shared
     @Environment(\.appReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showingRadioSchedule = false

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 struct SearchView: View {
-    @StateObject var viewModel = SearchViewModel()
+    @State var viewModel = SearchViewModel()
 
-    @ObservedObject private var playback = PlaybackRowState.shared
+    private let playback = PlaybackRowState.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var pendingSongID: String?
@@ -175,9 +175,9 @@ private struct SearchResultsSummaryHeader: View {
 
 private struct BrowseCategoriesView: View {
     let availableWidth: CGFloat
-    @StateObject private var genresVM = GenresViewModel()
-    @StateObject private var topChartVM = TopChartViewModel()
-    @StateObject private var publicPlaylistsVM = PublicPlaylistsViewModel()
+    @State private var genresVM = GenresViewModel()
+    @State private var topChartVM = TopChartViewModel()
+    @State private var publicPlaylistsVM = PublicPlaylistsViewModel()
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private let genres: [(String, [Color])] = [
         (
@@ -466,7 +466,7 @@ private struct BrowseCategoriesView: View {
 }
 
 private struct TopChartCollectionView: View {
-    @ObservedObject var viewModel: TopChartViewModel
+    let viewModel: TopChartViewModel
 
     var body: some View {
         BrowseSongCollectionView(
@@ -480,7 +480,7 @@ private struct TopChartCollectionView: View {
 }
 
 private struct PublicPlaylistsCollectionView: View {
-    @ObservedObject var viewModel: PublicPlaylistsViewModel
+    let viewModel: PublicPlaylistsViewModel
 
     var body: some View {
         PlaylistListView(
@@ -498,7 +498,7 @@ private struct PublicPlaylistsCollectionView: View {
 
 struct GenreDetailView: View {
     let genre: GenreSummary
-    @ObservedObject var viewModel: GenresViewModel
+    let viewModel: GenresViewModel
     let palette: [Color]
 
     var body: some View {
@@ -558,7 +558,7 @@ private struct GenreDetailLoadingView: View {
 struct SearchCategorySongCollectionView: View {
     let title: String
     let query: String
-    @StateObject private var loader: SearchCategorySongsViewModel
+    @State private var loader: SearchCategorySongsViewModel
     @Environment(\.appReduceMotion) private var reduceMotion
 
     private var categoryStateAnimation: Animation? {
@@ -569,7 +569,7 @@ struct SearchCategorySongCollectionView: View {
     init(title: String, query: String) {
         self.title = title
         self.query = query
-        _loader = StateObject(wrappedValue: SearchCategorySongsViewModel(query: query))
+        _loader = State(initialValue: SearchCategorySongsViewModel(query: query))
     }
 
     var body: some View {

--- a/Twinskaraoke/Models/Home/HomeViewModel.swift
+++ b/Twinskaraoke/Models/Home/HomeViewModel.swift
@@ -1,32 +1,37 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class HomeViewModel: ObservableObject {
+@Observable
+final class HomeViewModel {
     private enum TopPicksSource {
         case publicPlaylists
         case setlists
     }
 
-    @Published var trending: [Song] = []
-    @Published var suggestions: [Song] = []
-    @Published var recentPlaylists: [Playlist] = []
-    @Published var newReleases: [Song] = []
-    @Published var isLoading = false
-    @Published var isLoadingMoreTopPicks = false
-    @Published var canLoadMoreTopPicks = true
-    @Published var latestSingle: Song?
-    @Published var latestSingleContext: [Song] = []
-    private var hasLoaded = false
-    private var topPicksPage = 0
-    private let topPicksPageSize = 12
-    private var topPicksSource: TopPicksSource = .setlists
-    private var dataGeneration = 0
-    private var homeLoadTask: Task<Void, Never>?
+    var trending: [Song] = []
+    var suggestions: [Song] = []
+    var recentPlaylists: [Playlist] = []
+    var newReleases: [Song] = []
+    var isLoading = false
+    var isLoadingMoreTopPicks = false
+    var canLoadMoreTopPicks = true
+    var latestSingle: Song?
+    var latestSingleContext: [Song] = []
+    // Bookkeeping the views never read; keep it out of the observation graph.
+    @ObservationIgnored private var hasLoaded = false
+    @ObservationIgnored private var topPicksPage = 0
+    @ObservationIgnored private let topPicksPageSize = 12
+    @ObservationIgnored private var topPicksSource: TopPicksSource = .setlists
+    @ObservationIgnored private var dataGeneration = 0
+    @ObservationIgnored private var homeLoadTask: Task<Void, Never>?
 
-    init() {
-        fetchHomeData()
-    }
+    // No work in init. This type is held in `@State`, whose initial-value
+    // expression is re-evaluated on every re-initialization of the owning view
+    // struct (only the first instance is kept). `@StateObject` took an
+    // @autoclosure and evaluated it once, so an init-time fetch was safe there
+    // and is a request flood here. The fetch is driven from the view's .task
+    // instead, and `hasLoaded` keeps it to one round trip.
 
     func fetchHomeData(force: Bool = false) {
         if AppRuntime.isUITestMode {

--- a/Twinskaraoke/Models/Home/PlaylistListLoader.swift
+++ b/Twinskaraoke/Models/Home/PlaylistListLoader.swift
@@ -1,9 +1,10 @@
-import Combine
 import Foundation
+import Observation
 
-final class PlaylistListLoader: ObservableObject {
-    @Published var playlists: [Playlist] = []
-    @Published var isLoadingMore = false
+@Observable
+final class PlaylistListLoader {
+    var playlists: [Playlist] = []
+    var isLoadingMore = false
     private var canLoadMore = true
     private let pageSize = 25
     private var urlBuilder: ((Int, Int) -> String)?

--- a/Twinskaraoke/Models/Library/ArtistsViewModel.swift
+++ b/Twinskaraoke/Models/Library/ArtistsViewModel.swift
@@ -1,16 +1,17 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class ArtistsViewModel: ObservableObject {
-    @Published var artists: [Artist] = []
-    @Published var isLoading = false
-    @Published var canLoadMore = true
-    @Published private(set) var loadFailed = false
+@Observable
+final class ArtistsViewModel {
+    var artists: [Artist] = []
+    var isLoading = false
+    var canLoadMore = true
+    private(set) var loadFailed = false
     private var page = 0
     private let pageSize = 25
     private var loadGeneration = 0
-    private var activeTask: Task<Void, Never>?
+    @ObservationIgnored private var activeTask: Task<Void, Never>?
     func fetchInitial() {
         guard artists.isEmpty, !isLoading else { return }
         page = 0
@@ -98,14 +99,15 @@ final class ArtistsViewModel: ObservableObject {
 }
 
 @MainActor
-final class ArtistDetailViewModel: ObservableObject {
-    @Published var artist: Artist?
-    @Published var isLoading = false
-    @Published private(set) var hasLoadedDetail = false
-    @Published var errorMessage: String?
+@Observable
+final class ArtistDetailViewModel {
+    var artist: Artist?
+    var isLoading = false
+    private(set) var hasLoadedDetail = false
+    var errorMessage: String?
     private var loadedID: String?
     private var loadGeneration = 0
-    private var activeTask: Task<Void, Never>?
+    @ObservationIgnored private var activeTask: Task<Void, Never>?
 
     func load(id: String, fallback: Artist?, force: Bool = false) {
         if !force, loadedID == id, hasLoadedDetail { return }

--- a/Twinskaraoke/Models/Library/GalleryModels.swift
+++ b/Twinskaraoke/Models/Library/GalleryModels.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 struct GalleryArtist: Codable, Identifiable, Equatable {
     let id: String
@@ -43,10 +43,11 @@ struct GalleryArt: Codable, Identifiable, Equatable {
 }
 
 @MainActor
-final class ArtGalleryViewModel: ObservableObject {
-    @Published var artists: [GalleryArtist] = []
-    @Published var isLoading = false
-    @Published var loadFailed = false
+@Observable
+final class ArtGalleryViewModel {
+    var artists: [GalleryArtist] = []
+    var isLoading = false
+    var loadFailed = false
     private var hasLoaded = false
 
     func fetch(force: Bool = false) {

--- a/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/LibrarySongsViewModel.swift
@@ -1,36 +1,46 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class LibrarySongsViewModel: ObservableObject {
-    @Published var songs: [Song] = [] {
+@Observable
+final class LibrarySongsViewModel {
+    var songs: [Song] = [] {
         didSet { songsGeneration &+= 1 }
     }
-    @Published var isLoading = false
-    @Published var isLoadingMore = false
-    @Published var sort: LibrarySongSort = .recentlyAdded {
+    var isLoading = false
+    var isLoadingMore = false
+    var sort: LibrarySongSort = .recentlyAdded {
         didSet { rebuildDisplayedSongs() }
     }
-    @Published var searchText = ""
-    @Published private(set) var displayedSongs: [Song] = []
-    @Published private(set) var loadFailed = false
+    var searchText = "" {
+        didSet { scheduleDisplayedSongsRebuild() }
+    }
+    private(set) var displayedSongs: [Song] = []
+    private(set) var loadFailed = false
     private var hasLoaded = false
     private var canLoadMore = true
     private var page = 1
     private var requestToken = 0
     private var isReplacing = false
-    private var activeTask: Task<Void, Never>?
-    private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var activeTask: Task<Void, Never>?
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
+    @ObservationIgnored private var lastRebuiltSearchText = ""
     private var songsGeneration: UInt64 = 0
     private var sortCache: (sort: LibrarySongSort, generation: UInt64, songs: [Song])?
     private let pageSize = 40
 
-    init() {
-        $searchText
-            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
-            .removeDuplicates()
-            .sink { [weak self] _ in self?.rebuildDisplayedSongs() }
-            .store(in: &cancellables)
+    /// Replaces `$searchText.debounce(200ms).removeDuplicates()`. Filtering a
+    /// large library runs localized comparisons per song, so keystrokes must
+    /// still coalesce.
+    private func scheduleDisplayedSongsRebuild() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled, let self else { return }
+            guard searchText != lastRebuiltSearchText else { return }
+            lastRebuiltSearchText = searchText
+            rebuildDisplayedSongs()
+        }
     }
 
     // Sorting is the expensive half of a rebuild; cache it per (sort, songs)

--- a/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistDetailViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 nonisolated enum PlaylistSongSearch {
     static func filter(_ songs: [Song], matching searchText: String) -> [Song] {
@@ -60,13 +60,14 @@ nonisolated struct PlaylistSearchRevealState: Equatable {
 }
 
 @MainActor
-class PlaylistDetailViewModel: ObservableObject {
-    @Published var songs: [Song]?
-    @Published var isLoading = false
-    @Published private(set) var hasAuthoritativeSongs = false
-    @Published private var loadFailed = false
+@Observable
+class PlaylistDetailViewModel {
+    var songs: [Song]?
+    var isLoading = false
+    private(set) var hasAuthoritativeSongs = false
+    private var loadFailed = false
     private var loadedID: String?
-    private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
     var emptyStateMessage: String {
         if loadFailed {
             return "The playlist couldn't be loaded. Check your connection and try again."

--- a/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
+++ b/Twinskaraoke/Models/Library/PlaylistSongCountStore.swift
@@ -1,11 +1,12 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class PlaylistSongCountStore: ObservableObject {
+@Observable
+final class PlaylistSongCountStore {
     static let shared = PlaylistSongCountStore()
 
-    @Published private var resolvedCounts: [String: Int] = [:]
+    private var resolvedCounts: [String: Int] = [:]
     private var loadingIDs: Set<String> = []
     private var generations: [String: UInt64] = [:]
 

--- a/Twinskaraoke/Models/Library/PlaylistsViewModel.swift
+++ b/Twinskaraoke/Models/Library/PlaylistsViewModel.swift
@@ -1,33 +1,35 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class PlaylistsViewModel: ObservableObject {
-    @Published var playlists: [Playlist] = []
-    @Published var favoriteSongs: [Song] = []
-    @Published var isLoading = false
-    @Published var isLoadingFavorites = false
+@Observable
+final class PlaylistsViewModel {
+    var playlists: [Playlist] = []
+    var favoriteSongs: [Song] = []
+    var isLoading = false
+    var isLoadingFavorites = false
     /// Server + saved + user playlists, merged and deduped once per source
     /// change instead of on every view body evaluation.
-    @Published private(set) var combinedPlaylists: [Playlist] = []
-    private var hasLoadedPlaylists = false
-    private var hasLoadedFavoriteSongs = false
-    private var cancellables = Set<AnyCancellable>()
+    private(set) var combinedPlaylists: [Playlist] = []
+    @ObservationIgnored private var hasLoadedPlaylists = false
+    @ObservationIgnored private var hasLoadedFavoriteSongs = false
+    @ObservationIgnored private var sourceObservation: ObservationToken?
 
     init() {
-        let sourceChanges = Publishers.Merge4(
-            $playlists.map { _ in },
-            $favoriteSongs.map { _ in },
-            SavedPlaylistsStore.shared.$playlists.map { _ in },
-            UserPlaylistsManager.shared.$playlists.map { _ in }
-        )
-        .merge(with: FavoritesManager.shared.$favoriteIDs.map { _ in })
-        // @Published fires from willSet; hop one main-queue pass so the
-        // recompute below reads the already-updated values.
-        .receive(on: DispatchQueue.main)
-        sourceChanges
-            .sink { [weak self] in self?.recomputeCombinedPlaylists() }
-            .store(in: &cancellables)
+        // Replaces the Merge5 of `$playlists`, `$favoriteSongs`, the two stores
+        // and `$favoriteIDs`. `observeContinuously` already hops to the next
+        // main-actor turn before calling back, which is what the old
+        // `.receive(on: DispatchQueue.main)` was there for — observation fires
+        // from willSet, so the recompute must not read pre-write values.
+        sourceObservation = observeContinuously({
+            _ = self.playlists
+            _ = self.favoriteSongs
+            _ = SavedPlaylistsStore.shared.playlists
+            _ = UserPlaylistsManager.shared.playlists
+            _ = FavoritesManager.shared.favoriteIDs
+        }, onChange: { [weak self] in
+            self?.recomputeCombinedPlaylists()
+        })
         recomputeCombinedPlaylists()
     }
 
@@ -54,7 +56,14 @@ final class PlaylistsViewModel: ObservableObject {
         let uniqueUser = UserPlaylistsManager.shared.playlists
             .map { $0.asPlaylist() }
             .filter { !existingIDs.contains($0.id) }
-        combinedPlaylists = uniqueUser + all
+        let next = uniqueUser + all
+        // Guarded because @Observable publishes on every write, including one
+        // that stores an identical value, and `favoritesPlaylist` builds a fresh
+        // struct on each call — so an unguarded assignment re-renders the whole
+        // library on any unrelated source change. Combine's removeDuplicates
+        // used to absorb this.
+        guard next != combinedPlaylists else { return }
+        combinedPlaylists = next
     }
 
     func recentlyAddedPlaylists(saved: [Playlist]) -> [Playlist] {

--- a/Twinskaraoke/Models/Library/RandomSongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/RandomSongsViewModel.swift
@@ -1,17 +1,18 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class RandomSongsViewModel: ObservableObject {
+@Observable
+final class RandomSongsViewModel {
     static let playlistID = "__random_songs__"
 
-    @Published private(set) var songs: [Song] = []
-    @Published private(set) var isLoading = false
-    @Published private(set) var errorMessage: String?
+    private(set) var songs: [Song] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
 
     private var hasLoaded = false
     private var requestToken = 0
-    private var loadTask: Task<[Song], Error>?
+    @ObservationIgnored private var loadTask: Task<[Song], Error>?
 
     var playlist: Playlist {
         Playlist(

--- a/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
+++ b/Twinskaraoke/Models/Library/UploadedSongsViewModel.swift
@@ -1,34 +1,44 @@
 import AVFoundation
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class UploadedSongsViewModel: ObservableObject {
-    @Published private(set) var songs: [Song] = [] {
+@Observable
+final class UploadedSongsViewModel {
+    private(set) var songs: [Song] = [] {
         didSet { songsGeneration &+= 1 }
     }
-    @Published private(set) var displayedSongs: [Song] = []
-    @Published private(set) var isLoading = false
-    @Published private(set) var requiresSignIn = false
-    @Published private(set) var loadFailed = false
-    @Published var sort: LibrarySongSort = .recentlyAdded {
+    private(set) var displayedSongs: [Song] = []
+    private(set) var isLoading = false
+    private(set) var requiresSignIn = false
+    private(set) var loadFailed = false
+    var sort: LibrarySongSort = .recentlyAdded {
         didSet { rebuildDisplayedSongs() }
     }
-    @Published var searchText = ""
+    var searchText = "" {
+        didSet { scheduleDisplayedSongsRebuild() }
+    }
 
     private var hasLoaded = false
-    private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
     private var requestGeneration = 0
-    private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
+    @ObservationIgnored private var lastRebuiltSearchText = ""
     private var songsGeneration: UInt64 = 0
     private var sortCache: (sort: LibrarySongSort, generation: UInt64, songs: [Song])?
 
-    init() {
-        $searchText
-            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
-            .removeDuplicates()
-            .sink { [weak self] _ in self?.rebuildDisplayedSongs() }
-            .store(in: &cancellables)
+    /// Replaces `$searchText.debounce(200ms).removeDuplicates()`. Filtering a
+    /// large library runs localized comparisons per song, so keystrokes must
+    /// still coalesce.
+    private func scheduleDisplayedSongsRebuild() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled, let self else { return }
+            guard searchText != lastRebuiltSearchText else { return }
+            lastRebuiltSearchText = searchText
+            rebuildDisplayedSongs()
+        }
     }
 
     func loadIfNeeded() {
@@ -153,7 +163,7 @@ actor UploadedSongDurationResolver {
     static let shared = UploadedSongDurationResolver()
 
     private var resolvedDurations: [String: Int] = [:]
-    private var lookupTasks: [String: Task<Int?, Never>] = [:]
+    @ObservationIgnored private var lookupTasks: [String: Task<Int?, Never>] = [:]
 
     func fillingMissingDurations(
         in songs: [Song],

--- a/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
+++ b/Twinskaraoke/Models/Library/VideoGalleryViewModel.swift
@@ -1,16 +1,17 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class VideoGalleryViewModel: ObservableObject {
-    @Published var videos: [GalleryVideo] = []
-    @Published var isLoading = false
-    @Published var errorMessage: String?
-    @Published var canLoadMore = true
+@Observable
+final class VideoGalleryViewModel {
+    var videos: [GalleryVideo] = []
+    var isLoading = false
+    var errorMessage: String?
+    var canLoadMore = true
     private var page = 1
     private let pageSize = 25
     private var loadGeneration = 0
-    private var activeTask: Task<Void, Never>?
+    @ObservationIgnored private var activeTask: Task<Void, Never>?
 
     func fetchInitial() {
         guard videos.isEmpty, !isLoading else { return }
@@ -127,9 +128,10 @@ final class VideoGalleryViewModel: ObservableObject {
 }
 
 @MainActor
-final class SimilarVideosViewModel: ObservableObject {
-    @Published var videos: [GalleryVideo] = []
-    @Published var isLoading = false
+@Observable
+final class SimilarVideosViewModel {
+    var videos: [GalleryVideo] = []
+    var isLoading = false
 
     func fetch(excluding currentID: String) {
         guard videos.isEmpty, !isLoading else { return }

--- a/Twinskaraoke/Models/Player/LyricsViewModel.swift
+++ b/Twinskaraoke/Models/Player/LyricsViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 enum LyricsTranslationState: Equatable {
     case idle
@@ -9,17 +9,20 @@ enum LyricsTranslationState: Equatable {
     case failed
 }
 
-final class LyricsViewModel: ObservableObject {
-    @Published private(set) var lyrics: [LyricLine] = []
-    @Published private(set) var isLoading = false
-    @Published private(set) var didFail = false
-    @Published private(set) var hasNoLyrics = false
-    @Published private(set) var translationState: LyricsTranslationState = .idle
+@Observable
+final class LyricsViewModel {
+    private(set) var lyrics: [LyricLine] = []
+    private(set) var isLoading = false
+    private(set) var didFail = false
+    private(set) var hasNoLyrics = false
+    private(set) var translationState: LyricsTranslationState = .idle
 
+    // Read by the player view to match the prefetched model against the
+    // incoming song; under @Published it was untracked and could read stale.
     private(set) var loadedSongID: String?
-    private var inFlightSongID: String?
-    private var currentTask: URLSessionDataTask?
-    private var translationTask: Task<Void, Never>?
+    @ObservationIgnored private var inFlightSongID: String?
+    @ObservationIgnored private var currentTask: URLSessionDataTask?
+    @ObservationIgnored private var translationTask: Task<Void, Never>?
 
     var hasTranslatedLyrics: Bool {
         lyrics.contains { ($0.translatedText?.isEmpty == false) && $0.translatedText != $0.text }

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import Observation
 
 #if canImport(UIKit)
     import UIKit
@@ -36,9 +37,10 @@ struct GenreDetail: Decodable {
 }
 
 @MainActor
-final class PublicPlaylistsViewModel: ObservableObject {
-    @Published var playlists: [Playlist] = []
-    @Published var isLoadingMore = false
+@Observable
+final class PublicPlaylistsViewModel {
+    var playlists: [Playlist] = []
+    var isLoadingMore = false
     private var canLoadMore = true
     private var hasLoaded = false
     private var requestToken = 0
@@ -157,9 +159,10 @@ final class PublicPlaylistsViewModel: ObservableObject {
 }
 
 @MainActor
-final class TopChartViewModel: ObservableObject {
-    @Published var songs: [Song] = []
-    @Published var weeklyTrending: [Song] = []
+@Observable
+final class TopChartViewModel {
+    var songs: [Song] = []
+    var weeklyTrending: [Song] = []
     private var hasLoaded = false
     private var requestToken = 0
 
@@ -209,34 +212,35 @@ final class TopChartViewModel: ObservableObject {
 }
 
 @MainActor
-final class GenresViewModel: ObservableObject {
-    @Published var genres: [GenreSummary] = []
-    @Published var artworkURLs: [String: URL] = [:]
-    @Published var firstSongs: [String: Song] = [:]
-    @Published var allSongs: [String: [Song]] = [:]
-    @Published var isLoading = false
-    @Published var isLoadingMore = false
-    @Published var canLoadMore = true
-    @Published private(set) var failedDetailIDs = Set<String>()
-    private var page = 0
-    private let pageSize = 50
-    private var hasLoaded = false
-    private var genreDetailOrder: [String] = []
-    private let maxCachedGenreDetails = 30
-    private var detailRequestsInFlight = Set<String>()
-    private var pendingDetailOrder: [String] = []
-    private var pendingDetails: [String: GenreSummary] = [:]
-    private var detailTasks: [String: Task<Void, Never>] = [:]
-    // Published so views can key work on it: a purge cancels in-flight detail
+@Observable
+final class GenresViewModel {
+    var genres: [GenreSummary] = []
+    var artworkURLs: [String: URL] = [:]
+    var firstSongs: [String: Song] = [:]
+    var allSongs: [String: [Song]] = [:]
+    var isLoading = false
+    var isLoadingMore = false
+    var canLoadMore = true
+    private(set) var failedDetailIDs = Set<String>()
+    @ObservationIgnored private var page = 0
+    @ObservationIgnored private let pageSize = 50
+    @ObservationIgnored private var hasLoaded = false
+    @ObservationIgnored private var genreDetailOrder: [String] = []
+    @ObservationIgnored private let maxCachedGenreDetails = 30
+    @ObservationIgnored private var detailRequestsInFlight = Set<String>()
+    @ObservationIgnored private var pendingDetailOrder: [String] = []
+    @ObservationIgnored private var pendingDetails: [String: GenreSummary] = [:]
+    @ObservationIgnored private var detailTasks: [String: Task<Void, Never>] = [:]
+    // Observed so views can key work on it: a purge cancels in-flight detail
     // tasks, and without a generation-keyed restart those views would spin
     // forever on their loading branch.
-    @Published private(set) var detailGeneration: UInt64 = 0
-    private var pageGeneration: UInt64 = 0
-    private var detailFailureDates: [String: Date] = [:]
-    private let maxConcurrentDetailRequests = 4
-    private var genresNeedingFallback = Set<String>()
-    private var fallbackCancellable: AnyCancellable?
-    private var memoryWarningCancellable: AnyCancellable?
+    private(set) var detailGeneration: UInt64 = 0
+    @ObservationIgnored private var pageGeneration: UInt64 = 0
+    @ObservationIgnored private var detailFailureDates: [String: Date] = [:]
+    @ObservationIgnored private let maxConcurrentDetailRequests = 4
+    @ObservationIgnored private var genresNeedingFallback = Set<String>()
+    @ObservationIgnored private var memoryWarningCancellable: AnyCancellable?
+    @ObservationIgnored private var fallbackObservation: ObservationToken?
 
     init() {
         #if canImport(UIKit)
@@ -248,11 +252,11 @@ final class GenresViewModel: ObservableObject {
                 Task { @MainActor [weak self] in self?.clearCachedGenreDetails() }
             }
         #endif
-        fallbackCancellable = FallbackArtProvider.shared.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                Task { @MainActor [weak self] in self?.assignPendingFallbackArtwork() }
-            }
+        fallbackObservation = observeContinuously({
+            _ = FallbackArtRevision.shared.revision
+        }, onChange: { [weak self] in
+            self?.assignPendingFallbackArtwork()
+        })
     }
 
     private func assignPendingFallbackArtwork() {
@@ -477,11 +481,12 @@ final class GenresViewModel: ObservableObject {
 }
 
 @MainActor
-final class SearchCategorySongsViewModel: ObservableObject {
-    @Published var songs: [Song] = []
-    @Published var isLoading = false
-    @Published private var loadFailed = false
-    @Published private(set) var hasLoaded = false
+@Observable
+final class SearchCategorySongsViewModel {
+    var songs: [Song] = []
+    var isLoading = false
+    private var loadFailed = false
+    private(set) var hasLoaded = false
     private let query: String
     private var requestToken = 0
 
@@ -539,11 +544,14 @@ final class SearchCategorySongsViewModel: ObservableObject {
 }
 
 @MainActor
-final class SearchViewModel: ObservableObject {
-    @Published var results: [Song] = []
-    @Published var searchText = ""
-    @Published var isSearching = false
-    @Published var searchErrorMessage: String?
+@Observable
+final class SearchViewModel {
+    var results: [Song] = []
+    var searchText = "" {
+        didSet { scheduleSearch() }
+    }
+    var isSearching = false
+    var searchErrorMessage: String?
 
     /// Whether the field holds a query the search pipeline would actually run.
     /// Views must branch on this rather than `!searchText.isEmpty`: the
@@ -558,22 +566,27 @@ final class SearchViewModel: ObservableObject {
         !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private var cancellables = Set<AnyCancellable>()
-    private var queryToken: Int = 0
-    private var searchTask: Task<Void, Never>?
+    @ObservationIgnored private var queryToken: Int = 0
+    @ObservationIgnored private var searchTask: Task<Void, Never>?
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
+    @ObservationIgnored private var lastDispatchedQuery = ""
 
-    init() {
-        $searchText
-            // Trim before removeDuplicates so edits that only change
-            // surrounding whitespace ("abc" -> "abc ") don't refire an
-            // identical search request.
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
-            .removeDuplicates()
-            .sink { [weak self] query in
-                if !query.isEmpty { self?.search(query) } else { self?.clearSearch() }
-            }
-            .store(in: &cancellables)
+    /// Replaces the former `$searchText.debounce().removeDuplicates()` pipeline:
+    /// `@Observable` has no publisher projection, so the 500ms coalescing and
+    /// the duplicate-query suppression are done here instead. Trimming still
+    /// happens before the duplicate check, so edits that only change
+    /// surrounding whitespace ("abc" -> "abc ") don't refire an identical
+    /// search request.
+    private func scheduleSearch() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled, let self else { return }
+            let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard query != lastDispatchedQuery else { return }
+            lastDispatchedQuery = query
+            if query.isEmpty { clearSearch() } else { search(query) }
+        }
     }
 
     func retrySearch() {

--- a/Twinskaraoke/Services/Artwork/ArtworkMemoryCache.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkMemoryCache.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SDWebImage
+import SwiftUI
+import UIKit
+
+/// Synchronous memory-cache lookup for artwork, used to skip `WebImage`'s
+/// unavoidable placeholder frame.
+///
+/// `WebImage.body` checks `imageManager.image != nil` *before* it calls
+/// `setupInitialState()` (which is what starts the load). So even when the
+/// image is already in the memory cache and the load completes synchronously,
+/// the assignment lands after the current body evaluation has already taken
+/// the placeholder branch — SwiftUI schedules a second pass, and the row paints
+/// grey for at least one frame. During a fast flick that one frame per row is
+/// exactly the placeholder that remains visible.
+///
+/// Reading the memory cache directly during `body` sidesteps that: if the
+/// bitmap is already resident we render it immediately, in the same pass.
+///
+/// This is only valid because the app installs no `cacheKeyFilter` and no
+/// image transformer, so SDWebImage's cache key is the URL's absolute string.
+/// If either is ever added, this lookup must go through
+/// `SDWebImageManager.shared.cacheKey(for:)` instead.
+enum ArtworkMemoryCache {
+    /// Returns the decoded image if it is already resident in memory.
+    ///
+    /// Deliberately memory-only: a disk hit would touch the filesystem, and
+    /// doing that synchronously during `body` would stall the scroll — far
+    /// worse than the placeholder it would avoid.
+    static func image(for url: URL?) -> Image? {
+        guard let url else { return nil }
+        let cached = SDImageCache.shared.imageFromMemoryCache(forKey: url.absoluteString)
+        return cached.flatMap(renderableImage)
+    }
+
+    /// Mirrors `WebImage.configure(image:)`.
+    ///
+    /// SDWebImageSwiftUI deliberately prefers `Image(decorative:scale:
+    /// orientation:)` over `Image(uiImage:)`: with an EXIF-oriented UIImage,
+    /// SwiftUI's `.aspectRatio` misbehaves, and the UIImage initialiser has a
+    /// separate bug inside tab bar items. The fast path has to render
+    /// identically to the async path or images would subtly shift when one
+    /// took over from the other.
+    ///
+    /// Animated and vector images fall through to `WebImage`: animation needs
+    /// its player, and rasterising a vector here would mean drawing into a
+    /// bitmap context during `body`.
+    private static func renderableImage(_ image: UIImage) -> Image? {
+        guard !image.sd_isAnimated, !image.sd_isVector, let cgImage = image.cgImage else {
+            return nil
+        }
+        return Image(
+            decorative: cgImage,
+            scale: image.scale,
+            orientation: swiftUIOrientation(image.imageOrientation)
+        )
+    }
+
+    private static func swiftUIOrientation(_ orientation: UIImage.Orientation) -> Image.Orientation {
+        switch orientation {
+        case .up: .up
+        case .upMirrored: .upMirrored
+        case .down: .down
+        case .downMirrored: .downMirrored
+        case .left: .left
+        case .leftMirrored: .leftMirrored
+        case .right: .right
+        case .rightMirrored: .rightMirrored
+        @unknown default: .up
+        }
+    }
+}
+
+// Measured on device 2026-08-02 with a temporary hit-rate probe: 92–99% of rows
+// take this fast path once the cache is warm (25% on a cold start, and dipping
+// to ~75% only while images are still downloading). That is why the two
+// structural rewrites once planned here — persisting pre-decoded assets, and
+// replacing `WebImage` in lists with a UIKit collection view — were dropped:
+// decode is not on the critical path, and the collection view's only real
+// benefit was the synchronous assignment this already provides.

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -72,18 +72,103 @@ final class ArtworkPrefetcher {
 
     static let shared = ArtworkPrefetcher()
 
+    /// How far ahead of the visible rows artwork is warmed.
+    ///
+    /// These were 18/12, which a fast flick outruns almost immediately — past
+    /// the window you wait on both network and decode, which is what leaves
+    /// placeholders on screen. The URLs are server-resized variants and
+    /// `maxConcurrentPrefetchCount` still throttles the work, so a deeper
+    /// window mostly costs cache entries rather than bandwidth spikes.
+    static let songWindow = 36
+    static let playlistWindow = 24
+
     private let prefetcher = SDWebImagePrefetcher.shared
     private var recentlyRequested: [String: Date] = [:]
     private var activePrefetches: [String: ActivePrefetch] = [:]
     private let reuseWindow: TimeInterval = 45
 
+    /// Separate prefetcher for whole-collection warming.
+    ///
+    /// Deliberately not `SDWebImagePrefetcher.shared`: warming a 500-song
+    /// playlist must not consume the concurrency budget the scroll-driven
+    /// prefetch above depends on, and it must not be subject to (or interfere
+    /// with) that path's `recentlyRequested` reuse window.
+    private let warmPrefetcher: SDWebImagePrefetcher = {
+        let prefetcher = SDWebImagePrefetcher()
+        prefetcher.maxConcurrentPrefetchCount = 2
+        return prefetcher
+    }()
+
+    private var warmTokens: [String: SDWebImagePrefetchToken] = [:]
+
     private init() {
         prefetcher.maxConcurrentPrefetchCount = 3
     }
 
+    /// Warms artwork for an entire collection onto disk, off the scroll path.
+    ///
+    /// The windowed `prefetch(urls:limit:…)` above exists to stay just ahead of
+    /// the visible rows; a fast flick outruns any such window, because the limit
+    /// is ultimately bounded by network round trips. This instead pulls the
+    /// whole collection once, so a playlist you have opened before scrolls with
+    /// no placeholders at all — the images are already local.
+    ///
+    /// Row variants are a few KB each, so a 500-song playlist costs single-digit
+    /// MB against `CacheManager.imageCacheLimit` (2 GB). Unlike the windowed
+    /// path this is deliberately *not* clamped by `adjustedLimit`; it runs at
+    /// low priority with its own small concurrency budget instead.
+    func warmCollection(
+        songs: [Song],
+        reason: String,
+        variant: ArtworkImageVariant = .row
+    ) {
+        warm(urls: Self.urls(for: songs, variant: variant), reason: reason, variant: variant)
+    }
+
+    func warmCollection(
+        playlists: [Playlist],
+        reason: String,
+        variant: ArtworkImageVariant = .thumbnail
+    ) {
+        warm(urls: Self.urls(for: playlists, variant: variant), reason: reason, variant: variant)
+    }
+
+    private func warm(urls: [URL], reason: String, variant: ArtworkImageVariant) {
+        var seen = Set<String>()
+        let unique = urls
+            .map { ArtworkURLBuilder.variantURL(from: $0, variant: variant) ?? $0 }
+            .filter { seen.insert($0.absoluteString).inserted }
+            .filter { !ArtworkFailureBackoff.shared.isBlocked($0) }
+        guard !unique.isEmpty else { return }
+
+        warmTokens.removeValue(forKey: reason)?.cancel()
+        DebugLogger.log(
+            "Warming \(unique.count) artwork images for \(reason)",
+            category: .cache
+        )
+        warmTokens[reason] = warmPrefetcher.prefetchURLs(
+            unique,
+            options: [.lowPriority],
+            context: ImageCacheConfig.prefetchContext,
+            progress: nil
+        ) { finished, skipped in
+            Task { @MainActor [weak self] in
+                DebugLogger.log(
+                    "Artwork warm complete for \(reason): finished=\(finished), skipped=\(skipped)",
+                    category: .cache
+                )
+                self?.warmTokens.removeValue(forKey: reason)
+            }
+        }
+    }
+
+    func cancelWarm(reason: String) {
+        warmTokens.removeValue(forKey: reason)?.cancel()
+    }
+
     func prefetchSongs(
         _ songs: [Song],
-        limit: Int = 18,
+        limit: Int = ArtworkPrefetcher.songWindow,
         reason: String,
         variant: ArtworkImageVariant = .card
     ) {
@@ -117,7 +202,7 @@ final class ArtworkPrefetcher {
 
     func prefetchPlaylists(
         _ playlists: [Playlist],
-        limit: Int = 12,
+        limit: Int = ArtworkPrefetcher.playlistWindow,
         reason: String,
         variant: ArtworkImageVariant = .card
     ) {
@@ -147,7 +232,7 @@ final class ArtworkPrefetcher {
 
     func prefetch(
         urls: [URL],
-        limit: Int = 18,
+        limit: Int = ArtworkPrefetcher.songWindow,
         reason: String,
         variant: ArtworkImageVariant = .card
     ) {
@@ -207,15 +292,29 @@ final class ArtworkPrefetcher {
         }
     }
 
+    /// Caps the prefetch window so warming artwork can't starve an active
+    /// download queue or playback.
+    ///
+    /// The tiering is deliberate and stays: downloads matter more than artwork,
+    /// and playback matters more than scroll polish. The ceilings were 2/4/8,
+    /// which is why placeholders lingered during a fast flick — a window of 4
+    /// (the common case, since something is usually playing) is roughly one
+    /// screen of rows, so any real scrolling outran it immediately.
+    ///
+    /// Raised to 6/12/24. Prefetch also decodes now (see
+    /// `ImageCacheConfig.prefetchContext`), so this costs more CPU per image
+    /// than it used to; `maxConcurrentPrefetchCount` (3) still bounds the
+    /// parallelism. If scrolling during playback ever feels less smooth than
+    /// before, the playing tier is the first number to pull back.
     private func adjustedLimit(_ limit: Int, reason: String) -> Int {
         guard limit > 0 else { return 0 }
         if DownloadManager.shared.hasActiveQueue {
-            return min(limit, reason == "radio metadata" ? 3 : 2)
+            return min(limit, reason == "radio metadata" ? 8 : 6)
         }
         if AudioPlayerManager.shared.isPlaying {
-            return min(limit, 4)
+            return min(limit, 12)
         }
-        return min(limit, reason == "radio metadata" ? 6 : 8)
+        return min(limit, reason == "radio metadata" ? 10 : 24)
     }
 
     private func freshUniqueURLs(from urls: [URL], limit: Int) -> [URL] {

--- a/Twinskaraoke/Services/Artwork/FallbackArtProvider.swift
+++ b/Twinskaraoke/Services/Artwork/FallbackArtProvider.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 nonisolated struct FallbackArt {
     let url: URL
@@ -7,7 +7,32 @@ nonisolated struct FallbackArt {
     let artistLink: String?
 }
 
-final nonisolated class FallbackArtProvider: ObservableObject, @unchecked Sendable {
+/// Main-actor change signal for `FallbackArtProvider`.
+///
+/// The provider itself stays non-observable: it is `nonisolated`, mutates its
+/// pool under an `NSLock` from background URLSession callbacks, and
+/// `@Observable` gives no thread safety for that. It used to broadcast through
+/// `objectWillChange.send()`; observers now watch this counter instead, which
+/// is only ever bumped on the main actor.
+@MainActor
+@Observable
+final class FallbackArtRevision {
+    static let shared = FallbackArtRevision()
+
+    private(set) var revision: UInt64 = 0
+
+    private init() {}
+
+    /// Callable from the provider's background URLSession callbacks; the
+    /// counter itself is only ever written on the main actor.
+    nonisolated static func bump() {
+        Task { @MainActor in
+            shared.revision &+= 1
+        }
+    }
+}
+
+final nonisolated class FallbackArtProvider: @unchecked Sendable {
     static let shared = FallbackArtProvider()
 
     private var items: [FallbackArtItem] = []
@@ -142,7 +167,7 @@ final nonisolated class FallbackArtProvider: ObservableObject, @unchecked Sendab
             persistPool(updatedPool)
             UserDefaults.standard.removeObject(forKey: legacyBindingsKey)
 
-            objectWillChange.send()
+            FallbackArtRevision.bump()
         }
     }
 

--- a/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
+++ b/Twinskaraoke/Services/Artwork/ImageCacheConfig.swift
@@ -19,6 +19,12 @@ enum ImageCacheConfig {
     ]
 
     // Prefetch warms cache without forcing decode; decoding happens on display.
+    //
+    // Tried `.automatic` here to make prefetched rows display-ready. Reverted:
+    // force-decoding makes SDWebImage store a decoded image rather than the
+    // original bytes, and re-encoding those bytes fails — Apple's ImageIO can
+    // decode WebP but cannot write it, and this app requests WebP. That spammed
+    // `CGImageDestinationCreateWithData` failures on every image.
     static let prefetchContext: [SDWebImageContextOption: Any] = [
         .queryCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
         .storeCacheType: NSNumber(value: SDImageCacheType.all.rawValue),
@@ -30,7 +36,14 @@ enum ImageCacheConfig {
         didApply = true
         let cfg = SDImageCache.shared.config
         cfg.maxMemoryCost = 128 * 1024 * 1024
-        cfg.maxMemoryCount = 240
+        // The count cap binds long before the cost cap for list artwork: a 48pt
+        // row at @3x decodes to ~81 KB, so 240 images is only ~19 MB of the
+        // 128 MB budget. Scrolling past ~240 rows evicted the earliest bitmaps
+        // and forced a disk read *and* re-decode on the way back — placeholders
+        // on a playlist whose bytes were already local. 1000 row thumbnails is
+        // ~79 MB, still inside the cost cap, which remains the real ceiling
+        // (large hero images consume it far faster and evict sooner).
+        cfg.maxMemoryCount = 1000
         // Single source of truth: CacheManager.imageCacheLimit, so SDWebImage's
         // own pruning matches the limit CacheManager enforces (and the value
         // the Settings UI advertises).

--- a/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
+++ b/Twinskaraoke/Services/Artwork/PlaylistCoverLoader.swift
@@ -1,14 +1,15 @@
-import Combine
 import Foundation
 import SwiftUI
+import Observation
 
 @MainActor
-final class PlaylistCoverLoader: ObservableObject {
-    @Published var artworkURLs: [URL] = []
+@Observable
+final class PlaylistCoverLoader {
+    var artworkURLs: [URL] = []
     private var loadedID: String?
     private var fallbackSongs: [Song] = []
     private var loadedPlaylist: Playlist?
-    private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
 
     func load(playlistID: String, fallback: [Song]? = nil) {
         if loadedID == playlistID {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -3,6 +3,7 @@ import Combine
 import Foundation
 import MediaPlayer
 import SwiftUI
+import Observation
 
 #if canImport(UIKit)
     import SDWebImage
@@ -46,46 +47,48 @@ private enum ManagedAVPlayerKind {
 }
 
 @MainActor
-final class PlaybackClock: ObservableObject {
+@Observable
+final class PlaybackClock {
     static let shared = PlaybackClock()
 
-    @Published var progress: Double = 0
+    var progress: Double = 0
 
     private init() {}
 }
 
 @MainActor
-final class AudioPlayerManager: ObservableObject {
+@Observable
+final class AudioPlayerManager {
     static let shared = AudioPlayerManager()
-    @Published var currentSong: Song?
-    @Published var isPlaying = false
-    @Published var isBuffering = false
+    var currentSong: Song?
+    var isPlaying = false
+    var isBuffering = false
 
     var progress: Double {
         get { PlaybackClock.shared.progress }
         set { PlaybackClock.shared.progress = newValue }
     }
 
-    @Published var queue: [Song] = []
-    @Published var isEditingProgress = false
-    @Published var volume: Double = 1.0
-    @Published var isUserScrubbingVolume: Bool = false
+    var queue: [Song] = []
+    var isEditingProgress = false
+    var volume: Double = 1.0
+    var isUserScrubbingVolume: Bool = false
     private var suppressTransitionAfterSeek = false
     private var preferredStreamResumeSongID: String?
     private var preferredStreamResumeTime: TimeInterval?
     private var deferredAIEffect: AudioEffect?
-    @Published var routeIcon: String = "airplayaudio"
-    @Published var routeName: String = ""
-    @Published var repeatMode: RepeatMode = .off
-    @Published var isShuffled: Bool = false
-    @Published var autoplayEnabled: Bool = true
-    @Published var isRadioMode: Bool = false
-    @Published var radioArtworkURL: URL?
+    var routeIcon: String = "airplayaudio"
+    var routeName: String = ""
+    var repeatMode: RepeatMode = .off
+    var isShuffled: Bool = false
+    var autoplayEnabled: Bool = true
+    var isRadioMode: Bool = false
+    var radioArtworkURL: URL?
     private var isStreamMode: Bool {
         streamPlayer != nil
     }
 
-    @Published var aiEnabled: Bool = {
+    var aiEnabled: Bool = {
         if UserDefaults.standard.object(forKey: "nk.aiEnabled") != nil {
             return UserDefaults.standard.bool(forKey: "nk.aiEnabled")
         }
@@ -111,7 +114,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var aiAutoAnalyze: Bool = UserDefaults.standard.bool(forKey: "nk.aiAutoAnalyze") {
+    var aiAutoAnalyze: Bool = UserDefaults.standard.bool(forKey: "nk.aiAutoAnalyze") {
         didSet {
             UserDefaults.standard.set(aiAutoAnalyze, forKey: "nk.aiAutoAnalyze")
             DebugLogger.log("AI auto-analyze: \(aiAutoAnalyze)", category: .ai)
@@ -134,7 +137,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var karaokeMode: Bool = false {
+    var karaokeMode: Bool = false {
         didSet {
             guard !_suppressModeSwitch else { return }
             if karaokeMode, isBackgroundKaraokeLocked {
@@ -154,7 +157,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var aiVocalStrength: Float = AudioPlayerManager.loadAIVocalStrength() {
+    var aiVocalStrength: Float = AudioPlayerManager.loadAIVocalStrength() {
         didSet {
             let clamped = min(1, max(0, aiVocalStrength))
             if clamped != aiVocalStrength {
@@ -171,7 +174,7 @@ final class AudioPlayerManager: ObservableObject {
         return Float(min(1, max(0, raw)))
     }
 
-    @Published var bassEnhanceMode: Bool = false {
+    var bassEnhanceMode: Bool = false {
         didSet {
             guard !_suppressModeSwitch else { return }
             if bassEnhanceMode, shouldDeferAIEffectActivation {
@@ -186,7 +189,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var bassEnhanceStrength: Float = AudioPlayerManager.loadFloat(
+    var bassEnhanceStrength: Float = AudioPlayerManager.loadFloat(
         "nk.bassEnhanceStrength", default: 0.5
     ) {
         didSet {
@@ -195,7 +198,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var vocalEnhanceMode: Bool = false {
+    var vocalEnhanceMode: Bool = false {
         didSet {
             guard !_suppressModeSwitch else { return }
             if vocalEnhanceMode, shouldDeferAIEffectActivation {
@@ -210,7 +213,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var vocalEnhanceStrength: Float = AudioPlayerManager.loadFloat(
+    var vocalEnhanceStrength: Float = AudioPlayerManager.loadFloat(
         "nk.vocalEnhanceStrength", default: 0.5
     ) {
         didSet {
@@ -219,7 +222,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var instrumentalEnhanceMode: Bool = false {
+    var instrumentalEnhanceMode: Bool = false {
         didSet {
             guard !_suppressModeSwitch else { return }
             if instrumentalEnhanceMode, shouldDeferAIEffectActivation {
@@ -234,7 +237,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var instrumentalEnhanceStrength: Float = AudioPlayerManager.loadFloat(
+    var instrumentalEnhanceStrength: Float = AudioPlayerManager.loadFloat(
         "nk.instrumentalEnhanceStrength", default: 0.5
     ) {
         didSet {
@@ -243,7 +246,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var eqEnabled: Bool = UserDefaults.standard.bool(forKey: "nk.eqEnabled") {
+    var eqEnabled: Bool = UserDefaults.standard.bool(forKey: "nk.eqEnabled") {
         didSet {
             UserDefaults.standard.set(eqEnabled, forKey: "nk.eqEnabled")
             avEngine.setEQEnabled(eqEnabled)
@@ -251,7 +254,7 @@ final class AudioPlayerManager: ObservableObject {
     }
 
     private var eqPresetIsApplying = false
-    @Published var eqPreset: EQPreset = {
+    var eqPreset: EQPreset = {
         let raw = UserDefaults.standard.string(forKey: "nk.eqPreset") ?? ""
         return EQPreset(rawValue: raw) ?? .flat
     }() {
@@ -264,7 +267,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var eqGainsDB: [Float] = (UserDefaults.standard.array(forKey: "nk.eqGainsDB") as? [Float])
+    var eqGainsDB: [Float] = (UserDefaults.standard.array(forKey: "nk.eqGainsDB") as? [Float])
         ?? Array(repeating: 0, count: 10)
     {
         didSet {
@@ -276,7 +279,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var autoMixEnabled: Bool =
+    var autoMixEnabled: Bool =
         (UserDefaults.standard.object(forKey: "nk.autoMixEnabled") as? Bool ?? true)
     {
         didSet {
@@ -288,7 +291,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var crossfadeEnabled: Bool =
+    var crossfadeEnabled: Bool =
         (UserDefaults.standard.object(forKey: "nk.crossfadeEnabled") as? Bool ?? false)
     {
         didSet {
@@ -300,7 +303,7 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var crossfadeSeconds: Double = AudioPlayerManager.loadCrossfadeSeconds() {
+    var crossfadeSeconds: Double = AudioPlayerManager.loadCrossfadeSeconds() {
         didSet {
             let clamped = min(15, max(1, crossfadeSeconds))
             if clamped != crossfadeSeconds {
@@ -314,10 +317,10 @@ final class AudioPlayerManager: ObservableObject {
         }
     }
 
-    @Published var upcomingSong: Song?
-    @Published private(set) var preparedStemSongID: String?
+    var upcomingSong: Song?
+    private(set) var preparedStemSongID: String?
     #if canImport(UIKit)
-        @Published var nowPlayingArtwork: UIImage?
+        var nowPlayingArtwork: UIImage?
     #endif
     private var lastNowPlayingElapsedSecond: Int?
     private var lastNowPlayingPlaybackRate: Double?
@@ -337,7 +340,7 @@ final class AudioPlayerManager: ObservableObject {
 
     // Construct the graph only after init has configured/activated the audio
     // session, so its fixed effects bus adopts the active hardware sample rate.
-    private lazy var avEngine = AVEnginePlayback()
+    @ObservationIgnored private lazy var avEngine = AVEnginePlayback()
     private let transitionCoordinator = TransitionCoordinator()
     private var radioPlayer: AVPlayer?
     private var streamPlayer: AVPlayer?
@@ -347,7 +350,7 @@ final class AudioPlayerManager: ObservableObject {
     private var streamPlayerCancellables = Set<AnyCancellable>()
     private var radioPlaybackRequested = false
     private var streamPlaybackRequested = false
-    private var remotePlaybackCacheTask: Task<Void, Never>?
+    @ObservationIgnored private var remotePlaybackCacheTask: Task<Void, Never>?
     private var remotePlaybackCacheToken: UUID?
     private var fetchRandomTrendingToken: UUID?
     private var cacheRecoverySongID: String?
@@ -376,14 +379,14 @@ final class AudioPlayerManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var artworkURL: URL?
     private var artworkTask: (any SDWebImageOperation)?
-    private var artworkProcessingTask: Task<Void, Never>?
+    @ObservationIgnored private var artworkProcessingTask: Task<Void, Never>?
     private var playerArtworkWarmupTasks: [String: any SDWebImageOperation] = [:]
     private var warmedPlayerArtworkAt: [String: Date] = [:]
     private var currentPlaybackURL: URL?
-    private var instrumentalTask: Task<Void, Never>?
-    private var preparedStemTask: Task<Void, Never>?
-    private var backgroundAnalysisRetryTask: Task<Void, Never>?
-    private var cacheCompressionTask: Task<Void, Never>?
+    @ObservationIgnored private var instrumentalTask: Task<Void, Never>?
+    @ObservationIgnored private var preparedStemTask: Task<Void, Never>?
+    @ObservationIgnored private var backgroundAnalysisRetryTask: Task<Void, Never>?
+    @ObservationIgnored private var cacheCompressionTask: Task<Void, Never>?
     // Set while a stem-switch load is in flight so its failure can drop the
     // broken stem cache. Must be cleared on every pause/stop/new-play path:
     // those bump the engine's suppression token, the load completion then
@@ -398,7 +401,7 @@ final class AudioPlayerManager: ObservableObject {
     private var separationGeneration: UInt64 = 0
     private var transitionTimeoutGeneration: UInt64 = 0
     private var transitionStartGeneration: UInt64 = 0
-    private var transitionStartTask: Task<Void, Never>?
+    @ObservationIgnored private var transitionStartTask: Task<Void, Never>?
     private var activeCrossfadePlan: TransitionCoordinator.TransitionPlan?
     private var suppressPlaybackEndedUntil: Date = .distantPast
     private var wasPlayingBeforeInterruption = false
@@ -408,8 +411,8 @@ final class AudioPlayerManager: ObservableObject {
 
     private let easterEggSongID = "73376790-47d2-4c17-a7fc-88d11dccd2f0"
     private var easterEggQueuedForCurrentSong = false
-    private var easterEggLyricsTask: Task<Void, Never>?
-    private var easterEggSongTask: Task<Void, Never>?
+    @ObservationIgnored private var easterEggLyricsTask: Task<Void, Never>?
+    @ObservationIgnored private var easterEggSongTask: Task<Void, Never>?
 
     #if canImport(UIKit)
         private var trackTransitionTaskID: UIBackgroundTaskIdentifier = .invalid
@@ -626,10 +629,12 @@ final class AudioPlayerManager: ObservableObject {
             self?.upcomingSong = song
         }
 
-        FallbackArtProvider.shared.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.objectWillChange.send() }
-            .store(in: &cancellables)
+        // The former `FallbackArtProvider.objectWillChange -> objectWillChange`
+        // forwarding is gone: it existed only to invalidate views that derive
+        // artwork URLs through `Song`, and `@Observable` has no blanket
+        // invalidation. Those views now read `FallbackArtRevision.shared`
+        // directly, which is both narrower and no longer re-renders every
+        // observer of the player.
         // AVAudioSession posts these off the main thread (route changes are
         // documented as arriving on a secondary thread). Under Swift 6 these
         // sink closures are main-actor-isolated, so delivering them on the
@@ -3356,7 +3361,9 @@ final class AudioPlayerManager: ObservableObject {
                 pathSegments: ["api", "songs", "playCount", songID]
             ) else { return }
             req.httpMethod = "PUT"
-            let _ = try? await KaraokeAPIClient.data(for: req)
+            // Fire and forget: the result is discarded, so a retry only costs
+            // requests. One skipped song used to cost 3 of these.
+            let _ = try? await KaraokeAPIClient.data(for: req, allowsRetry: false)
         }
     }
 

--- a/Twinskaraoke/Services/Audio/PopupOpenIntentGate.swift
+++ b/Twinskaraoke/Services/Audio/PopupOpenIntentGate.swift
@@ -1,4 +1,3 @@
-import Combine
 import LNPopupUI
 import SwiftUI
 

--- a/Twinskaraoke/Services/Audio/PopupPresentationState.swift
+++ b/Twinskaraoke/Services/Audio/PopupPresentationState.swift
@@ -1,11 +1,12 @@
-import Combine
 import SwiftUI
+import Observation
 
 @MainActor
-final class PopupPresentationState: ObservableObject {
+@Observable
+final class PopupPresentationState {
     static let shared = PopupPresentationState()
 
-    @Published private(set) var isExpanded = false
+    private(set) var isExpanded = false
 
     private init() {}
 

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -1,8 +1,8 @@
 import AVFoundation
-import Combine
 import CoreML
 import Foundation
 import Spleeter
+import Observation
 
 extension Notification.Name {
     static let vocalSeparatorDidCacheStems = Notification.Name("VocalSeparatorDidCacheStems")
@@ -141,7 +141,8 @@ struct SeparationJobOwnership {
 }
 
 @MainActor
-final class VocalSeparator: ObservableObject {
+@Observable
+final class VocalSeparator {
     static let shared = VocalSeparator()
 
     private enum SeparationTaskKind {
@@ -149,20 +150,20 @@ final class VocalSeparator: ObservableObject {
         case background
     }
 
-    @Published private(set) var processingSongID: String?
-    @Published private(set) var progressFraction: Float = 0
+    private(set) var processingSongID: String?
+    private(set) var progressFraction: Float = 0
     // progressFraction fans out to the whole player tree; only publish >=1%
     // deltas (plus exact completion) so minute-long analyses don't publish
     // hundreds of times.
     private var lastPublishedProgressFraction: Float = -1
-    @Published private(set) var isBackgroundAnalyzing: Bool = false
+    private(set) var isBackgroundAnalyzing: Bool = false
 
     let isAvailable: Bool
     private let modelURL: URL?
-    private var activeTask: Task<URL, Error>?
+    @ObservationIgnored private var activeTask: Task<URL, Error>?
     private var activeTaskKind: SeparationTaskKind?
-    private var backgroundAnalysisTask: Task<Void, Never>?
-    private var realtimeCleanupTask: Task<Void, Never>?
+    @ObservationIgnored private var backgroundAnalysisTask: Task<Void, Never>?
+    @ObservationIgnored private var realtimeCleanupTask: Task<Void, Never>?
     private var jobOwnership = SeparationJobOwnership()
 
     private nonisolated static var realtimeTempDir: URL {

--- a/Twinskaraoke/Services/Debug/BottomChromeState.swift
+++ b/Twinskaraoke/Services/Debug/BottomChromeState.swift
@@ -1,11 +1,12 @@
-import Combine
 import SwiftUI
+import Observation
 
 @MainActor
-final class BottomChromeState: ObservableObject {
+@Observable
+final class BottomChromeState {
     static let shared = BottomChromeState()
 
-    @Published private(set) var isCollapsed = false
+    private(set) var isCollapsed = false
 
     private let collapseThreshold: CGFloat = 36
     private let expandThreshold: CGFloat = 4

--- a/Twinskaraoke/Services/Debug/PlaybackRowState.swift
+++ b/Twinskaraoke/Services/Debug/PlaybackRowState.swift
@@ -1,42 +1,55 @@
 import Combine
 import SwiftUI
+import Observation
 
 @MainActor
-final class PlaybackRowState: ObservableObject {
+@Observable
+final class PlaybackRowState {
     static let shared = PlaybackRowState()
 
-    @Published private(set) var currentSongID: String?
-    @Published private(set) var isPlaying = false
-    @Published private(set) var isRadioMode = false
-    @Published private(set) var radioArtworkURL: URL?
+    private(set) var currentSongID: String?
+    private(set) var isPlaying = false
+    private(set) var isRadioMode = false
+    private(set) var radioArtworkURL: URL?
 
-    private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var observation: ObservationToken?
 
     private init() {
+        observation = observeContinuously({
+            let manager = AudioPlayerManager.shared
+            _ = manager.currentSong
+            _ = manager.isPlaying
+            _ = manager.isRadioMode
+            _ = manager.radioArtworkURL
+        }, onChange: { [weak self] in
+            self?.syncFromPlayer()
+        })
+        syncFromPlayer()
+    }
+
+    /// Mirrors the player's state onto this row-facing projection.
+    ///
+    /// Each assignment is guarded because `@Observable` notifies on every
+    /// write, including writes of an identical value — the `removeDuplicates`
+    /// the former `$property.sink` pipelines carried. Without the guards, a
+    /// paused player still re-rendering every song row on each player change.
+    private func syncFromPlayer() {
         let manager = AudioPlayerManager.shared
-        manager.$currentSong
-            .map(\.?.id)
-            .removeDuplicates()
-            .sink { [weak self] in self?.currentSongID = $0 }
-            .store(in: &cancellables)
-
-        manager.$isPlaying
-            .removeDuplicates()
-            .sink { [weak self] in self?.isPlaying = $0 }
-            .store(in: &cancellables)
-
-        manager.$isRadioMode
-            .removeDuplicates()
-            .sink { [weak self] in self?.isRadioMode = $0 }
-            .store(in: &cancellables)
-
-        manager.$radioArtworkURL
-            .removeDuplicates()
-            .sink { [weak self] in self?.radioArtworkURL = $0 }
-            .store(in: &cancellables)
+        let songID = manager.currentSong?.id
+        if currentSongID != songID { currentSongID = songID }
+        if isPlaying != manager.isPlaying { isPlaying = manager.isPlaying }
+        if isRadioMode != manager.isRadioMode { isRadioMode = manager.isRadioMode }
+        if radioArtworkURL != manager.radioArtworkURL { radioArtworkURL = manager.radioArtworkURL }
     }
 
     func displayImageURL(for song: Song, variant: ArtworkImageVariant = .card) -> URL? {
+        // Song's artwork URLs fall back to FallbackArtProvider's pool, but `Song`
+        // is nonisolated and can't register that dependency itself. Rows and
+        // grid cards call this during body evaluation, so reading the revision
+        // here is what refreshes them when the pool loads. This used to come for
+        // free: FallbackArtProvider forwarded objectWillChange into
+        // AudioPlayerManager, invalidating every observer of the player.
+        _ = FallbackArtRevision.shared.revision
         if isRadioMode, currentSongID == song.id, let radioArtworkURL {
             return ArtworkURLBuilder.variantURL(from: radioArtworkURL, variant: variant) ?? radioArtworkURL
         }

--- a/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
+++ b/Twinskaraoke/Services/Debug/ScrollPerformanceState.swift
@@ -1,14 +1,15 @@
-import Combine
 import SwiftUI
+import Observation
 
 @MainActor
-final class ScrollPerformanceState: ObservableObject {
+@Observable
+final class ScrollPerformanceState {
     static let shared = ScrollPerformanceState()
 
-    @Published private(set) var isScrolling = false
+    private(set) var isScrolling = false
 
     private var activeScrollIDs = Set<UUID>()
-    private var scrollEndTask: Task<Void, Never>?
+    @ObservationIgnored private var scrollEndTask: Task<Void, Never>?
     private var scrollEndGeneration: UInt = 0
 
     private init() {}

--- a/Twinskaraoke/Services/Radio/RadioController.swift
+++ b/Twinskaraoke/Services/Radio/RadioController.swift
@@ -1,19 +1,20 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class RadioController: ObservableObject {
+@Observable
+final class RadioController {
     static let shared = RadioController()
     static let metadataURL = URL(
         string: "https://radio.twinskaraoke.com/api/nowplaying_static/neuro_21.json"
     )!
     static let stationID = "neuro_21"
-    @Published var nowPlaying: RadioNowPlaying?
-    @Published var isRefreshing = false
-    @Published var refreshErrorMessage: String?
-    @Published var lastUpdated: Date?
+    var nowPlaying: RadioNowPlaying?
+    var isRefreshing = false
+    var refreshErrorMessage: String?
+    var lastUpdated: Date?
     private var pollTimer: Timer?
-    private var refreshTask: Task<Void, Never>?
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
     private var lastMetadataSignature: String?
     private init() {}
     func start() {

--- a/Twinskaraoke/Services/Shimeji/ShimejiEngine.swift
+++ b/Twinskaraoke/Services/Shimeji/ShimejiEngine.swift
@@ -1,7 +1,7 @@
-import Combine
 import CoreGraphics
 import Foundation
 import QuartzCore
+import Observation
 
 #if canImport(UIKit)
     import UIKit
@@ -10,7 +10,8 @@ import QuartzCore
 /// One on-screen creature. Position/animation state live here; the engine
 /// owns the shared physics tick, `ShimejiSpriteView` just renders whatever
 /// this currently says.
-final class ShimejiInstance: Identifiable, ObservableObject {
+@Observable
+final class ShimejiInstance: Identifiable {
     enum Motion {
         case falling
         case idle
@@ -23,10 +24,10 @@ final class ShimejiInstance: Identifiable, ObservableObject {
     let id = UUID()
     let character: ShimejiCharacterDefinition
 
-    @Published var position: CGPoint
-    @Published var action: ShimejiActionKind = .fall
-    @Published var frameIndex: Int = 0
-    @Published var facingRight: Bool = true
+    var position: CGPoint
+    var action: ShimejiActionKind = .fall
+    var frameIndex: Int = 0
+    var facingRight: Bool = true
 
     var motion: Motion = .falling
     var velocityX: CGFloat = 0
@@ -66,15 +67,16 @@ final class ShimejiInstance: Identifiable, ObservableObject {
 /// Drives every on-screen Shimeji: spawn/despawn, the shared physics/AI tick,
 /// and drag interaction. One instance lives for the app's lifetime.
 @MainActor
-final class ShimejiEngine: NSObject, ObservableObject {
+@Observable
+final class ShimejiEngine: NSObject {
     static let shared = ShimejiEngine()
     /// Rendered sprite size in points; shared with ShimejiSpriteView (visual
     /// size) and the overlay window's hitTest (touch target) so both agree
     /// on where a sprite actually is on screen.
     static let displaySize: CGFloat = 84
 
-    @Published private(set) var instances: [ShimejiInstance] = []
-    @Published var bounds: CGRect = .zero
+    private(set) var instances: [ShimejiInstance] = []
+    var bounds: CGRect = .zero
 
     /// The app's actual tab bar top edge, in the same coordinate space as
     /// `bounds`, kept fresh by `ShimejiOverlayController`'s periodic poll of
@@ -99,14 +101,14 @@ final class ShimejiEngine: NSObject, ObservableObject {
 
     // MARK: - Mini player floor
 
-    @Published private(set) var hasMiniPlayer: Bool = false {
+    private(set) var hasMiniPlayer: Bool = false {
         didSet {
             guard hasMiniPlayer != oldValue else { return }
             handleFloorTargetChange()
         }
     }
 
-    @Published var isNowPlayingOpen: Bool = false {
+    var isNowPlayingOpen: Bool = false {
         didSet {
             guard isNowPlayingOpen != oldValue else { return }
             handleFloorTargetChange()
@@ -120,7 +122,7 @@ final class ShimejiEngine: NSObject, ObservableObject {
         }
     }
 
-    private var cancellables = Set<AnyCancellable>()
+    private var playbackObservation: ObservationToken?
 
     override private init() {
         super.init()
@@ -128,22 +130,23 @@ final class ShimejiEngine: NSObject, ObservableObject {
     }
 
     private func observePlaybackState() {
-        AudioPlayerManager.shared.$currentSong
-            .map { $0 != nil }
-            .removeDuplicates()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] hasSong in
-                self?.hasMiniPlayer = hasSong
-            }
-            .store(in: &cancellables)
+        // The guarded assignments below replace `removeDuplicates`: only the
+        // presence of a song matters here, so most `currentSong` changes are
+        // no-ops for the overlay and must not restart its animation.
+        playbackObservation = observeContinuously({
+            _ = AudioPlayerManager.shared.currentSong
+            _ = PopupPresentationState.shared.isExpanded
+        }, onChange: { [weak self] in
+            self?.syncPlaybackState()
+        })
+        syncPlaybackState()
+    }
 
-        PopupPresentationState.shared.$isExpanded
-            .removeDuplicates()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] isExpanded in
-                self?.isNowPlayingOpen = isExpanded
-            }
-            .store(in: &cancellables)
+    private func syncPlaybackState() {
+        let hasSong = AudioPlayerManager.shared.currentSong != nil
+        if hasMiniPlayer != hasSong { hasMiniPlayer = hasSong }
+        let isExpanded = PopupPresentationState.shared.isExpanded
+        if isNowPlayingOpen != isExpanded { isNowPlayingOpen = isExpanded }
     }
 
     // MARK: - Lifecycle

--- a/Twinskaraoke/Services/Shimeji/ShimejiResourceManager.swift
+++ b/Twinskaraoke/Services/Shimeji/ShimejiResourceManager.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 #if canImport(UIKit)
     import UIKit
@@ -10,7 +10,8 @@ import Foundation
 /// characters/actions can ship without an app update — see manifest.json's
 /// `formatVersion` for the on-disk contract this expects.
 @MainActor
-final class ShimejiResourceManager: NSObject, ObservableObject {
+@Observable
+final class ShimejiResourceManager: NSObject {
     static let shared = ShimejiResourceManager()
 
     static let packURL = URL(string: "https://sb.sillyprootsoda.com/shimeji_nwero.zip")!
@@ -23,15 +24,15 @@ final class ShimejiResourceManager: NSObject, ObservableObject {
         case failed(String)
     }
 
-    @Published private(set) var state: State = .notDownloaded
-    @Published private(set) var manifest: ShimejiManifest?
+    private(set) var state: State = .notDownloaded
+    private(set) var manifest: ShimejiManifest?
 
     private var downloadTask: URLSessionDownloadTask?
     private var progressObservation: NSKeyValueObservation?
-    private var installationTask: Task<Void, Never>?
+    @ObservationIgnored private var installationTask: Task<Void, Never>?
     private var operationGeneration: UInt = 0
 
-    private lazy var packDirectory: URL = {
+    @ObservationIgnored private lazy var packDirectory: URL = {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         return base.appendingPathComponent("ShimejiPack", isDirectory: true)
     }()

--- a/Twinskaraoke/Services/Storage/CacheManager.swift
+++ b/Twinskaraoke/Services/Storage/CacheManager.swift
@@ -1,9 +1,10 @@
-import Combine
 import Foundation
 import SDWebImageSwiftUI
+import Observation
 
 @MainActor
-final class CacheManager: ObservableObject {
+@Observable
+final class CacheManager {
     static let shared = CacheManager()
 
     nonisolated static let imageCacheLimit: UInt64 = 2 * 1024 * 1024 * 1024
@@ -12,12 +13,12 @@ final class CacheManager: ObservableObject {
     nonisolated static let lyricsCacheLimit: UInt64 = 64 * 1024 * 1024
     nonisolated static let maxCacheAge: TimeInterval = 6 * 30 * 24 * 3600
 
-    @Published private(set) var imageCacheSize: UInt64 = 0
-    @Published private(set) var musicCacheSize: UInt64 = 0
-    @Published private(set) var lyricsCacheSize: UInt64 = 0
+    private(set) var imageCacheSize: UInt64 = 0
+    private(set) var musicCacheSize: UInt64 = 0
+    private(set) var lyricsCacheSize: UInt64 = 0
 
     private let fm = FileManager.default
-    private var sizeRefreshTask: Task<Void, Never>?
+    @ObservationIgnored private var sizeRefreshTask: Task<Void, Never>?
 
     // Maintenance walks entire cache directories (music cache can hold
     // gigabytes across hundreds of folders). That file I/O must stay off the
@@ -29,11 +30,23 @@ final class CacheManager: ObservableObject {
     // Debounce state for the per-transition/per-save enforcement passes.
     // Only touched on the serial maintenanceQueue.
     private nonisolated static let enforcementDebounceInterval: TimeInterval = 60
-    private nonisolated(unsafe) var lastMusicEnforcementAt: Date?
+    // Written on the serial maintenance queue, never read by a view:
+    // observation-tracking these would route background writes through the
+    // registrar and break the nonisolated(unsafe) contract.
+    @ObservationIgnored private nonisolated(unsafe) var lastMusicEnforcementAt: Date?
     private nonisolated(unsafe) static var lastMusicCommitAt: Date?
-    private nonisolated(unsafe) var lastMusicCacheSize: UInt64?
-    private nonisolated(unsafe) var lastLyricsEnforcementAt: Date?
-    private nonisolated(unsafe) var lastLyricsCacheSize: UInt64?
+    // Written on the serial maintenance queue, never read by a view:
+    // observation-tracking these would route background writes through the
+    // registrar and break the nonisolated(unsafe) contract.
+    @ObservationIgnored private nonisolated(unsafe) var lastMusicCacheSize: UInt64?
+    // Written on the serial maintenance queue, never read by a view:
+    // observation-tracking these would route background writes through the
+    // registrar and break the nonisolated(unsafe) contract.
+    @ObservationIgnored private nonisolated(unsafe) var lastLyricsEnforcementAt: Date?
+    // Written on the serial maintenance queue, never read by a view:
+    // observation-tracking these would route background writes through the
+    // registrar and break the nonisolated(unsafe) contract.
+    @ObservationIgnored private nonisolated(unsafe) var lastLyricsCacheSize: UInt64?
 
     private init() {
         let directories = Self.directories

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -1,7 +1,7 @@
-import Combine
 import Foundation
 import Network
 import SwiftUI
+import Observation
 
 // Called from URLSession completion handlers off the main actor; NSLock-guarded.
 private nonisolated final class DownloadTaskRegistry: @unchecked Sendable {
@@ -88,7 +88,8 @@ struct SongCollectionDownloadStatus: Equatable, Sendable {
 }
 
 @MainActor
-final class DownloadManager: ObservableObject {
+@Observable
+final class DownloadManager {
     private struct PublishedState: Equatable {
         var downloadedIDs = Set<String>()
         var inProgress = Set<String>()
@@ -116,12 +117,12 @@ final class DownloadManager: ObservableObject {
     }
 
     static let shared = DownloadManager()
-    @Published private var publishedState = PublishedState()
+    private var publishedState = PublishedState()
     var downloadedIDs: Set<String> { publishedState.downloadedIDs }
     var inProgress: Set<String> { publishedState.inProgress }
     private let cacheDir: URL
     private var tasks: [String: URLSessionDownloadTask] = [:]
-    private var cachePromotionTasks: [String: Task<Void, Never>] = [:]
+    @ObservationIgnored private var cachePromotionTasks: [String: Task<Void, Never>] = [:]
     // Song IDs that already used their one resume-data retry for the current
     // download attempt; a second interruption fails normally.
     private var resumeRetriedSongIDs: Set<String> = []
@@ -343,19 +344,6 @@ final class DownloadManager: ObservableObject {
             inProgress: inProgress,
             songs: songs
         )
-    }
-
-    func statusPublisher(for songID: String) -> AnyPublisher<SongDownloadStatus, Never> {
-        $publishedState
-            .map { state in
-                SongDownloadStatus.make(
-                    downloadedIDs: state.downloadedIDs,
-                    inProgress: state.inProgress,
-                    songID: songID
-                )
-            }
-            .removeDuplicates()
-            .eraseToAnyPublisher()
     }
 
     private func updatePublishedState(_ update: (inout PublishedState) -> Void) {
@@ -774,6 +762,21 @@ final class DownloadManager: ObservableObject {
                 )
             )
             completedInCurrentQueue += 1
+            // A downloaded song should never need the network again — but the
+            // audio was the only thing being persisted, so its artwork was
+            // still fetched on demand and showed a placeholder offline. Warm
+            // the row and card variants into the (2 GB, 90-day) image cache so
+            // the whole row renders from disk.
+            ArtworkPrefetcher.shared.warmCollection(
+                songs: [song],
+                reason: "downloaded artwork \(songID)",
+                variant: .row
+            )
+            ArtworkPrefetcher.shared.warmCollection(
+                songs: [song],
+                reason: "downloaded artwork card \(songID)",
+                variant: .card
+            )
         } else {
             failedInCurrentQueue += 1
             DebugLogger.log("Download failed: \(songID)", category: .network)

--- a/Twinskaraoke/Services/User/AuthManager.swift
+++ b/Twinskaraoke/Services/User/AuthManager.swift
@@ -1,8 +1,8 @@
 import AuthenticationServices
-import Combine
 import CryptoKit
 import Foundation
 import Security
+import Observation
 
 @MainActor
 private final class WebAuthenticationPresentationContextProvider:
@@ -20,13 +20,14 @@ private final class WebAuthenticationPresentationContextProvider:
 }
 
 @MainActor
-final class AuthManager: NSObject, ObservableObject {
-    @Published private(set) var isLoggedIn = false
-    @Published private(set) var currentUsername: String?
-    @Published private(set) var currentUserId: String?
-    @Published private(set) var currentAvatar: String?
-    @Published private(set) var isLoading = false
-    @Published private(set) var errorMessage: String?
+@Observable
+final class AuthManager: NSObject {
+    private(set) var isLoggedIn = false
+    private(set) var currentUsername: String?
+    private(set) var currentUserId: String?
+    private(set) var currentAvatar: String?
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
     private(set) var authToken: String?
     private let defaults = UserDefaults.standard
     private var webAuthenticationSession: ASWebAuthenticationSession?

--- a/Twinskaraoke/Services/User/RecentlyAddedTracker.swift
+++ b/Twinskaraoke/Services/User/RecentlyAddedTracker.swift
@@ -1,11 +1,12 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class RecentlyAddedTracker: ObservableObject {
+@Observable
+final class RecentlyAddedTracker {
     static let shared = RecentlyAddedTracker()
     private static let storageKey = "nk.recentlyAddedDates.v1"
-    @Published private(set) var dates: [String: Date] = [:]
+    private(set) var dates: [String: Date] = [:]
     private init() {
         load()
     }

--- a/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
+++ b/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
@@ -1,13 +1,14 @@
-import Combine
 import Foundation
 import SwiftUI
+import Observation
 
 @MainActor
-final class RecentlyPlayedStore: ObservableObject {
+@Observable
+final class RecentlyPlayedStore {
     static let shared = RecentlyPlayedStore()
     private static let storageKey = "nk.recentlyPlayed.playlists.v1"
     private static let limit = 20
-    @Published private(set) var playlists: [Playlist] = []
+    private(set) var playlists: [Playlist] = []
     private init() {
         load()
     }

--- a/Twinskaraoke/Services/User/SavedPlaylistsStore.swift
+++ b/Twinskaraoke/Services/User/SavedPlaylistsStore.swift
@@ -1,12 +1,13 @@
-import Combine
 import Foundation
 import SwiftUI
+import Observation
 
 @MainActor
-final class SavedPlaylistsStore: ObservableObject {
+@Observable
+final class SavedPlaylistsStore {
     static let shared = SavedPlaylistsStore()
     private static let storageKey = "nk.savedPlaylists.v1"
-    @Published private(set) var playlists: [Playlist] = []
+    private(set) var playlists: [Playlist] = []
     // O(1) membership cache for isSaved, which is called per visible
     // playlist count label on every publish.
     private var savedIDs: Set<String> = []

--- a/Twinskaraoke/Services/User/UserPlaylistsManager.swift
+++ b/Twinskaraoke/Services/User/UserPlaylistsManager.swift
@@ -1,12 +1,13 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class UserPlaylistsManager: ObservableObject {
+@Observable
+final class UserPlaylistsManager {
     static let shared = UserPlaylistsManager()
 
-    @Published private(set) var playlists: [UserPlaylist] = []
-    @Published private(set) var isLoading = false
+    private(set) var playlists: [UserPlaylist] = []
+    private(set) var isLoading = false
 
     private var loaded = false
     private var stateGeneration = 0

--- a/Twinskaraoke/Theme/AuroraBackgroundViews.swift
+++ b/Twinskaraoke/Theme/AuroraBackgroundViews.swift
@@ -1,9 +1,10 @@
 import SwiftUI
-import Combine
+import Observation
 
-class CloudProvider: ObservableObject {
-    @Published var offset: CGSize
-    @Published var frameHeightRatio: CGFloat
+@Observable
+class CloudProvider {
+    var offset: CGSize
+    var frameHeightRatio: CGFloat
 
     init() {
         frameHeightRatio = CGFloat.random(in: 0.7 ..< 1.4)
@@ -16,7 +17,7 @@ class CloudProvider: ObservableObject {
 
 struct Cloud: View {
     // Fixed: Marked StateObject private and added appReduceMotion environment key
-    @StateObject private var provider = CloudProvider()
+    @State private var provider = CloudProvider()
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var move = false
 

--- a/TwinskaraokeShared/Services/FavoritesManager.swift
+++ b/TwinskaraokeShared/Services/FavoritesManager.swift
@@ -1,11 +1,12 @@
-import Combine
 import Foundation
 import SwiftUI
+import Observation
 
 @MainActor
-final class FavoritesManager: ObservableObject {
+@Observable
+final class FavoritesManager {
     static let shared = FavoritesManager()
-    @Published private(set) var favoriteIDs: Set<String> = []
+    private(set) var favoriteIDs: Set<String> = []
     private var inFlight: Set<String> = []
     private var loaded = false
     private var isLoading = false

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -789,11 +789,15 @@ nonisolated enum KaraokeAPIClient {
 
   static func data(
     for request: URLRequest,
-    retriesNonIdempotentRequest: Bool = false
+    retriesNonIdempotentRequest: Bool = false,
+    allowsRetry: Bool = true
   ) async throws -> Data {
     let maxRetries = 3
     let baseDelay: UInt64 = 500_000_000
-    let canRetry = retriesNonIdempotentRequest || isIdempotent(request)
+    // `allowsRetry: false` is for fire-and-forget writes whose failure is
+    // cosmetic (play counts). Retrying those triples their cost for no user
+    // benefit, and they burst when someone skips through a queue.
+    let canRetry = allowsRetry && (retriesNonIdempotentRequest || isIdempotent(request))
 
     for attempt in 0..<maxRetries {
       do {

--- a/TwinskaraokeShared/Services/ObservationBridge.swift
+++ b/TwinskaraokeShared/Services/ObservationBridge.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Observation
+
+/// Re-arming bridge from `@Observable` back to imperative change callbacks.
+///
+/// `@Observable` has no publisher projection, so the `$property.sink` pipelines
+/// this app used for cross-module wiring (CarPlay, the popup bar, the Shimeji
+/// overlay) have no direct equivalent. `withObservationTracking` is the
+/// replacement primitive, but it differs from `sink` in two ways that matter:
+///
+///   * it fires `onChange` **once** and then stops tracking, and
+///   * it fires *before* the write lands, so reading inside `onChange` still
+///     yields the old value.
+///
+/// This wrapper restores `sink` semantics — a callback after every change, for
+/// as long as the token is held — by hopping to the next main-actor turn (so
+/// the new value is visible) and then re-arming.
+///
+/// Cancel by releasing the token or calling `cancel()`; a cancelled token stops
+/// re-arming, which is what keeps view models from observing past their own
+/// lifetime.
+@MainActor
+final class ObservationToken {
+    private var isCancelled = false
+
+    fileprivate init() {}
+
+    func cancel() {
+        isCancelled = true
+    }
+
+    fileprivate var isActive: Bool { !isCancelled }
+
+    deinit {
+        // `isCancelled` is plain stored state on a MainActor type; the isolated
+        // deinit lets us touch it without hopping. See the house pattern note
+        // in AVEnginePlayback/AudioPlayerManager.
+        isCancelled = true
+    }
+}
+
+/// Calls `onChange` after every change to any `@Observable` property read
+/// inside `track`, until the returned token is cancelled or released.
+///
+/// `track` must actually *read* the properties to observe — that read is what
+/// registers them. Returning them is not required.
+@MainActor
+@discardableResult
+func observeContinuously(
+    _ track: @escaping @MainActor () -> Void,
+    onChange: @escaping @MainActor () -> Void
+) -> ObservationToken {
+    let token = ObservationToken()
+    armObservation(token: token, track: track, onChange: onChange)
+    return token
+}
+
+@MainActor
+private func armObservation(
+    token: ObservationToken,
+    track: @escaping @MainActor () -> Void,
+    onChange: @escaping @MainActor () -> Void
+) {
+    guard token.isActive else { return }
+    withObservationTracking {
+        track()
+    } onChange: {
+        // onChange runs in the mutating context, before the value is written,
+        // and is not main-actor isolated. Hop so observers see the new value.
+        Task { @MainActor [weak token] in
+            guard let token, token.isActive else { return }
+            onChange()
+            armObservation(token: token, track: track, onChange: onChange)
+        }
+    }
+}

--- a/TwinskaraokeTVApp/App/ContentView.swift
+++ b/TwinskaraokeTVApp/App/ContentView.swift
@@ -9,7 +9,7 @@ enum TVTab: Hashable {
 }
 
 struct ContentView: View {
-    @StateObject private var audioManager = AudioManager.shared
+    private let audioManager = AudioManager.shared
     @State private var selectedTab: TVTab = .home
 
     var body: some View {
@@ -34,7 +34,7 @@ struct ContentView: View {
                 .tabItem { Label("Now Playing", systemImage: "play.circle.fill") }
                 .tag(TVTab.nowPlaying)
         }
-        .environmentObject(audioManager)
+        .environment(audioManager)
         .tint(.appAccent)
         // The lyrics panel reads `\.appReduceMotion` for its scroll and
         // depth-of-field animations, same as iOS; without this it would always

--- a/TwinskaraokeTVApp/Features/Account/AccountView.swift
+++ b/TwinskaraokeTVApp/Features/Account/AccountView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct AccountView: View {
-    @StateObject private var auth = TVAuthManager()
+    @State private var auth = TVAuthManager()
     @State private var username = ""
     @State private var password = ""
     @State private var showSignOutConfirmation = false

--- a/TwinskaraokeTVApp/Features/Account/TVQRSignInPanel.swift
+++ b/TwinskaraokeTVApp/Features/Account/TVQRSignInPanel.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// The pairing half of the TV sign-in screen: renders the current pairing code
 /// and reflects `TVAuthManager.qrPhase` while a phone approves it.
 struct TVQRSignInPanel: View {
-    @ObservedObject var auth: TVAuthManager
+    let auth: TVAuthManager
     let onUsePassword: () -> Void
 
     private let codeSize: CGFloat = 320

--- a/TwinskaraokeTVApp/Features/Home/HomeView.swift
+++ b/TwinskaraokeTVApp/Features/Home/HomeView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 struct HomeView: View {
     let onPlay: (Song, [Song]) -> Void
 
-    @EnvironmentObject private var audioManager: AudioManager
-    @StateObject private var viewModel = HomeViewModel()
+    @Environment(AudioManager.self) private var audioManager
+    @State private var viewModel = HomeViewModel()
 
     var body: some View {
         Group {

--- a/TwinskaraokeTVApp/Features/Library/LibraryView.swift
+++ b/TwinskaraokeTVApp/Features/Library/LibraryView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct LibraryView: View {
     let onPlay: (Song, [Song]) -> Void
 
-    @StateObject private var viewModel = PlaylistsViewModel()
+    @State private var viewModel = PlaylistsViewModel()
 
     private let cardWidth: CGFloat = 260
     private let columns = [GridItem(.adaptive(minimum: 260), spacing: 60)]

--- a/TwinskaraokeTVApp/Features/Library/PlaylistDetailView.swift
+++ b/TwinskaraokeTVApp/Features/Library/PlaylistDetailView.swift
@@ -4,13 +4,13 @@ struct PlaylistDetailView: View {
     let playlist: Playlist
     let onPlay: (Song, [Song]) -> Void
 
-    @EnvironmentObject private var audioManager: AudioManager
-    @StateObject private var viewModel: PlaylistDetailViewModel
+    @Environment(AudioManager.self) private var audioManager
+    @State private var viewModel: PlaylistDetailViewModel
 
     init(playlist: Playlist, onPlay: @escaping (Song, [Song]) -> Void) {
         self.playlist = playlist
         self.onPlay = onPlay
-        _viewModel = StateObject(wrappedValue: PlaylistDetailViewModel(playlistID: playlist.id))
+        _viewModel = State(initialValue: PlaylistDetailViewModel(playlistID: playlist.id))
     }
 
     var body: some View {

--- a/TwinskaraokeTVApp/Features/Player/PlayerView.swift
+++ b/TwinskaraokeTVApp/Features/Player/PlayerView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct PlayerView: View {
-    @EnvironmentObject private var audioManager: AudioManager
-    @StateObject private var lyrics = TVLyricsViewModel()
+    @Environment(AudioManager.self) private var audioManager
+    @State private var lyrics = TVLyricsViewModel()
     @FocusState private var focusedTransportControl: TVTransportControl?
 
     var body: some View {

--- a/TwinskaraokeTVApp/Features/Search/SearchView.swift
+++ b/TwinskaraokeTVApp/Features/Search/SearchView.swift
@@ -3,11 +3,14 @@ import SwiftUI
 struct SearchView: View {
     let onPlay: (Song, [Song]) -> Void
 
-    @EnvironmentObject private var audioManager: AudioManager
-    @StateObject private var viewModel = SearchViewModel()
+    @Environment(AudioManager.self) private var audioManager
+    @State private var viewModel = SearchViewModel()
 
     var body: some View {
-        NavigationStack {
+        // @Observable models expose bindings through @Bindable rather than the
+        // old $viewModel projection.
+        @Bindable var viewModel = viewModel
+        return NavigationStack {
             // See `LibraryView`: the tab bar labels this screen, and a tvOS nav
             // title floats over the scroll content instead of reserving space.
             content

--- a/TwinskaraokeTVApp/Models/HomeViewModel.swift
+++ b/TwinskaraokeTVApp/Models/HomeViewModel.swift
@@ -1,12 +1,13 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class HomeViewModel: ObservableObject {
-    @Published var trending: [Song] = []
-    @Published var latest: [Song] = []
-    @Published var isLoading = false
-    @Published var loadError: String?
+@Observable
+final class HomeViewModel {
+    var trending: [Song] = []
+    var latest: [Song] = []
+    var isLoading = false
+    var loadError: String?
 
     func fetch() {
         guard !isLoading, trending.isEmpty else { return }

--- a/TwinskaraokeTVApp/Models/PlaylistDetailViewModel.swift
+++ b/TwinskaraokeTVApp/Models/PlaylistDetailViewModel.swift
@@ -1,11 +1,12 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class PlaylistDetailViewModel: ObservableObject {
-    @Published var songs: [Song] = []
-    @Published var isLoading = false
-    @Published var loadError: String?
+@Observable
+final class PlaylistDetailViewModel {
+    var songs: [Song] = []
+    var isLoading = false
+    var loadError: String?
     let playlistID: String
 
     init(playlistID: String) {

--- a/TwinskaraokeTVApp/Models/PlaylistsViewModel.swift
+++ b/TwinskaraokeTVApp/Models/PlaylistsViewModel.swift
@@ -1,11 +1,12 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class PlaylistsViewModel: ObservableObject {
-    @Published var playlists: [Playlist] = []
-    @Published var isLoading = false
-    @Published var loadError: String?
+@Observable
+final class PlaylistsViewModel {
+    var playlists: [Playlist] = []
+    var isLoading = false
+    var loadError: String?
 
     func fetch() {
         guard !isLoading, playlists.isEmpty else { return }

--- a/TwinskaraokeTVApp/Models/SearchViewModel.swift
+++ b/TwinskaraokeTVApp/Models/SearchViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 /// A search result paired with its playable Song, resolved once per results
 /// change so rows don't re-run `toSong()` on every body evaluation.
@@ -10,38 +10,47 @@ struct TVSearchResult: Identifiable {
 }
 
 @MainActor
-final class SearchViewModel: ObservableObject {
-    @Published var results: [SearchSongItem] = [] {
+@Observable
+final class SearchViewModel {
+    var results: [SearchSongItem] = [] {
         didSet {
             resolvedResults = results.map { TVSearchResult(item: $0, song: $0.toSong()) }
             playableSongs = resolvedResults.compactMap(\.song)
         }
     }
-    @Published private(set) var resolvedResults: [TVSearchResult] = []
-    @Published private(set) var playableSongs: [Song] = []
-    @Published var isLoading = false
-    @Published var searchText = ""
-    @Published var loadError: String?
+    private(set) var resolvedResults: [TVSearchResult] = []
+    private(set) var playableSongs: [Song] = []
+    var isLoading = false
+    var searchText = "" {
+        didSet { scheduleSearch() }
+    }
 
-    private var cancellables = Set<AnyCancellable>()
-    private var queryToken = 0
+    var loadError: String?
 
-    init() {
-        $searchText
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .debounce(for: .milliseconds(400), scheduler: RunLoop.main)
-            .removeDuplicates()
-            .sink { [weak self] text in
-                if !text.isEmpty {
-                    self?.performSearch(query: text)
-                } else {
-                    self?.queryToken += 1
-                    self?.results = []
-                    self?.isLoading = false
-                    self?.loadError = nil
-                }
+    @ObservationIgnored private var queryToken = 0
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
+    @ObservationIgnored private var lastDispatchedQuery = ""
+
+    /// Replaces the former `$searchText.debounce().removeDuplicates()` pipeline:
+    /// `@Observable` has no publisher projection, so the 400ms coalescing and
+    /// the duplicate-query suppression are done here instead.
+    private func scheduleSearch() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled, let self else { return }
+            let text = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard text != lastDispatchedQuery else { return }
+            lastDispatchedQuery = text
+            if text.isEmpty {
+                queryToken += 1
+                results = []
+                isLoading = false
+                loadError = nil
+            } else {
+                performSearch(query: text)
             }
-            .store(in: &cancellables)
+        }
     }
 
     func performSearch(query: String) {

--- a/TwinskaraokeTVApp/Models/TVLyricsViewModel.swift
+++ b/TwinskaraokeTVApp/Models/TVLyricsViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 /// Loads timed lyrics for the tvOS player.
 ///
@@ -10,11 +10,12 @@ import Foundation
 /// streams instead of downloading — so an in-memory cache keyed by song is
 /// enough to make returning to a song in the same session instant.
 @MainActor
-final class TVLyricsViewModel: ObservableObject {
-    @Published private(set) var lyrics: [LyricLine] = []
-    @Published private(set) var isLoading = false
-    @Published private(set) var didFail = false
-    @Published private(set) var hasNoLyrics = false
+@Observable
+final class TVLyricsViewModel {
+    private(set) var lyrics: [LyricLine] = []
+    private(set) var isLoading = false
+    private(set) var didFail = false
+    private(set) var hasNoLyrics = false
 
     /// The song a load is currently satisfied for. Cleared on failure so that
     /// coming back to the player retries instead of showing a stale error.
@@ -23,7 +24,7 @@ final class TVLyricsViewModel: ObservableObject {
     /// what to re-request.
     private var requestedSongID: String?
 
-    private var task: Task<Void, Never>?
+    @ObservationIgnored private var task: Task<Void, Never>?
     private var cache: [String: [LyricLine]] = [:]
     /// Songs the API answered 404 for, so switching back and forth doesn't
     /// re-ask for something the catalog has already said it lacks.

--- a/TwinskaraokeTVApp/Services/AudioManager.swift
+++ b/TwinskaraokeTVApp/Services/AudioManager.swift
@@ -3,6 +3,7 @@ import Combine
 import Foundation
 import MediaPlayer
 import SwiftUI
+import Observation
 
 enum PlaybackMode {
     case listLoop
@@ -21,26 +22,27 @@ enum PlaybackMode {
 /// downloading to a local cache first. It still drives the queue, Now Playing
 /// info, and the Siri Remote / Control Center transport commands.
 @MainActor
-final class AudioManager: ObservableObject {
+@Observable
+final class AudioManager {
     static let shared = AudioManager()
 
-    @Published var currentSong: Song? {
+    var currentSong: Song? {
         didSet { refreshUpNext() }
     }
-    @Published var isPlaying = false
-    @Published var isLoading = false
-    @Published private(set) var playbackError: String?
-    @Published var currentTime: Double = 0
-    @Published var duration: Double = 0
-    @Published var queue: [Song] = [] {
+    var isPlaying = false
+    var isLoading = false
+    private(set) var playbackError: String?
+    var currentTime: Double = 0
+    var duration: Double = 0
+    var queue: [Song] = [] {
         didSet { refreshUpNext() }
     }
-    @Published var currentIndex: Int = 0 {
+    var currentIndex: Int = 0 {
         didSet { refreshUpNext() }
     }
-    @Published private(set) var upNextSongs: [Song] = []
-    @Published var playbackMode: PlaybackMode = .listLoop
-    @Published var isShuffleOn = false
+    private(set) var upNextSongs: [Song] = []
+    var playbackMode: PlaybackMode = .listLoop
+    var isShuffleOn = false
 
     private var player: AVPlayer?
     private var timeObserver: Any?

--- a/TwinskaraokeTVApp/Services/TVAuthManager.swift
+++ b/TwinskaraokeTVApp/Services/TVAuthManager.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 struct TVProfileResponse: Decodable, Sendable {
     let profile: TVProfile
@@ -64,22 +64,23 @@ struct TVUploadLimits: Decodable, Sendable {
 }
 
 @MainActor
-final class TVAuthManager: ObservableObject {
-    @Published private(set) var isLoggedIn = false
-    @Published private(set) var currentUsername: String?
-    @Published private(set) var currentUserId: String?
-    @Published private(set) var currentAvatar: String?
-    @Published private(set) var profile: TVProfile?
-    @Published private(set) var badges: [TVBadge] = []
-    @Published private(set) var uploadLimits: TVUploadLimits?
-    @Published private(set) var isAuthenticating = false
-    @Published private(set) var isRefreshing = false
-    @Published private(set) var authError: String?
-    @Published private(set) var profileError: String?
+@Observable
+final class TVAuthManager {
+    private(set) var isLoggedIn = false
+    private(set) var currentUsername: String?
+    private(set) var currentUserId: String?
+    private(set) var currentAvatar: String?
+    private(set) var profile: TVProfile?
+    private(set) var badges: [TVBadge] = []
+    private(set) var uploadLimits: TVUploadLimits?
+    private(set) var isAuthenticating = false
+    private(set) var isRefreshing = false
+    private(set) var authError: String?
+    private(set) var profileError: String?
 
-    @Published private(set) var qrSession: TVQRSignIn.Session?
-    @Published private(set) var qrPhase: QRPhase = .idle
-    @Published private(set) var qrError: String?
+    private(set) var qrSession: TVQRSignIn.Session?
+    private(set) var qrPhase: QRPhase = .idle
+    private(set) var qrError: String?
 
     enum QRPhase: Equatable {
         case idle
@@ -91,7 +92,7 @@ final class TVAuthManager: ObservableObject {
         case expired
     }
 
-    private var qrTask: Task<Void, Never>?
+    @ObservationIgnored private var qrTask: Task<Void, Never>?
 
     private let defaults = UserDefaults.standard
 

--- a/TwinskaraokeWatchApp/App/ContentView.swift
+++ b/TwinskaraokeWatchApp/App/ContentView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import WatchKit
 
 struct ContentView: View {
-    @StateObject var audioManager = AudioManager.shared
+    let audioManager = AudioManager.shared
     var body: some View {
         HomeView()
-            .environmentObject(audioManager)
+            .environment(audioManager)
     }
 }
 

--- a/TwinskaraokeWatchApp/Features/Account/AccountView.swift
+++ b/TwinskaraokeWatchApp/Features/Account/AccountView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
 struct AccountView: View {
-    @ObservedObject private var auth = WatchAuthManager.shared
+    private let auth = WatchAuthManager.shared
     /// Watched only for `cacheRevision`: a song that finishes downloading while
     /// this screen is open changes what "Downloaded Audio" should say, and
     /// leaving it to `onAppear` meant the listener had to navigate away and
     /// back before the figure — and whether "Clear Cache" is even enabled —
     /// caught up.
-    @ObservedObject private var audioManager = AudioManager.shared
+    private let audioManager = AudioManager.shared
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @AppStorage(AppLanguage.storageKey) private var languageMode: String = AppLanguage.system.rawValue

--- a/TwinskaraokeWatchApp/Features/Home/HomeView.swift
+++ b/TwinskaraokeWatchApp/Features/Home/HomeView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct HomeView: View {
-    @EnvironmentObject var audioManager: AudioManager
-    @StateObject var homeViewModel = HomeViewModel()
-    @ObservedObject private var auth = WatchAuthManager.shared
-    @ObservedObject private var recents = RecentlyPlayedStore.shared
+    @Environment(AudioManager.self) var audioManager
+    @State var homeViewModel = HomeViewModel()
+    private let auth = WatchAuthManager.shared
+    private var recents = RecentlyPlayedStore.shared
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @State private var path = NavigationPath()
@@ -221,17 +221,17 @@ struct HomeView: View {
     private func view(for destination: Destination) -> some View {
         switch destination {
         case .player:
-            PlayerView().environmentObject(audioManager)
+            PlayerView().environment(audioManager)
         case .playlists:
             PlaylistsGridView()
         case .favorites:
-            FavoritesView().environmentObject(audioManager)
+            FavoritesView().environment(audioManager)
         case .songs:
-            SongsView().environmentObject(audioManager)
+            SongsView().environment(audioManager)
         case .radio:
-            RadioView().environmentObject(audioManager)
+            RadioView().environment(audioManager)
         case .search:
-            SearchView().environmentObject(audioManager)
+            SearchView().environment(audioManager)
         case .account:
             AccountView()
         }

--- a/TwinskaraokeWatchApp/Features/Library/FavoritesView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/FavoritesView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct FavoritesView: View {
-    @StateObject private var viewModel = FavoritesViewModel()
-    @ObservedObject private var favorites = FavoritesManager.shared
-    @ObservedObject private var auth = WatchAuthManager.shared
-    @EnvironmentObject var audioManager: AudioManager
+    @State private var viewModel = FavoritesViewModel()
+    private let favorites = FavoritesManager.shared
+    private let auth = WatchAuthManager.shared
+    @Environment(AudioManager.self) var audioManager
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @State private var showPlayer = false
@@ -98,7 +98,7 @@ struct FavoritesView: View {
         .animation(listAnimation, value: viewModel.songs.count)
         .navigationDestination(isPresented: $showPlayer) {
             PlayerView()
-                .environmentObject(audioManager)
+                .environment(audioManager)
         }
         .onAppear {
             favorites.loadIfNeeded()

--- a/TwinskaraokeWatchApp/Features/Library/PlaylistDetailView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/PlaylistDetailView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct PlaylistDetailView: View {
-    @StateObject var viewModel: PlaylistDetailViewModel
-    @EnvironmentObject var audioManager: AudioManager
+    @State var viewModel: PlaylistDetailViewModel
+    @Environment(AudioManager.self) var audioManager
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @State private var showPlayer = false
@@ -25,8 +25,8 @@ struct PlaylistDetailView: View {
 
     init(playlistID: String, playlistName: String, fallbackSongs: [Song] = []) {
         self.playlistName = playlistName
-        _viewModel = StateObject(
-            wrappedValue: PlaylistDetailViewModel(
+        _viewModel = State(
+            initialValue: PlaylistDetailViewModel(
                 playlistID: playlistID,
                 fallbackSongs: fallbackSongs
             )
@@ -102,7 +102,7 @@ struct PlaylistDetailView: View {
         .animation(playbackAnimation, value: viewModel.isLoading)
         .navigationDestination(isPresented: $showPlayer) {
             PlayerView()
-                .environmentObject(audioManager)
+                .environment(audioManager)
         }
         .onAppear {
             viewModel.fetchSongs()

--- a/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/PlaylistsGridView.swift
@@ -37,9 +37,9 @@ struct PlaylistRoute: Hashable {
 }
 
 struct PlaylistsGridView: View {
-    @StateObject var viewModel = PlaylistsViewModel()
-    @StateObject private var userViewModel = UserPlaylistsViewModel()
-    @ObservedObject private var auth = WatchAuthManager.shared
+    @State var viewModel = PlaylistsViewModel()
+    @State private var userViewModel = UserPlaylistsViewModel()
+    private let auth = WatchAuthManager.shared
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     let columns = [

--- a/TwinskaraokeWatchApp/Features/Library/SongsView.swift
+++ b/TwinskaraokeWatchApp/Features/Library/SongsView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct SongsView: View {
-    @StateObject var viewModel = SongsViewModel()
-    @EnvironmentObject var audioManager: AudioManager
+    @State var viewModel = SongsViewModel()
+    @Environment(AudioManager.self) var audioManager
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @State private var showPlayer = false
@@ -83,7 +83,7 @@ struct SongsView: View {
         .animation(playbackAnimation, value: viewModel.isLoading)
         .navigationDestination(isPresented: $showPlayer) {
             PlayerView()
-                .environmentObject(audioManager)
+                .environment(audioManager)
         }
         .onAppear {
             viewModel.fetchSongs()

--- a/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/PlayerView.swift
@@ -97,9 +97,9 @@ private struct WatchPlayerLayoutMetrics {
 }
 
 struct PlayerView: View {
-    @EnvironmentObject var audioManager: AudioManager
-    @ObservedObject private var favorites = FavoritesManager.shared
-    @ObservedObject private var auth = WatchAuthManager.shared
+    @Environment(AudioManager.self) var audioManager
+    private let favorites = FavoritesManager.shared
+    private let auth = WatchAuthManager.shared
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
@@ -159,7 +159,7 @@ struct PlayerView: View {
                 // swipe to while the radio is on.
                 if !audioManager.isRadioMode {
                     QueueView(showsCurrentSong: false)
-                        .environmentObject(audioManager)
+                        .environment(audioManager)
                         .tag(Page.queue)
                 }
             }

--- a/TwinskaraokeWatchApp/Features/Player/QueueView.swift
+++ b/TwinskaraokeWatchApp/Features/Player/QueueView.swift
@@ -8,7 +8,7 @@ struct QueueView: View {
     /// beside it already shows.
     var showsCurrentSong = true
 
-    @EnvironmentObject var audioManager: AudioManager
+    @Environment(AudioManager.self) var audioManager
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
 

--- a/TwinskaraokeWatchApp/Features/Radio/RadioView.swift
+++ b/TwinskaraokeWatchApp/Features/Radio/RadioView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct RadioView: View {
-    @ObservedObject private var radio = RadioController.shared
-    @EnvironmentObject var audioManager: AudioManager
+    private var radio = RadioController.shared
+    @Environment(AudioManager.self) var audioManager
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
 

--- a/TwinskaraokeWatchApp/Features/Search/SearchView.swift
+++ b/TwinskaraokeWatchApp/Features/Search/SearchView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct SearchView: View {
-    @StateObject var viewModel = SearchViewModel()
-    @EnvironmentObject var audioManager: AudioManager
+    @State var viewModel = SearchViewModel()
+    @Environment(AudioManager.self) var audioManager
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @State private var showPlayer = false
@@ -19,7 +19,10 @@ struct SearchView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        // @Observable models expose bindings through @Bindable rather than the
+        // old $viewModel projection.
+        @Bindable var viewModel = viewModel
+        return VStack(spacing: 0) {
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 11, weight: .semibold))
@@ -145,7 +148,7 @@ struct SearchView: View {
         .animation(stateAnimation, value: viewModel.isLoading)
         .navigationDestination(isPresented: $showPlayer) {
             PlayerView()
-                .environmentObject(audioManager)
+                .environment(audioManager)
         }
         .onAppear {
             prefetchArtwork()

--- a/TwinskaraokeWatchApp/Models/Home/HomeViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Home/HomeViewModel.swift
@@ -1,10 +1,11 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class HomeViewModel: ObservableObject {
-    @Published var trending: [Song] = []
-    @Published var isLoading = false
+@Observable
+final class HomeViewModel {
+    var trending: [Song] = []
+    var isLoading = false
 
     func fetchTrending() {
         if AppRuntime.isUITestMode {

--- a/TwinskaraokeWatchApp/Models/Library/FavoritesViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/FavoritesViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 /// The signed-in listener's favorite songs.
 ///
@@ -7,16 +7,17 @@ import Foundation
 /// `FavoritesManager` loads from, so the star state on a row and the contents
 /// of this list can't disagree.
 @MainActor
-final class FavoritesViewModel: ObservableObject {
-    @Published var songs: [Song] = []
-    @Published var isLoading = false
+@Observable
+final class FavoritesViewModel {
+    var songs: [Song] = []
+    var isLoading = false
     /// Set when the initial load fails so the view can offer a retry instead
     /// of showing a misleading empty state.
-    @Published var loadError: String?
+    var loadError: String?
     /// Set when the phone says we are signed in but the token it holds has not
     /// reached this watch yet. Without it an empty list reads as "no favorites"
     /// when the truth is "could not ask".
-    @Published var needsPhoneSession = false
+    var needsPhoneSession = false
 
     func fetch(force: Bool = false) {
         guard !isLoading else { return }

--- a/TwinskaraokeWatchApp/Models/Library/PlaylistDetailViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/PlaylistDetailViewModel.swift
@@ -1,13 +1,14 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class PlaylistDetailViewModel: ObservableObject {
-    @Published var songs: [Song] = []
-    @Published var isLoading = false
+@Observable
+final class PlaylistDetailViewModel {
+    var songs: [Song] = []
+    var isLoading = false
     /// Set when the initial load fails so the view can offer a retry instead
     /// of showing a misleading empty state.
-    @Published var loadError: String?
+    var loadError: String?
     let playlistID: String
     /// Songs the caller already had — personal playlists arrive from
     /// `/api/user/playlists` with their contents inline. Shown immediately so

--- a/TwinskaraokeWatchApp/Models/Library/PlaylistsViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/PlaylistsViewModel.swift
@@ -1,13 +1,14 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class PlaylistsViewModel: ObservableObject {
-    @Published var playlists: [Playlist] = []
-    @Published var isLoading = false
+@Observable
+final class PlaylistsViewModel {
+    var playlists: [Playlist] = []
+    var isLoading = false
     /// Set when the initial load fails so the view can offer a retry instead
     /// of showing a misleading empty state.
-    @Published var loadError: String?
+    var loadError: String?
 
     func fetchMusic() {
         guard !isLoading, playlists.isEmpty else { return }

--- a/TwinskaraokeWatchApp/Models/Library/SongsViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/SongsViewModel.swift
@@ -1,13 +1,14 @@
-import Combine
 import Foundation
+import Observation
 
 @MainActor
-final class SongsViewModel: ObservableObject {
-    @Published var songs: [Song] = []
-    @Published var isLoading = false
+@Observable
+final class SongsViewModel {
+    var songs: [Song] = []
+    var isLoading = false
     /// Set when the initial load fails so the view can offer a retry instead
     /// of showing a misleading empty state.
-    @Published var loadError: String?
+    var loadError: String?
 
     func fetchSongs() {
         guard !isLoading, songs.isEmpty else { return }

--- a/TwinskaraokeWatchApp/Models/Library/UserPlaylistsViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/UserPlaylistsViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 /// The signed-in listener's own playlists.
 ///
@@ -8,12 +8,13 @@ import Foundation
 /// are mapped to `Playlist` so the existing watch grid and detail views work
 /// unchanged.
 @MainActor
-final class UserPlaylistsViewModel: ObservableObject {
-    @Published var playlists: [Playlist] = []
-    @Published var isLoading = false
+@Observable
+final class UserPlaylistsViewModel {
+    var playlists: [Playlist] = []
+    var isLoading = false
     /// Set when the initial load fails so the view can offer a retry instead
     /// of showing a misleading empty state.
-    @Published var loadError: String?
+    var loadError: String?
 
     func fetch(force: Bool = false) {
         guard !isLoading else { return }

--- a/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 /// A search result paired with its playable Song, resolved once per results change
 /// so rows don't re-run toSong() on every body evaluation.
@@ -10,39 +10,48 @@ struct WatchSearchResult: Identifiable {
 }
 
 @MainActor
-final class SearchViewModel: ObservableObject {
-    @Published var results: [SearchSongItem] = [] {
+@Observable
+final class SearchViewModel {
+    var results: [SearchSongItem] = [] {
         didSet {
             resolvedResults = results.map { WatchSearchResult(item: $0, song: $0.toSong()) }
             playableSongs = resolvedResults.compactMap(\.song)
         }
     }
-    @Published private(set) var resolvedResults: [WatchSearchResult] = []
-    @Published private(set) var playableSongs: [Song] = []
-    @Published var isLoading = false
-    @Published var searchText = ""
+    private(set) var resolvedResults: [WatchSearchResult] = []
+    private(set) var playableSongs: [Song] = []
+    var isLoading = false
+    var searchText = "" {
+        didSet { scheduleSearch() }
+    }
+
     /// Set when the latest query fails so the view can offer a retry instead
     /// of showing a misleading "no results" state.
-    @Published var loadError: String?
-    private var cancellables = Set<AnyCancellable>()
-    private var queryToken = 0
+    var loadError: String?
+    @ObservationIgnored private var queryToken = 0
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
+    @ObservationIgnored private var lastDispatchedQuery = ""
 
-    init() {
-        $searchText
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
-            .removeDuplicates()
-            .sink { [weak self] text in
-                if !text.isEmpty {
-                    self?.performSearch(query: text)
-                } else {
-                    self?.queryToken += 1
-                    self?.results = []
-                    self?.isLoading = false
-                    self?.loadError = nil
-                }
+    /// Replaces the former `$searchText.debounce().removeDuplicates()` pipeline:
+    /// `@Observable` has no publisher projection, so the 500ms coalescing and
+    /// the duplicate-query suppression are done here instead.
+    private func scheduleSearch() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled, let self else { return }
+            let text = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard text != lastDispatchedQuery else { return }
+            lastDispatchedQuery = text
+            if text.isEmpty {
+                queryToken += 1
+                results = []
+                isLoading = false
+                loadError = nil
+            } else {
+                performSearch(query: text)
             }
-            .store(in: &cancellables)
+        }
     }
 
     func performSearch(query: String) {

--- a/TwinskaraokeWatchApp/Services/AudioManager.swift
+++ b/TwinskaraokeWatchApp/Services/AudioManager.swift
@@ -3,6 +3,7 @@ import Combine
 import Foundation
 import MediaPlayer
 import SwiftUI
+import Observation
 
 enum PlaybackMode {
     case listLoop
@@ -16,33 +17,34 @@ enum PlaybackMode {
 }
 
 @MainActor
-class AudioManager: ObservableObject {
+@Observable
+class AudioManager {
     static let shared = AudioManager()
-    @Published var currentSong: Song? {
+    var currentSong: Song? {
         didSet { refreshUpNext() }
     }
-    @Published var isPlaying = false
-    @Published var isLoading = false
-    @Published var currentTime: Double = 0
-    @Published var duration: Double = 0
-    @Published var queue: [Song] = [] {
+    var isPlaying = false
+    var isLoading = false
+    var currentTime: Double = 0
+    var duration: Double = 0
+    var queue: [Song] = [] {
         didSet { refreshUpNext() }
     }
-    @Published var currentIndex: Int = 0 {
+    var currentIndex: Int = 0 {
         didSet { refreshUpNext() }
     }
     /// Up-next slice of the queue plus its summary string, recomputed only when
     /// the queue or current track changes (views re-evaluate on every 0.5s tick).
-    @Published private(set) var upNextSongs: [Song] = []
-    @Published private(set) var queueSummaryText = "End of queue"
-    @Published var playbackMode: PlaybackMode = .listLoop
-    @Published var isShuffleOn = false
-    @Published var volume: Double = AudioManager.storedVolume()
+    private(set) var upNextSongs: [Song] = []
+    private(set) var queueSummaryText = "End of queue"
+    var playbackMode: PlaybackMode = .listLoop
+    var isShuffleOn = false
+    var volume: Double = AudioManager.storedVolume()
     /// Live radio plays a stream straight from the network instead of going
     /// through the download-then-play cache pipeline, and has no queue,
     /// duration, or seekable position. Everything that assumes those is gated
     /// on this.
-    @Published private(set) var isRadioMode = false
+    private(set) var isRadioMode = false
     /// Bumped whenever the downloaded-audio cache gains or loses a file.
     ///
     /// The size itself is not published, because working it out means walking
@@ -50,7 +52,7 @@ class AudioManager: ObservableObject {
     /// screen that *is* looking can watch, so a download finishing behind the
     /// Account screen updates the figure on it instead of leaving it stale
     /// until the listener navigates away and back.
-    @Published private(set) var cacheRevision = 0
+    private(set) var cacheRevision = 0
     /// Radio artwork comes from the station metadata, not from `Song`, which
     /// carries only a synthetic ID for the current track.
     private var radioArtworkURL: URL?

--- a/TwinskaraokeWatchApp/Services/RadioController.swift
+++ b/TwinskaraokeWatchApp/Services/RadioController.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 /// Live station metadata for the watch.
 ///
@@ -7,18 +7,19 @@ import Foundation
 /// `AudioManager` is: the two targets drive completely different players. The
 /// wire format and the polling contract are shared through `RadioNowPlaying`.
 @MainActor
-final class RadioController: ObservableObject {
+@Observable
+final class RadioController {
     static let shared = RadioController()
 
-    @Published private(set) var nowPlaying: RadioNowPlaying?
-    @Published private(set) var isRefreshing = false
-    @Published private(set) var refreshErrorMessage: String?
+    private(set) var nowPlaying: RadioNowPlaying?
+    private(set) var isRefreshing = false
+    private(set) var refreshErrorMessage: String?
 
     /// Polling is driven by the radio screen being on-wrist, not by a timer
     /// that outlives it: a watch that keeps hitting the network with the
     /// display off is a battery complaint.
-    private var pollTask: Task<Void, Never>?
-    private var refreshTask: Task<Void, Never>?
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
     private var lastMetadataSignature: String?
     private var isScreenVisible = false
     private let pollInterval: Duration = .seconds(15)

--- a/TwinskaraokeWatchApp/Services/RecentlyPlayedStore.swift
+++ b/TwinskaraokeWatchApp/Services/RecentlyPlayedStore.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 /// Songs played on this watch, most recent first.
 ///
@@ -8,10 +8,11 @@ import Foundation
 /// from the phone's recently-played playlists, and it stays useful while
 /// signed out.
 @MainActor
-final class RecentlyPlayedStore: ObservableObject {
+@Observable
+final class RecentlyPlayedStore {
     static let shared = RecentlyPlayedStore()
 
-    @Published private(set) var songs: [Song] = []
+    private(set) var songs: [Song] = []
 
     /// Small enough that the whole list stays a glance rather than a scroll,
     /// and that re-encoding it on every track change stays cheap.

--- a/TwinskaraokeWatchApp/Services/WatchAuthManager.swift
+++ b/TwinskaraokeWatchApp/Services/WatchAuthManager.swift
@@ -1,6 +1,6 @@
-import Combine
 import Foundation
 import WatchConnectivity
+import Observation
 
 /// Watch half of the session bridge (see `WatchSessionLink`).
 ///
@@ -9,7 +9,8 @@ import WatchConnectivity
 /// token is pulled separately and kept only in this device's Keychain, where
 /// `KaraokeAPIClient` picks it up for every request.
 @MainActor
-final class WatchAuthManager: NSObject, ObservableObject {
+@Observable
+final class WatchAuthManager: NSObject {
     static let shared = WatchAuthManager()
 
     /// How the watch describes its own link to the phone, so the account
@@ -21,11 +22,11 @@ final class WatchAuthManager: NSObject, ObservableObject {
         case awaitingPhone
     }
 
-    @Published private(set) var linkState: LinkState = .signedOut
-    @Published private(set) var username: String?
-    @Published private(set) var userID: String?
-    @Published private(set) var avatarURL: URL?
-    @Published private(set) var isSyncing = false
+    private(set) var linkState: LinkState = .signedOut
+    private(set) var username: String?
+    private(set) var userID: String?
+    private(set) var avatarURL: URL?
+    private(set) var isSyncing = false
 
     private enum Key {
         static let username = "nk.watch.username"


### PR DESCRIPTION
Migrates the app off `ObservableObject`/`@Published` to `@Observable` (63 types across iOS, watchOS and tvOS) and fixes the artwork placeholders visible when fast-scrolling large playlists.

## Observation migration

Observation is not a drop-in rename. Three semantic differences caused real regressions, all found by device testing and fixed here:

**Subscription happens on property read, not on holding a reference.** `@ObservedObject` subscribed as long as you held the object; `@Observable` only subscribes to properties you actually read in `body`. Types that were held but never read silently stopped updating. Lyrics froze mid-song because `TimedLyricsView` held `PlaybackClock` without reading it, and `audioManager.playbackTime` is a computed property over `AVPlayer`, so it registers nothing with observation. The affected views now take an explicit read, commented as load-bearing so it is not "cleaned up" later.

**`@State` re-evaluates its initial value on every struct init.** `@StateObject` took an `@autoclosure` evaluated once. A `fetchHomeData()` call in `HomeViewModel.init()` that used to run a single time began running on every view init: **647 requests in 80s**, enough to earn HTTP 429s from the server. Moved to `.task`; the same interaction is now 89 requests.

**Invalidation re-enters SwiftUI's graph synchronously, and publishes on every write including no-ops.** `objectWillChange` was coalesced by Combine; `@Observable` is not. `ArtworkFailureBackoff.blockedUntil` published on `removeValue` calls that removed nothing, recursing until the test suite hung. It is now `@ObservationIgnored`, with `generation` as the sole publish signal, bumped only when something actually changed.

Adds `ObservationBridge.observeContinuously` to replace Combine `sink`s: `withObservationTracking` fires once, and before the write lands, so it re-arms on the next main-actor turn.

## Artwork scroll placeholders

The cause was **not** decode cost, which is where this started. `WebImage.body` in SDWebImageSwiftUI tests `image != nil` *before* the branch that calls `setupInitialState()`, and that is what starts the load:

```swift
if imageManager.image != nil && imageModel.url == imageManager.currentURL {
    displayImage()
} else {
    content(.empty)          // placeholder
    setupInitialState()      // starts the load
}
```

So even when the bitmap is already in the memory cache and the load completes synchronously, the assignment lands after this pass already committed to the placeholder. SwiftUI schedules a second pass, and **every row pays at least one grey frame regardless of decode speed**. At flick speed that is the placeholder.

`ArtworkMemoryCache` reads the memory cache synchronously during `body` and renders in the same pass, falling back to `WebImage` on a miss. Measured on device: **92-99% of rows** take the fast path once the cache is warm (25% on a cold start, ~75% while images are still downloading — those are bytes that have not arrived, which no synchronous path can fix).

Constraints worth noting for review:
- Valid only because the app sets no `cacheKeyFilter` and no image transformer, so the cache key is `url.absoluteString`. If either is added, this must go through `SDWebImageManager.shared.cacheKey(for:)`. Noted in the source.
- Renders via `Image(decorative:scale:orientation:)` to match `WebImage.configure(image:)` exactly — `Image(uiImage:)` breaks `.aspectRatio` on EXIF images. Animated and vector images deliberately fall through to `WebImage`.
- Memory-only on purpose: a synchronous disk read during `body` would stall the scroll, which is worse than the placeholder it avoids.

This replaced two planned rewrites (persisting pre-decoded assets; replacing `WebImage` in lists with a UIKit collection view). Both are now unnecessary — decode is not on the critical path, and the collection view's only real benefit was the synchronous assignment this already provides.

Supporting changes:
- `ArtworkPrefetcher` clamped every window to <=8, and to **4 during playback** — roughly one screen of rows, so any real scrolling outran it. Now 6/12/24, plus `warmCollection()` to pull a whole playlist on a separate prefetcher so it cannot starve the scroll path.
- SDWebImage `maxMemoryCount` 240 -> 1000. The count cap bound long before the 128MB cost cap (a 48pt row at @3x is ~81KB), so scrolling past ~240 rows forced a re-decode of bytes already held.
- Progressive blur preview gate 96pt -> 24pt, so 44-48pt song rows get a preview instead of flat grey.
- `DownloadManager` warms row and card artwork so downloaded songs render offline. Caveat: this lands in the shared 2GB LRU image cache, so unlike the audio it is not pinned.

Also stops retrying play-count reports, which are not idempotent, via an `allowsRetry` flag on `KaraokeAPIClient.data(for:)`.

## Testing

- iOS unit tests pass; iOS, watchOS and tvOS all build clean.
- Device-tested on iPhone across several rounds. The lyrics sync, 429 flood, WebP encode failures and test-suite hang above were all found this way and fixed.

## Known and deliberately not fixed

`Failed to create <width>x0 image slot` still appears in device logs. The search field's `.safeAreaInset(edge: .top)` changes `contentInsets.top`, which is part of the value `onScrollGeometryChange` observes, creating a feedback loop; the full-width field animates through zero height and its opacity transition asks CoreAnimation for a `<width>x0` buffer. It is cosmetic — nothing is drawn that frame — and the only fix found (coalescing scroll geometry updates to one per runloop turn) measurably hurt fast-scroll feel, so it was reverted.

## Summary by Sourcery

Migrate the app’s state and UI layer from Combine-based ObservableObject/@Published to the Swift Observation framework, introducing helpers and targeted fixes to preserve behaviour while improving performance and correctness, and overhaul artwork loading and prefetching so cached images render immediately during fast scrolling and downloaded songs carry their artwork offline.

New Features:
- Introduce ObservationBridge helper to provide continuous callbacks from @Observable models and bridge imperative observers.
- Add ArtworkMemoryCache to synchronously render cached artwork from SDWebImage in SwiftUI lists, bypassing placeholder frames.

Bug Fixes:
- Resolve multiple regressions from migrating to @Observable, including stalled lyrics updates, excessive home data fetches, and artwork backoff recursion that could hang tests.
- Eliminate unnecessary retrying of non-idempotent play-count API calls by adding an allowsRetry flag to KaraokeAPIClient.data(for:).
- Fix artwork fast-scroll behaviour so cached images render without mandatory grey placeholder frames and improve progressive preview visibility in small song rows.

Enhancements:
- Migrate numerous view models, managers, and SwiftUI views across iOS, watchOS, and tvOS from ObservableObject/@Published to @Observable, updating environment usage and bindings accordingly.
- Refine artwork prefetching with larger windows, separate warmCollection prefetcher, and SDWebImage cache tuning to reduce re-decodes and improve scrolling smoothness.
- Replace Combine-based observation pipelines (sinks, MergeMany, debounces) with @Observable-driven observation and custom debounced Task scheduling in search, CarPlay, queue, and other flows.
- Scope observation of internal state with @ObservationIgnored to avoid unnecessary view invalidations and to preserve thread-safety for nonisolated/locked fields.
- Improve download and cache flows by warming artwork for downloaded songs and exposing cache sizes through an @Observable CacheManager for UI consumers.

Build:
- No build or tooling changes were introduced beyond observation-related imports.

Tests:
- Adjust observation patterns and backoff behaviour to prevent test-suite hangs caused by recursive artwork failure backoff publishing.