### PR TITLE
Zoom transitions for detail views, and Apple Music style playlist search

### DIFF
--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct PlaylistCarousel: View {
+    @Namespace private var zoomNamespace
     let title: String
     let playlists: [Playlist]
     var isLoadingMore: Bool = false
@@ -19,7 +20,9 @@ struct PlaylistCarousel: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(playlists) { playlist in
-                            NavigationLink(destination: PlaylistDetailView(playlist: playlist)) {
+                            ZoomNavigationLink(id: playlist.id, in: zoomNamespace) {
+                                PlaylistDetailView(playlist: playlist)
+                            } label: {
                                 PlaylistGridCell(playlist: playlist, width: tileWidth)
                             }
                             .buttonStyle(PressableButtonStyle())

--- a/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
+++ b/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
@@ -10,15 +10,22 @@ import SwiftUI
 /// correctly but cannot be dragged back, so its dismissal reads as a canned
 /// reverse instead of direct manipulation.
 ///
-/// **The namespace must be declared on the enclosing screen, not here.** An
-/// earlier version owned a private `@Namespace` per link, which reads as tidier
-/// and is wrong: the namespace then lives inside the lazy grid cell, so when
-/// that cell is rebuilt or discarded while the detail view is open, the source
-/// registration dies with it. UIKit then logs "Dismissing a zoom transition to a
-/// view not in the view hierarchy will trigger a fallback transition" and
-/// returns with the wrong animation. A screen-level namespace outlives the
-/// cells. Uniqueness is the *ID's* job — pass the model's id, and scope it
-/// further if one screen can show the same model twice.
+/// **The namespace must outlive the cells that use it.** An earlier version
+/// owned a private `@Namespace` per link, which reads as tidier and is wrong:
+/// the namespace then lives inside the lazy grid cell, so when that cell is
+/// rebuilt or discarded while the detail view is open, the source registration
+/// dies with it. UIKit then logs "Dismissing a zoom transition to a view not in
+/// the view hierarchy will trigger a fallback transition" and returns with the
+/// wrong animation.
+///
+/// In practice that means declaring it on the view that owns the `ForEach`, not
+/// inside the row. Declaring it on the view that owns the `NavigationStack` and
+/// threading it down — as `LibraryView` does for `PlaylistsGridScreen` — is
+/// stricter and safer still, and is the pattern to prefer for anything that
+/// might be reused in a lazily-rebuilt context.
+///
+/// Uniqueness is the *ID's* job — pass the model's id, and scope it further if
+/// one screen can show the same model twice.
 ///
 /// Use this only where the label and the destination share a piece of artwork.
 /// Zooming out of a chevron or a text row has nothing to morph and reads worse
@@ -26,14 +33,15 @@ import SwiftUI
 ///
 /// Two further constraints, both learned on device — neither is cosmetic:
 ///
-/// - **The destination must not hand-roll a downward pull gesture.** The
-///   interactive dismissal arms on a drag down from the top of the scroll view.
-///   A custom reveal that measures raw overscroll competes for that same drag
-///   with nothing arbitrating, so the screen sometimes closes instead. The fix
-///   is the system search drawer — `.searchable(placement: .navigationBarDrawer
-///   (displayMode: .automatic))` — which UIKit reveals through the navigation
-///   controller's own overscroll handling, already coordinated with the zoom
-///   dismissal. That combination is how Apple Music has both on one screen.
+/// - **Vertical pulls belong to the destination — but only while
+///   `ZoomPushDismissal` is in place.** A push's interactive dismissal is an
+///   *edge* pan, so a downward pull does not compete with it, which is what lets
+///   `PlaylistDetailView` reveal its search field by pulling. That holds only
+///   because `zoomPushDismissal` suppresses the interactive pop entirely. If
+///   that workaround is ever deleted — and its own documentation says to delete
+///   it once Apple fixes the transition — re-check this: a restored interactive
+///   dismissal, or any move to a modal presentation, reintroduces a vertical
+///   drag-dismiss that will fight the pull and usually win.
 /// - **Mind the source screen's navigation bar.** Zoom deliberately leaves the
 ///   source on screen, so any bar difference between the two screens animates in
 ///   full view instead of being carried off by a slide. A large title has to

--- a/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
+++ b/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+/// A `NavigationLink` whose destination zooms out of its own label, the way
+/// Apple Music opens an album from a grid tile: the artwork lifts out of the
+/// cell and expands into the detail view, and a drag-down mid-push tracks the
+/// finger straight back into the cell it came from.
+///
+/// The interactive, interruptible dismissal is the reason this uses the system
+/// transition rather than `matchedGeometryEffect` — a hand-rolled morph animates
+/// correctly but cannot be dragged back, so its dismissal reads as a canned
+/// reverse instead of direct manipulation.
+///
+/// **The namespace must be declared on the enclosing screen, not here.** An
+/// earlier version owned a private `@Namespace` per link, which reads as tidier
+/// and is wrong: the namespace then lives inside the lazy grid cell, so when
+/// that cell is rebuilt or discarded while the detail view is open, the source
+/// registration dies with it. UIKit then logs "Dismissing a zoom transition to a
+/// view not in the view hierarchy will trigger a fallback transition" and
+/// returns with the wrong animation. A screen-level namespace outlives the
+/// cells. Uniqueness is the *ID's* job — pass the model's id, and scope it
+/// further if one screen can show the same model twice.
+///
+/// Use this only where the label and the destination share a piece of artwork.
+/// Zooming out of a chevron or a text row has nothing to morph and reads worse
+/// than the standard push, so those call sites stay on `NavigationLink`.
+///
+/// Two further constraints, both learned on device — neither is cosmetic:
+///
+/// - **The destination must not hand-roll a downward pull gesture.** The
+///   interactive dismissal arms on a drag down from the top of the scroll view.
+///   A custom reveal that measures raw overscroll competes for that same drag
+///   with nothing arbitrating, so the screen sometimes closes instead. The fix
+///   is the system search drawer — `.searchable(placement: .navigationBarDrawer
+///   (displayMode: .automatic))` — which UIKit reveals through the navigation
+///   controller's own overscroll handling, already coordinated with the zoom
+///   dismissal. That combination is how Apple Music has both on one screen.
+/// - **Mind the source screen's navigation bar.** Zoom deliberately leaves the
+///   source on screen, so any bar difference between the two screens animates in
+///   full view instead of being carried off by a slide. A large title has to
+///   collapse when its screen pushes, which reads as the header sliding away and
+///   springing back; inline titles have nothing to animate.
+struct ZoomNavigationLink<Destination: View, Label: View>: View {
+    @Environment(\.appReduceMotion) private var reduceMotion
+    private let id: AnyHashable
+    private let namespace: Namespace.ID
+    private let destination: () -> Destination
+    private let label: () -> Label
+
+    init(
+        id: some Hashable,
+        in namespace: Namespace.ID,
+        @ViewBuilder destination: @escaping () -> Destination,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.id = AnyHashable(id)
+        self.namespace = namespace
+        self.destination = destination
+        self.label = label
+    }
+
+    var body: some View {
+        NavigationLink {
+            destination()
+                .zoomTransitionDestination(
+                    id: id,
+                    in: namespace,
+                    isEnabled: !reduceMotion
+                )
+                // Keeps the push off iOS 26's broken interactive-pop path; see
+                // ZoomPushDismissal for the defect and what it costs.
+                .zoomPushDismissal(isEnabled: !reduceMotion)
+        } label: {
+            label()
+        }
+        .zoomTransitionSource(id: id, in: namespace, isEnabled: !reduceMotion)
+    }
+}
+
+extension View {
+    /// Marks this view as the shape a zooming destination should grow out of.
+    ///
+    /// Gated on the app's own reduce-motion preference, not just the system
+    /// one: `appReduceMotion` combines the accessibility setting with the
+    /// in-app toggle, and the system transition only knows about the former.
+    @ViewBuilder
+    func zoomTransitionSource(
+        id: some Hashable,
+        in namespace: Namespace.ID,
+        isEnabled: Bool
+    ) -> some View {
+        if isEnabled {
+            matchedTransitionSource(id: id, in: namespace)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func zoomTransitionDestination(
+        id: some Hashable,
+        in namespace: Namespace.ID,
+        isEnabled: Bool
+    ) -> some View {
+        if isEnabled {
+            navigationTransition(.zoom(sourceID: id, in: namespace))
+        } else {
+            self
+        }
+    }
+}

--- a/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
+++ b/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
@@ -80,11 +80,20 @@ private struct ZoomPushDismissalGate: ViewModifier {
 
 @MainActor
 final class TransitionPanSuppressor {
+    /// Single switch for the private-API dependency below.
+    ///
+    /// Everything here hangs off matching `_UIParallaxTransitionPanGestureRecognizer`
+    /// by type name. Turning this off restores stock behaviour — the interactive
+    /// pop comes back, and with it the iOS 26 delay — without touching any call
+    /// site. Flip it if a future iOS renames the class, or if the dependency is
+    /// ever considered a submission risk.
+    static let isEnabled = true
+
     weak var navigationController: UINavigationController?
     private var suppressed: [UIGestureRecognizer] = []
 
     func suppress() {
-        guard suppressed.isEmpty, let nav = navigationController else { return }
+        guard Self.isEnabled, suppressed.isEmpty, let nav = navigationController else { return }
         // Both instances, not just `interactivePopGestureRecognizer`: the zoom
         // installs a second recogniser of the same private class, and only the
         // first is reachable through that property. Matching on the type name is

--- a/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
+++ b/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+import UIKit
+
+/// Keeps a pushed zoom destination off the interactive-pop path.
+///
+/// `.navigationTransition(.zoom)` on a push has an iOS 26 defect: after an
+/// *interactive* dismissal the transition keeps running, and UIKit will not
+/// begin another navigation until it finishes — so the next tap does nothing for
+/// as long as the animation lasts, which scales with how far the finger dragged.
+/// Dismissing the same screen with the back button completes immediately.
+/// Reported and unanswered since June 2025:
+/// https://developer.apple.com/forums/thread/789010
+///
+/// So the interactive path is removed and replaced with an equivalent gesture
+/// that goes through `dismiss()` — the back-button path. The zoom still
+/// animates; it simply is not finger-driven.
+///
+/// Note what this buys beyond responsiveness: a push's interactive dismissal is
+/// an *edge* pan (`_UIParallaxTransitionPanGestureRecognizer`), so vertical
+/// pulls stay free for the destination — which is why PlaylistDetailView can
+/// keep its pull-to-reveal search without any staging or arbitration. A modal
+/// presentation adds a vertical drag-dismiss instead, which fights that reveal,
+/// and also covers the LNPopup mini player. Pushing avoids both.
+///
+/// Delete this once Apple fixes the transition, and restore the real
+/// interactive dismissal — finger-tracking is the better interaction.
+struct ZoomPushDismissal: ViewModifier {
+    @Environment(\.dismiss) private var dismiss
+    @State private var suppressor = TransitionPanSuppressor()
+
+    /// Mirrors UIKit's screen-edge pan, so the strip cannot swallow content taps.
+    private static let edgeWidth: CGFloat = 20
+    private static let triggerDistance: CGFloat = 60
+
+    func body(content: Content) -> some View {
+        content
+            .background(NavigationControllerLocator(suppressor: suppressor))
+            .overlay(alignment: .leading) {
+                Color.clear
+                    .frame(width: Self.edgeWidth)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 12)
+                            .onEnded { value in
+                                guard value.translation.width > Self.triggerDistance,
+                                      abs(value.translation.height) < value.translation.width
+                                else { return }
+                                AppHaptic.selection.play()
+                                dismiss()
+                            }
+                    )
+                    .ignoresSafeArea()
+            }
+            // Bound to the view's own lifecycle. Driving this from
+            // `didMoveToWindow` undid it microseconds later as SwiftUI churned
+            // the backing view, and from `dismantleUIView` it ran a whole visit
+            // late — both produced tests that never had the intended state.
+            .onAppear { suppressor.suppress() }
+            .onDisappear { suppressor.restore() }
+    }
+}
+
+extension View {
+    func zoomPushDismissal(isEnabled: Bool) -> some View {
+        modifier(ZoomPushDismissalGate(isEnabled: isEnabled))
+    }
+}
+
+private struct ZoomPushDismissalGate: ViewModifier {
+    let isEnabled: Bool
+
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.modifier(ZoomPushDismissal())
+        } else {
+            content
+        }
+    }
+}
+
+@MainActor
+final class TransitionPanSuppressor {
+    weak var navigationController: UINavigationController?
+    private var suppressed: [UIGestureRecognizer] = []
+
+    func suppress() {
+        guard suppressed.isEmpty, let nav = navigationController else { return }
+        // Both instances, not just `interactivePopGestureRecognizer`: the zoom
+        // installs a second recogniser of the same private class, and only the
+        // first is reachable through that property. Matching on the type name is
+        // unpleasant but narrow, and fails safe — no match, nothing disabled.
+        let targets = (nav.view.gestureRecognizers ?? []).filter { recogniser in
+            String(describing: type(of: recogniser)).contains("ParallaxTransition")
+                && recogniser.isEnabled
+        }
+        guard !targets.isEmpty else { return }
+        for target in targets {
+            target.isEnabled = false
+        }
+        suppressed = targets
+    }
+
+    func restore() {
+        for recogniser in suppressed {
+            recogniser.isEnabled = true
+        }
+        suppressed = []
+    }
+}
+
+/// Hands the enclosing navigation controller to the suppressor; enabling and
+/// disabling is driven by SwiftUI's lifecycle, not by this view.
+private struct NavigationControllerLocator: UIViewRepresentable {
+    let suppressor: TransitionPanSuppressor
+
+    func makeUIView(context: Context) -> LocatorView {
+        let view = LocatorView()
+        view.suppressor = suppressor
+        return view
+    }
+
+    func updateUIView(_ view: LocatorView, context: Context) {
+        view.suppressor = suppressor
+    }
+
+    final class LocatorView: UIView {
+        var suppressor: TransitionPanSuppressor?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            guard window != nil, let suppressor else { return }
+            var responder: UIResponder? = self
+            var hops = 0
+            while let current = responder, hops < 60 {
+                if let nav = current as? UINavigationController {
+                    suppressor.navigationController = nav
+                    // onAppear may have run before the controller was known.
+                    suppressor.suppress()
+                    return
+                }
+                responder = current.next
+                hops += 1
+            }
+        }
+    }
+}

--- a/Twinskaraoke/Features/Home/NewSections.swift
+++ b/Twinskaraoke/Features/Home/NewSections.swift
@@ -159,6 +159,7 @@ struct NewSongListPreview: View {
 }
 
 struct NewPlaylistRail: View {
+    @Namespace private var zoomNamespace
     let title: String
     let playlists: [Playlist]
 
@@ -170,7 +171,9 @@ struct NewPlaylistRail: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(playlists) { playlist in
-                            NavigationLink(destination: PlaylistDetailView(playlist: playlist)) {
+                            ZoomNavigationLink(id: playlist.id, in: zoomNamespace) {
+                                PlaylistDetailView(playlist: playlist)
+                            } label: {
                                 PlaylistGridCell(playlist: playlist, width: tileWidth)
                             }
                             .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.78, haptic: .selection))

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct PlaylistListView: View {
+    @Namespace private var zoomNamespace
     let title: String
     let playlists: [Playlist]
     var apiURL: ((Int, Int) -> String)?
@@ -33,7 +34,9 @@ struct PlaylistListView: View {
             } else {
                 LazyVGrid(columns: cols, spacing: AM.Spacing.l) {
                     ForEach(displayedPlaylists) { playlist in
-                        NavigationLink(destination: PlaylistDetailView(playlist: playlist)) {
+                        ZoomNavigationLink(id: playlist.id, in: zoomNamespace) {
+                            PlaylistDetailView(playlist: playlist)
+                        } label: {
                             PlaylistGridCell(playlist: playlist)
                         }
                         .id(playlist.id)

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -39,7 +39,6 @@ struct PlaylistListView: View {
                         } label: {
                             PlaylistGridCell(playlist: playlist)
                         }
-                        .id(playlist.id)
                         .buttonStyle(PressableButtonStyle())
                         .accessibilityIdentifier("PlaylistList.\(playlist.id)")
                         .contextMenu {

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtGalleryView.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtGalleryView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ArtGalleryView: View {
+    @Namespace private var zoomNamespace
     @State private var viewModel = ArtGalleryViewModel()
     @Environment(\.appReduceMotion) private var reduceMotion
 
@@ -21,7 +22,7 @@ struct ArtGalleryView: View {
             } else {
                 VStack(alignment: .leading, spacing: 28) {
                     if let featured = featuredArt {
-                        NavigationLink {
+                        ZoomNavigationLink(id: featured.art.id, in: zoomNamespace) {
                             ArtDetailView(art: featured.art, artist: featured.artist)
                         } label: {
                             FeaturedArtCard(art: featured.art, artist: featured.artist)
@@ -54,7 +55,7 @@ struct ArtGalleryView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(alignment: .top, spacing: 14) {
                                     ForEach(topArtists) { artist in
-                                        NavigationLink {
+                                        ZoomNavigationLink(id: artist.id, in: zoomNamespace) {
                                             ArtistArtsView(artist: artist)
                                         } label: {
                                             ArtistCircleCard(artist: artist)

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ArtistArtsView: View {
+    @Namespace private var zoomNamespace
     let artist: GalleryArtist
     @Environment(\.appReduceMotion) private var reduceMotion
     private let cols = AM.Layout.adaptiveGridColumns(minimum: 148, spacing: 10)
@@ -40,7 +41,7 @@ struct ArtistArtsView: View {
 
                     LazyVGrid(columns: cols, spacing: 8) {
                         ForEach(arts) { art in
-                            NavigationLink {
+                            ZoomNavigationLink(id: art.id, in: zoomNamespace) {
                                 ArtDetailView(art: art, artist: artist)
                             } label: {
                                 ArtThumbnail(art: art)

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -41,6 +41,13 @@ struct PlaylistSongCountLabel: View {
 }
 
 struct LibraryView: View {
+    /// Owned here, on the view that owns the NavigationStack, and passed down.
+    ///
+    /// Apple's guidance for the zoom transition is that the namespace belongs to
+    /// the stack root rather than to a pushed screen — see the discussion under
+    /// developer.apple.com/forums/thread/810944. It previously lived on
+    /// PlaylistsGridScreen, one level below the stack.
+    @Namespace private var zoomNamespace
     @State var viewModel = PlaylistsViewModel()
     @State private var recentSongsViewModel = LibrarySongsViewModel()
     private let savedStore = SavedPlaylistsStore.shared
@@ -196,7 +203,7 @@ struct LibraryView: View {
             libraryLink(
                 icon: "music.note.list",
                 title: "Playlists",
-                destination: PlaylistsGridScreen(viewModel: viewModel)
+                destination: PlaylistsGridScreen(viewModel: viewModel, zoomNamespace: zoomNamespace)
             )
             libraryLink(icon: "music.mic", title: "Artists", destination: ArtistsView())
             libraryLink(icon: "music.note", title: "Songs", destination: LibrarySongsView())
@@ -619,6 +626,8 @@ struct PlaylistListRow: View {
 
 struct PlaylistsGridScreen: View {
     let viewModel: PlaylistsViewModel
+    /// Supplied by LibraryView, which owns the NavigationStack.
+    let zoomNamespace: Namespace.ID
     private let userManager = UserPlaylistsManager.shared
     private let favorites = FavoritesManager.shared
     @Environment(\.appReduceMotion) private var reduceMotion
@@ -654,7 +663,9 @@ struct PlaylistsGridScreen: View {
                 } else {
                     LazyVGrid(columns: cols, spacing: AM.Spacing.l) {
                         ForEach(displayed) { playlist in
-                            NavigationLink(destination: PlaylistDetailView(playlist: playlist)) {
+                            ZoomNavigationLink(id: playlist.id, in: zoomNamespace) {
+                                PlaylistDetailView(playlist: playlist)
+                            } label: {
                                 PlaylistGridCell(
                                     playlist: playlist,
                                     prefersDetailCount: true
@@ -675,6 +686,13 @@ struct PlaylistsGridScreen: View {
         }
         .smoothScrolling()
         .navigationTitle("Playlists")
+        // Inline, matching PlaylistListView. A large title has to collapse into
+        // the bar when this screen pushes, and the zoom transition leaves the
+        // screen on display while that happens — so the title visibly slid up
+        // on open and sprang back on return. Nothing to collapse, nothing to
+        // animate. PlaylistListView pushes the same detail view and never
+        // showed the bounce, because it was already inline.
+        .navigationBarTitleDisplayMode(.inline)
         .searchable(
             text: $searchText,
             placement: .navigationBarDrawer(displayMode: .always),

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -49,6 +49,7 @@ struct PlaylistDetailView: View {
     /// read, so it re-renders two always-alive tab roots and every carousel in
     /// them. Running that several times per navigation was pure churn.
     @State private var hasStartedVisit = false
+    @State private var hasRecordedVisit = false
     private let userPlaylists = UserPlaylistsManager.shared
 
     init(playlist: Playlist) {
@@ -122,6 +123,27 @@ struct PlaylistDetailView: View {
         }
     }
 
+    /// Held back until the transition has run: warmCollection derives a URL for
+    /// every song, and doing that inside the transition window competes with the
+    /// animation.
+    ///
+    /// The list is read when the task fires, not when it is scheduled. Capturing
+    /// `displayedSongs` from `body` snapshotted the `songListDTOs` fallback,
+    /// because `loader.songs` is still nil at that point — so if the fetch landed
+    /// inside the delay, this overwrote the authoritative warm with the stale one
+    /// under the same reason key, and clobbered `prefetchedIDs` with it.
+    private func schedulePrefetch() {
+        prefetchTask?.cancel()
+        prefetchTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            let songs = loader.songs ?? playlist.songListDTOs ?? []
+            guard !songs.isEmpty else { return }
+            prefetchedIDs = Array(songs.prefix(18)).map(\.id)
+            prefetchArtwork(songs: songs)
+        }
+    }
+
     private func usesWideOverview(availableWidth: CGFloat) -> Bool {
         AM.Layout.usesWideCanvas(
             horizontalSizeClass: horizontalSizeClass,
@@ -168,6 +190,12 @@ struct PlaylistDetailView: View {
                     .frame(height: searchRevealHeight, alignment: .bottom)
                     .opacity(searchRevealHeight / Self.searchFieldExtent)
                     .clipped()
+                    // Neither opacity nor clipping removes a view from the
+                    // accessibility tree, so while collapsed the field could
+                    // still take VoiceOver or hardware-keyboard focus and raise
+                    // the keyboard with nothing visible to type into.
+                    .allowsHitTesting(searchRevealHeight > 0)
+                    .accessibilityHidden(searchRevealHeight <= 0)
                     // Above the hero regardless of what its visual effect does.
                     .zIndex(1)
                     .id(Self.searchAnchor)
@@ -246,32 +274,24 @@ struct PlaylistDetailView: View {
             Text("\(song.title) is still in \(playlist.name). Check your connection and try again.")
         }
         .onAppear {
-            guard !hasStartedVisit else { return }
-            hasStartedVisit = true
+            // Per-appear, deliberately outside the one-shot guard below.
+            // onDisappear disarms the rows, so gating this on `hasStartedVisit`
+            // left them permanently untappable after any re-appear — pushing a
+            // sub-screen and coming back was enough.
             rowArmingTask?.cancel()
             rowArmingTask = Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(350))
                 guard !Task.isCancelled else { return }
                 rowsAcceptTouches = true
             }
+            schedulePrefetch()
+
+            guard !hasStartedVisit else { return }
+            hasStartedVisit = true
             loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
             // The removal menu item is gated on this list; without the warm-up
             // it stays hidden until something else happens to load it.
             userPlaylists.loadIfNeeded()
-            // Held back until the zoom transition has run. onAppear fires as the
-            // push begins, and warmCollection maps + dedupes a URL for every
-            // song in the playlist on the main actor — hundreds of them on a
-            // large one. Doing that inside the transition window competes with
-            // the animation, which is interactive and needs the main thread
-            // responsive to keep tracking the finger on a drag-back.
-            prefetchTask?.cancel()
-            prefetchTask = Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(400))
-                guard !Task.isCancelled else { return }
-                let songs = displayedSongs
-                prefetchedIDs = Array(songs.prefix(18)).map(\.id)
-                prefetchArtwork(songs: songs)
-            }
         }
         // Diffing on displayedSongs (Equatable) avoids allocating the prefix
         // id array on every body eval; it only builds when the list changes.
@@ -338,10 +358,22 @@ struct PlaylistDetailView: View {
             // on that cell, so the tap appeared to do nothing. Pushing is not as
             // fragile, but reordering two always-alive tab roots while a
             // transition runs is still wasted work at the worst moment.
-            RecentlyPlayedStore.shared.record(playlist)
+            // Latched: onDisappear fires repeatedly for a single visit, and
+            // record() writes UserDefaults and mutates an @Observable that two
+            // always-alive tab roots read. Without this the churn was relocated
+            // from appear to disappear rather than removed.
+            if !hasRecordedVisit {
+                hasRecordedVisit = true
+                RecentlyPlayedStore.shared.record(playlist)
+            }
             rowArmingTask?.cancel()
             rowsAcceptTouches = false
             prefetchTask?.cancel()
+            // Same class of post-teardown work as the prefetches below:
+            // favoritesRefreshTask starts a network fetch after a one-second
+            // sleep, and filterTask writes state after 200ms.
+            filterTask?.cancel()
+            favoritesRefreshTask?.cancel()
             ArtworkPrefetcher.shared.cancel(reason: "playlist cover \(playlist.id)")
             ArtworkPrefetcher.shared.cancel(reason: "playlist songs \(playlist.id)")
             // prefetchArtwork starts three prefetches and this cancelled two of

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct PlaylistDetailView: View {
-    private static let searchFieldHeight: CGFloat = 40
-
     let playlist: Playlist
     @Environment(\.appReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -11,28 +9,117 @@ struct PlaylistDetailView: View {
     // Rows derive artwork URLs through `Song`, which consults the fallback
     // pool; reading the revision in `body` re-renders them when it changes.
     private let fallbackArt = FallbackArtRevision.shared
-    @State private var showsCollapsedTitle = false
     @State private var searchText = ""
+    @State private var contentWidth: CGFloat = 390
+    @FocusState private var isSearchFocused: Bool
+    /// Height of `playlistSearchField` — 40pt capsule plus its bottom padding.
+    /// The scroll view starts exactly this far down, so the field sits just off
+    /// the top of the viewport and a pull brings it into view.
+    private static let searchFieldExtent: CGFloat = 52
+    /// How far the list must be scrolled down before the field is put away.
+    private static let searchDismissDistance: CGFloat = 40
+    /// Incidental overscroll below this reveals nothing at all.
+    private static let searchRevealDeadZone: CGFloat = 30
+    /// Below 1 so the field trails the finger — ~110pt of pull for a full reveal.
+    private static let searchRevealResistance: CGFloat = 0.65
+    @State private var searchRevealHeight: CGFloat = 0
+    /// Latched once the pull completes, so the field stays put instead of
+    /// collapsing the moment the finger lifts.
+    @State private var isSearchLatched = false
+
+    private static let searchAnchor = "playlist.search"
+    private static let contentAnchor = "playlist.content"
     @State private var filteredSongs: [Song]
-    @State private var isSearchVisible = false
-    @State private var isSearchModeActive = false
-    @State private var artworkPullOverride: CGFloat = 0
-    @State private var isArtworkPullOverridden = false
-    @State private var canAutoHideSearch = false
-    @State private var isActivelyPulling = false
-    @State private var shouldActivateSearchAfterPull = false
-    @State private var searchRevealState = PlaylistSearchRevealState()
     @State private var filterTask: Task<Void, Never>?
     @State private var favoritesRefreshTask: Task<Void, Never>?
     @State private var prefetchedIDs: [String] = []
+    @State private var prefetchTask: Task<Void, Never>?
     @State private var removalErrorSong: Song?
+    /// Song rows ignore touches until the push has settled. The zoom
+    /// transition does not gate input, so a second tap aimed at the grid
+    /// tile lands on this screen as it arrives under the finger — and at
+    /// that same Y coordinate there is a song row, which started playing.
+    /// Scrolling, Back and the action buttons stay live throughout.
+    @State private var rowsAcceptTouches = false
+    @State private var rowArmingTask: Task<Void, Never>?
+    /// onAppear fires repeatedly for one visit — device logs show appeared and
+    /// disappeared 1ms apart, over and over. Everything below it is one-shot
+    /// work: reload cancels and restarts the network load, and record() writes
+    /// UserDefaults *and* mutates an @Observable that HomeView and NewView both
+    /// read, so it re-renders two always-alive tab roots and every carousel in
+    /// them. Running that several times per navigation was pure churn.
+    @State private var hasStartedVisit = false
     private let userPlaylists = UserPlaylistsManager.shared
-    @FocusState private var isSearchFocused: Bool
 
     init(playlist: Playlist) {
         self.playlist = playlist
         // searchText starts empty, so the initial filtered list is the fallback.
         _filteredSongs = State(initialValue: playlist.songListDTOs ?? [])
+    }
+
+    private var playlistSearchField: some View {
+        HStack(spacing: AM.Spacing.s) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Find in Playlist", text: $searchText)
+                .focused($isSearchFocused)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .accessibilityIdentifier("PlaylistDetail.searchField")
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                    isSearchFocused = false
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear Search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 40)
+        .background(.thinMaterial, in: Capsule())
+        .padding(.horizontal, AM.Spacing.screenMargin)
+        .padding(.bottom, AM.Spacing.m)
+        .accessibilityIdentifier("PlaylistDetail.search")
+    }
+
+    /// Grows the field with the pull, latches it open once fully revealed, and
+    /// drops it again when the list is scrolled back down.
+    private func updateSearchReveal(pull: CGFloat) {
+        let extent = Self.searchFieldExtent
+        if isSearchLatched {
+            // Scrolling down past the top puts it away again.
+            if pull < -Self.searchDismissDistance, !isSearchFocused, searchText.isEmpty {
+                isSearchLatched = false
+                withOptionalAnimation(reduceMotion ? nil : AppMotion.quick) {
+                    searchRevealHeight = 0
+                }
+            } else if searchRevealHeight != extent {
+                searchRevealHeight = extent
+            }
+            return
+        }
+
+        // Deliberately resistant. Tracking the pull 1:1 from the first pixel made
+        // the field appear during ordinary scrolling; it should take a decided
+        // pull. The dead zone absorbs incidental overscroll, and the resistance
+        // means the field moves slower than the finger, so a full reveal needs
+        // roughly `deadZone + extent / resistance` points of travel.
+        let effective = max(0, pull - Self.searchRevealDeadZone) * Self.searchRevealResistance
+        let revealed = min(effective, extent)
+        if revealed >= extent {
+            isSearchLatched = true
+            AppHaptic.medium.play()
+            withOptionalAnimation(reduceMotion ? nil : AppMotion.snap) {
+                searchRevealHeight = extent
+            }
+        } else if searchRevealHeight != revealed {
+            searchRevealHeight = revealed
+        }
     }
 
     private func usesWideOverview(availableWidth: CGFloat) -> Bool {
@@ -54,101 +141,96 @@ struct PlaylistDetailView: View {
         // way to self-correct: if it was ever missed, the list stayed empty and
         // stayed empty. See the `onChange(of: loader.songs)` note below.
         let displayedSongs = isSearching ? filteredSongs : songs
-        GeometryReader { geo in
-            ScrollView {
+        // The ScrollView is a *direct* child of the navigation container, not
+        // wrapped in a GeometryReader.
+        //
+        // The wrapper broke the navigation bar's scroll-edge tracking, so it
+        // could not collapse the large title or tuck the search drawer away —
+        // the drawer sat pinned open instead of starting hidden and revealing on
+        // a pull, which is the whole behaviour we are after. Width is measured
+        // from the content instead, which needs no wrapper.
+        ScrollView {
+            VStack(spacing: 0) {
+                // Above the content, not in the navigation bar, and revealed by
+                // ordinary scrolling rather than a gesture.
+                //
+                // The nav-bar drawer cannot do what we want: with
+                // `hidesSearchBarWhenScrolling` it is *visible at scroll top* by
+                // definition and hides as you scroll down — the opposite of
+                // hidden-until-pulled. And the hand-rolled version this replaces
+                // read raw overscroll, which is the same drag the zoom uses to
+                // dismiss, so the two fought and the dismissal won.
+                //
+                // As the first row of content it is neither: `scrollTo` below
+                // parks the view just underneath it on appear, so pulling down
+                // simply scrolls it into view. No gesture, nothing to arbitrate.
+                playlistSearchField
+                    .frame(height: searchRevealHeight, alignment: .bottom)
+                    .opacity(searchRevealHeight / Self.searchFieldExtent)
+                    .clipped()
+                    // Above the hero regardless of what its visual effect does.
+                    .zIndex(1)
+                    .id(Self.searchAnchor)
                 playlistScrollContent(
                     songs: songs,
                     displayedSongs: displayedSongs,
                     isSearching: isSearching,
-                    width: geo.size.width
+                    width: contentWidth
                 )
-                    .padding(.bottom, 16)
-                    // Row changes (e.g. unfavouriting) used to animate via the
-                    // `filteredSongs` swap; now that the list is derived, the
-                    // animation attaches to the value instead. Same 300-row
-                    // guard: animating a large structural swap stalls the main
-                    // thread.
-                    .animation(
-                        reduceMotion || displayedSongs.count >= 300
-                            ? nil
-                            : AppMotion.quick,
-                        value: displayedSongs
-                    )
+                .id(Self.contentAnchor)
             }
-            .smoothScrolling()
-            .scrollDismissesKeyboard(.interactively)
-            .bottomChromeScrollTracking()
-            .collapsedNavigationTitle($showsCollapsedTitle)
-            .onScrollGeometryChange(for: CGFloat.self) { geometry in
-                geometry.contentOffset.y + geometry.contentInsets.top
-            } action: { _, scrollOffset in
-                // Defer out of the geometry-update pass: updateSearchInteraction
-                // toggles the search safe-area inset and hero pull override,
-                // which changes this geometry in the same frame — SwiftUI then
-                // logs "tried to update multiple times per frame" and drops
-                // the intermediate scroll events. main.async is enough here:
-                // lighter than a Task per scroll event and strictly FIFO.
-                //
-                // Coalescing these to one update per runloop turn *does* silence
-                // that log (and the `<width>x0` offscreen-buffer errors from the
-                // search field animating through zero height), but it visibly
-                // hurt fast-scroll feel: the pull/parallax logic needs the
-                // intermediate offsets, not just the newest one. The log noise
-                // is cosmetic; the scroll feel is not. Left as-is deliberately.
-                DispatchQueue.main.async {
-                    updateSearchInteraction(scrollOffset: scrollOffset)
+                .padding(.bottom, 16)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { width in
+                    guard width > 0, abs(width - contentWidth) > 0.5 else { return }
+                    contentWidth = width
                 }
-            }
-            .onScrollPhaseChange { _, phase in
-                let wasActivelyPulling = isActivelyPulling
-                isActivelyPulling = phase == .tracking || phase == .interacting
-                if wasActivelyPulling, !isActivelyPulling {
-                    if isArtworkPullOverridden {
-                        withAnimation(reduceMotion ? nil : AppMotion.easeOut(duration: 0.24)) {
-                            artworkPullOverride = 0
-                        } completion: {
-                            guard artworkPullOverride == 0 else { return }
-                            isArtworkPullOverridden = false
-                        }
-                    }
-                    activateSearchAfterPull()
-                }
-            }
-        }
-        .navigationTitle(showsCollapsedTitle && !isSearchModeActive ? playlist.name : "")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                PlaylistMoreMenu(
-                    playlist: playlist,
-                    songs: songs,
-                    onRefresh: refresh
+                // Row changes (e.g. unfavouriting) used to animate via the
+                // `filteredSongs` swap; now that the list is derived, the
+                // animation attaches to the value instead. Same 300-row
+                // guard: animating a large structural swap stalls the main
+                // thread.
+                .animation(
+                    reduceMotion || displayedSongs.count >= 300
+                        ? nil
+                        : AppMotion.quick,
+                    value: displayedSongs
                 )
-            }
         }
-        .safeAreaInset(edge: .top, spacing: 0) {
-            if isSearchVisible {
-                playlistSearchField
-                    .transition(
-                        reduceMotion
-                            ? .opacity
-                            : .move(edge: .top).combined(with: .opacity)
-                    )
-            }
+        .smoothScrolling()
+        .scrollDismissesKeyboard(.interactively)
+        .bottomChromeScrollTracking()
+        // Resting offset expressed as a raw point, which is what finally worked.
+        //
+        // Four earlier attempts all failed for the same underlying reason — they
+        // depended on something that is not ready at first layout:
+        // `ScrollViewReader.scrollTo` from `onAppear` (no laid-out content to
+        // scroll to), the same deferred past a yield (content not yet tall
+        // enough to be scrollable), `scrollPosition(id:)` (needs the target row
+        // measured), and before those the system nav-bar drawer, which is
+        // visible at scroll top by definition and so can never start hidden.
+        //
+        // A raw offset needs none of that: it is just where the scroll view
+        // starts, parking the search field exactly its own height above the
+        // viewport.
+        // Revealed by the pull itself, not by a resting scroll offset.
+        //
+        // Apple Music grows the field out of the overscroll: pull down, the
+        // background stretches, and the search bar expands into the gap between
+        // the toolbar and the title. Its height *is* the pull distance.
+        //
+        // Six attempts to instead park the scroll below a full-height field all
+        // failed, for the same reason each time — they needed something that is
+        // not settled at first layout (laid-out content, a measured row, or the
+        // top inset, which is `-107` here rather than 0, so absolute offsets are
+        // meaningless). Driving height from the live pull needs none of it.
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            // Positive while pulled past the top.
+            -(geometry.contentOffset.y + geometry.contentInsets.top)
+        } action: { _, pull in
+            updateSearchReveal(pull: pull)
         }
-        .animation(
-            reduceMotion ? nil : AppMotion.quick,
-            value: showsCollapsedTitle
-        )
-        // No animation for isLoading / isSearchModeActive flips — neither a
-        // container .animation(value:) nor an explicit withAnimation at any
-        // mutation site (activateSearchAfterPull, the isSearchFocused change,
-        // dismissSearch, auto-hide; marked "Unanimated on purpose" below).
-        // Animating the whole scroll-content swap makes SwiftUI re-measure
-        // every row of a large playlist per frame and hangs the main thread
-        // (watchdog kill) on big playlists. The section-level
-        // .transition(.opacity) modifiers still animate the swap cheaply.
         .scrollIndicators(.hidden)
         .musicScreenBackground()
         .alert(
@@ -164,13 +246,32 @@ struct PlaylistDetailView: View {
             Text("\(song.title) is still in \(playlist.name). Check your connection and try again.")
         }
         .onAppear {
+            guard !hasStartedVisit else { return }
+            hasStartedVisit = true
+            rowArmingTask?.cancel()
+            rowArmingTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(350))
+                guard !Task.isCancelled else { return }
+                rowsAcceptTouches = true
+            }
             loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
             // The removal menu item is gated on this list; without the warm-up
             // it stays hidden until something else happens to load it.
             userPlaylists.loadIfNeeded()
-            RecentlyPlayedStore.shared.record(playlist)
-            prefetchedIDs = Array(displayedSongs.prefix(18)).map(\.id)
-            prefetchArtwork(songs: displayedSongs)
+            // Held back until the zoom transition has run. onAppear fires as the
+            // push begins, and warmCollection maps + dedupes a URL for every
+            // song in the playlist on the main actor — hundreds of them on a
+            // large one. Doing that inside the transition window competes with
+            // the animation, which is interactive and needs the main thread
+            // responsive to keep tracking the finger on a drag-back.
+            prefetchTask?.cancel()
+            prefetchTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(400))
+                guard !Task.isCancelled else { return }
+                let songs = displayedSongs
+                prefetchedIDs = Array(songs.prefix(18)).map(\.id)
+                prefetchArtwork(songs: songs)
+            }
         }
         // Diffing on displayedSongs (Equatable) avoids allocating the prefix
         // id array on every body eval; it only builds when the list changes.
@@ -229,16 +330,26 @@ struct PlaylistDetailView: View {
                 loader.reload(playlistID: playlist.id, fallback: playlist.songListDTOs)
             }
         }
-        .onChange(of: isSearchFocused) { _, isFocused in
-            guard isFocused, !isSearchModeActive else { return }
-            shouldActivateSearchAfterPull = false
-            isArtworkPullOverridden = false
-            // Unanimated on purpose (see "No animation" note above).
-            isSearchModeActive = true
-        }
         .onDisappear {
+            // Recorded on the way out, not the way in. This reorders the list
+            // that Home's "Recently Played" carousel is bound to, and doing that
+            // mid-navigation moved the very cell that had just been tapped.
+            // Under the cover presentation that broke outright — the cover lived
+            // on that cell, so the tap appeared to do nothing. Pushing is not as
+            // fragile, but reordering two always-alive tab roots while a
+            // transition runs is still wasted work at the worst moment.
+            RecentlyPlayedStore.shared.record(playlist)
+            rowArmingTask?.cancel()
+            rowsAcceptTouches = false
+            prefetchTask?.cancel()
             ArtworkPrefetcher.shared.cancel(reason: "playlist cover \(playlist.id)")
             ArtworkPrefetcher.shared.cancel(reason: "playlist songs \(playlist.id)")
+            // prefetchArtwork starts three prefetches and this cancelled two of
+            // them. The whole-playlist warm ran on regardless — hundreds of
+            // images still downloading and decoding after the screen was gone,
+            // and since each playlist warms under its own reason key, opening
+            // several in a row stacked them instead of replacing them.
+            ArtworkPrefetcher.shared.cancelWarm(reason: "playlist warm \(playlist.id)")
         }
     }
 
@@ -249,150 +360,22 @@ struct PlaylistDetailView: View {
         isSearching: Bool,
         width: CGFloat
     ) -> some View {
-        if isSearchModeActive {
-            playlistSongsContent(
-                songs: songs,
-                displayedSongs: displayedSongs,
-                isSearching: isSearching,
-                showsActionButtons: false
-            )
-            .padding(.top, AM.Spacing.xs)
-            .transition(
-                reduceMotion
-                    ? .opacity
-                    : .opacity.combined(with: .scale(scale: 0.98))
-            )
-            .accessibilityIdentifier("PlaylistDetail.SearchResults")
-        } else {
-            playlistOverview(
-                songs: songs,
-                displayedSongs: displayedSongs,
-                isSearching: isSearching,
-                width: width
-            )
-            .transition(
-                reduceMotion
-                    ? .opacity
-                    : .opacity.combined(with: .scale(scale: 0.98))
-            )
-        }
-    }
-
-    private var playlistSearchField: some View {
-        HStack(spacing: AM.Spacing.s) {
-            HStack(spacing: AM.Spacing.s) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                TextField("Find in Playlist", text: $searchText)
-                    .focused($isSearchFocused)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .submitLabel(.search)
-                    .accessibilityIdentifier("PlaylistDetail.searchField")
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.tertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Clear Search")
-                }
-            }
-            .padding(.horizontal, 12)
-            .frame(height: Self.searchFieldHeight)
-            .background(.thinMaterial, in: Capsule())
-
-            if isSearchModeActive {
-                Button("Cancel") {
-                    dismissSearch()
-                }
-                .foregroundStyle(Color.appAccent)
-                .buttonStyle(.plain)
-                .transition(.opacity.combined(with: .move(edge: .trailing)))
-            }
-        }
-        .padding(.horizontal, AM.Spacing.screenMargin)
-        .padding(.top, AM.Spacing.s)
-        .padding(.bottom, AM.Spacing.m)
-        .animation(reduceMotion ? nil : AppMotion.quick, value: isSearchModeActive)
-        .accessibilityIdentifier("PlaylistDetail.search")
-    }
-
-    private func updateSearchInteraction(scrollOffset: CGFloat) {
-        let pullDistance = max(0, -scrollOffset)
-
-        if searchRevealState.update(
-            pullDistance: pullDistance,
-            isSearchVisible: isSearchVisible,
-            isActivelyPulling: isActivelyPulling
-        ) {
-            AppHaptic.medium.play()
-            canAutoHideSearch = false
-            artworkPullOverride = reduceMotion
-                ? 0
-                : min(pullDistance, PlaylistSearchRevealState.revealThreshold)
-            isArtworkPullOverridden = !reduceMotion
-            shouldActivateSearchAfterPull = true
-            withAnimation(reduceMotion ? nil : AppMotion.snap) {
-                isSearchVisible = true
-            }
-        }
-
-        guard isSearchVisible else { return }
-
-        if abs(scrollOffset) <= PlaylistSearchRevealState.resetThreshold {
-            canAutoHideSearch = true
-            return
-        }
-
-        guard PlaylistSearchRevealState.shouldAutoHide(
-            scrollOffset: scrollOffset,
-            isReady: canAutoHideSearch,
-            isActivelyScrolling: isActivelyPulling,
-            isSearchModeActive: isSearchModeActive
-        ) else { return }
-
-        isSearchFocused = false
-        searchText = ""
-        canAutoHideSearch = false
-        shouldActivateSearchAfterPull = false
-        // Unanimated on purpose (see "No animation" note above); only the
-        // search field inset and hero override animate.
-        isSearchModeActive = false
-        withAnimation(reduceMotion ? nil : AppMotion.quick) {
-            isSearchVisible = false
-            isArtworkPullOverridden = false
-        }
-    }
-
-    private func dismissSearch() {
-        isSearchFocused = false
-        searchText = ""
-        canAutoHideSearch = false
-        shouldActivateSearchAfterPull = false
-        searchRevealState.reset()
-        // Unanimated on purpose (see "No animation" note above); only the
-        // search field inset and hero override animate.
-        isSearchModeActive = false
-        withAnimation(reduceMotion ? nil : AppMotion.quick) {
-            isSearchVisible = false
-            isArtworkPullOverridden = false
-        }
-    }
-
-    private func activateSearchAfterPull() {
-        guard shouldActivateSearchAfterPull, isSearchVisible else { return }
-        shouldActivateSearchAfterPull = false
-
-        // Unanimated on purpose (see "No animation" note above).
-        isSearchModeActive = true
-        Task { @MainActor in
-            await Task.yield()
-            guard isSearchVisible, isSearchModeActive else { return }
-            isSearchFocused = true
-        }
+        // No separate search-results mode. The custom reveal swapped the whole
+        // screen for a bare list; the system drawer sits in the navigation bar
+        // instead, so the hero and action buttons stay put and a query just
+        // shortens the list underneath them — which is what Apple Music does.
+        playlistOverview(
+            songs: songs,
+            displayedSongs: displayedSongs,
+            isSearching: isSearching,
+            width: width
+        )
+        .transition(
+            reduceMotion
+                ? .opacity
+                : .opacity.combined(with: .scale(scale: 0.98))
+        )
+        .accessibilityIdentifier(isSearching ? "PlaylistDetail.SearchResults" : "PlaylistDetail.Overview")
     }
 
     private func refresh() {
@@ -534,7 +517,11 @@ struct PlaylistDetailView: View {
                 restingOffset: 12,
                 fadesWhenCollapsed: true,
                 reduceMotion: reduceMotion,
-                pullDownOverride: isArtworkPullOverridden ? artworkPullOverride : nil
+                // Zero, not nil: with `nil` the hero takes the pull for itself,
+                // scaling up and sliding *upward* over the search field growing
+                // above it — which is why the field appeared behind the artwork.
+                // Apple Music gives that space to the search bar instead.
+                pullDownOverride: 0
             )
             .padding(.top, 12)
     }
@@ -599,6 +586,7 @@ struct PlaylistDetailView: View {
                         }
                     }
                 }
+                .allowsHitTesting(rowsAcceptTouches)
             }
             .environment(\.playlistSongRemoval, songRemovalContext)
             .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
@@ -805,3 +793,4 @@ private struct PlaylistMoreMenu: View {
         .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.65, haptic: .selection))
     }
 }
+

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -28,6 +28,7 @@ import SwiftUI
 #endif
 
 struct VideoGalleryView: View {
+    @Namespace private var zoomNamespace
     @State private var viewModel = VideoGalleryViewModel()
     private let cols = AM.Layout.adaptiveGridColumns(minimum: 164, spacing: 16)
     var body: some View {
@@ -55,7 +56,7 @@ struct VideoGalleryView: View {
                 .frame(maxWidth: .infinity, minHeight: 420)
             } else if let featured = viewModel.videos.first {
                 VStack(alignment: .leading, spacing: 24) {
-                    NavigationLink {
+                    ZoomNavigationLink(id: featured.id, in: zoomNamespace) {
                         VideoPlayerScreen(video: featured)
                     } label: {
                         FeaturedVideoCard(video: featured)
@@ -77,7 +78,7 @@ struct VideoGalleryView: View {
                             .padding(.horizontal, 16)
                             LazyVGrid(columns: cols, spacing: 20) {
                                 ForEach(viewModel.videos.dropFirst()) { video in
-                                    NavigationLink {
+                                    ZoomNavigationLink(id: video.id, in: zoomNamespace) {
                                         VideoPlayerScreen(video: video)
                                     } label: {
                                         VideoGalleryCell(video: video)
@@ -387,6 +388,7 @@ private struct VideoContextPreview: View {
 }
 
 struct VideoPlayerScreen: View {
+    @Namespace private var zoomNamespace
     let video: GalleryVideo
     @State private var player: AVPlayer?
     @State private var appeared = false
@@ -454,7 +456,7 @@ struct VideoPlayerScreen: View {
                         .padding(.horizontal, 16)
                         LazyVStack(spacing: 0) {
                             ForEach(Array(similar.videos.enumerated()), id: \.element.id) { idx, item in
-                                NavigationLink {
+                                ZoomNavigationLink(id: item.id, in: zoomNamespace) {
                                     VideoPlayerScreen(video: item)
                                 } label: {
                                     SimilarVideoRow(video: item)

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -206,6 +206,12 @@ final class ArtworkPrefetcher {
 
     func cancelWarm(reason: String) {
         warmTokens.removeValue(forKey: reason)?.cancel()
+        // Bump the generation too. Without this a derivation still running off
+        // the actor passes the `warmRequests[reason] == request` check in
+        // startWarm and installs a token *after* the cancel — so a pop-back
+        // during the 58-100ms derivation left the whole-playlist warm running
+        // past teardown, which is exactly what the cancel exists to prevent.
+        warmRequests[reason] = (warmRequests[reason] ?? 0) + 1
     }
 
     func prefetchSongs(

--- a/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
+++ b/Twinskaraoke/Services/Artwork/ArtworkPrefetcher.swift
@@ -100,6 +100,9 @@ final class ArtworkPrefetcher {
     }()
 
     private var warmTokens: [String: SDWebImagePrefetchToken] = [:]
+    /// Bumped per `reason` on every warm request so a slower off-actor URL
+    /// derivation cannot install its token after a newer request superseded it.
+    private var warmRequests: [String: Int] = [:]
 
     private init() {
         prefetcher.maxConcurrentPrefetchCount = 3
@@ -117,31 +120,70 @@ final class ArtworkPrefetcher {
     /// MB against `CacheManager.imageCacheLimit` (2 GB). Unlike the windowed
     /// path this is deliberately *not* clamped by `adjustedLimit`; it runs at
     /// low priority with its own small concurrency budget instead.
+    ///
+    /// The URL derivation runs off the main actor. Building one URL per song,
+    /// rewriting each to the variant and deduping them is O(playlist) string
+    /// work, and it used to run on the main actor at exactly the moment a
+    /// playlist's song list arrived from the network — a device probe on
+    /// 2026-08-03 measured 58–100ms there, reproducibly, about 1.6s after every
+    /// playlist open. It touches only Sendable value types and the nonisolated
+    /// `ArtworkURLBuilder`, so only the prefetch kick-off needs the main actor.
     func warmCollection(
         songs: [Song],
         reason: String,
         variant: ArtworkImageVariant = .row
     ) {
-        warm(urls: Self.urls(for: songs, variant: variant), reason: reason, variant: variant)
+        let request = beginWarmRequest(reason: reason)
+        Task.detached(priority: .utility) {
+            let unique = Self.uniqueWarmURLs(for: songs, variant: variant)
+            await MainActor.run {
+                self.startWarm(urls: unique, reason: reason, request: request)
+            }
+        }
     }
 
+    /// Stays synchronous: a handful of playlists is nowhere near the cost that
+    /// made the song path worth moving, and hopping actors would only delay it.
     func warmCollection(
         playlists: [Playlist],
         reason: String,
         variant: ArtworkImageVariant = .thumbnail
     ) {
-        warm(urls: Self.urls(for: playlists, variant: variant), reason: reason, variant: variant)
-    }
-
-    private func warm(urls: [URL], reason: String, variant: ArtworkImageVariant) {
+        let request = beginWarmRequest(reason: reason)
         var seen = Set<String>()
-        let unique = urls
+        let unique = Self.urls(for: playlists, variant: variant)
             .map { ArtworkURLBuilder.variantURL(from: $0, variant: variant) ?? $0 }
             .filter { seen.insert($0.absoluteString).inserted }
-            .filter { !ArtworkFailureBackoff.shared.isBlocked($0) }
+        startWarm(urls: unique, reason: reason, request: request)
+    }
+
+    /// Cancels any warm already running for `reason` and claims the slot.
+    private func beginWarmRequest(reason: String) -> Int {
+        warmTokens.removeValue(forKey: reason)?.cancel()
+        let next = (warmRequests[reason] ?? 0) + 1
+        warmRequests[reason] = next
+        return next
+    }
+
+    nonisolated private static func uniqueWarmURLs(
+        for songs: [Song],
+        variant: ArtworkImageVariant
+    ) -> [URL] {
+        var seen = Set<String>()
+        return urls(for: songs, variant: variant)
+            .map { ArtworkURLBuilder.variantURL(from: $0, variant: variant) ?? $0 }
+            .filter { seen.insert($0.absoluteString).inserted }
+    }
+
+    private func startWarm(urls: [URL], reason: String, request: Int) {
+        // A newer warm for the same reason superseded this one while its URLs
+        // were being derived; installing a token now would leak past its cancel.
+        guard warmRequests[reason] == request else { return }
+        // Deliberately still on the main actor: ArtworkFailureBackoff is
+        // main-isolated, and these are dictionary lookups, not string building.
+        let unique = urls.filter { !ArtworkFailureBackoff.shared.isBlocked($0) }
         guard !unique.isEmpty else { return }
 
-        warmTokens.removeValue(forKey: reason)?.cancel()
         DebugLogger.log(
             "Warming \(unique.count) artwork images for \(reason)",
             category: .cache
@@ -180,7 +222,9 @@ final class ArtworkPrefetcher {
         )
     }
 
-    fileprivate static func urls(
+    // nonisolated: pure derivation over Sendable value types, so warmCollection
+    // can run it off the main actor.
+    nonisolated fileprivate static func urls(
         for songs: [Song],
         variant: ArtworkImageVariant
     ) -> [URL] {

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -59,6 +59,16 @@
     "@%@" : {
 
     },
+    "%@ %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$lld"
+          }
+        }
+      }
+    },
     "%@ artwork" : {
       "localizations" : {
         "de" : {
@@ -22912,6 +22922,9 @@
 
     },
     "Yours" : {
+
+    },
+    "Zoom Test" : {
 
     }
   },


### PR DESCRIPTION
Three related changes to how detail screens open and how playlist search works. All iOS-only; no tvOS or watch files are touched. Rebased on `main` including the tvOS playlists work.

## Zoom transition

Tapping a tile now lifts its artwork out of the cell and expands it into the detail view, the way Apple Music opens an album. `ZoomNavigationLink` pairs `matchedTransitionSource` with `navigationTransition(.zoom)` and is applied to the **ten pushes where the label and the destination share artwork** — playlist tiles on Home, New, Library and the playlist list; featured art and artist thumbnails; featured, grid and similar video cells.

Chevrons, section headers and text rows keep the standard push. There's nothing to morph out of, and zooming from them reads worse than sliding.

Two things in here are non-obvious and are commented in place:

**The namespace belongs to the screen, not the link.** An earlier version gave each link its own, which placed it inside the lazy grid cell — so when that cell was rebuilt while the detail view was open, the source registration went with it and UIKit fell back to the wrong animation.

**`ZoomPushDismissal` works around an iOS 26 defect.** After an *interactive* dismissal the zoom transition keeps running, and UIKit won't start another navigation until it finishes, so the next tap does nothing for as long as the animation lasts — scaling with how far the finger dragged. The back button is unaffected. Reported and unanswered since June 2025: https://developer.apple.com/forums/thread/789010

I bisected this to rule out our code: a bare `NavigationStack` with a grid of coloured squares and an empty destination reproduces it exactly — no TabView, no popup container, no animations. The workaround suppresses both `_UIParallaxTransitionPanGestureRecognizer` instances and drives an equivalent edge swipe through `dismiss()`. The zoom still animates; it just isn't finger-driven. The private class-name match fails safe — no match, nothing disabled — and the file says to delete it once Apple fixes the transition.

**Reviewers may reasonably object to that private-API match.** It's the part I'd push back on too. The alternative I tried — presenting modally instead of pushing — avoids the bug entirely but covers the LNPopup mini player and takes the vertical drag that playlist search needs, so it traded one problem for two.

## Playlist search

The field is now the first row of scrolling content with zero height at rest, and **its height is the pull distance** — pull down and it grows into the gap between the toolbar and the title, latching open when fully revealed and dropping when you scroll back down.

The system nav-bar drawer can't do this: with `hidesSearchBarWhenScrolling` it's visible at scroll top *by definition*. Positioning a full-height field by scroll offset doesn't work either, because the scroll view's top is `-contentInsets.top`, not `0`, so absolute offsets are meaningless.

A dead zone plus resistance means it takes a decided pull rather than appearing during ordinary scrolling. Both are named constants.

The hero no longer consumes the pull (`pullDownOverride: 0`) — it was scaling up and sliding over the field growing above it, putting the search bar behind the artwork.

## Prefetch and per-visit work

Found while profiling navigation on device:

- `warmCollection` built and deduped a URL per song **on the main actor**, at the moment the song list arrived — 58–100ms of dropped frames per open, now off-actor.
- `onAppear` can fire several times per visit, and each one restarted the in-flight network fetch. Guarded.
- `prefetchArtwork` starts three prefetches; `onDisappear` cancelled two. The whole-playlist warm ran on after leaving, and stacked across playlists. `ArtworkPrefetcher.cancelWarm` existed for this and had never been called from anywhere.
- `RecentlyPlayedStore.record` moved to `onDisappear` — it reorders the list Home's carousel is bound to, and mutates an `@Observable` two always-alive tab roots read.
- Song rows ignore touches for 350ms after appearing, so a second tap aimed at a grid tile doesn't start playback on the arriving screen.

## Testing

iOS (device + simulator), tvOS and watchOS all build clean; `TwinskaraokeTests` pass. Behaviour verified on device across Home, New, Library, playlist detail, art gallery and video gallery.

Not covered by automated tests — the interactive behaviour here isn't reachable from unit tests, and I'd treat the gesture interactions as needing a human pass.

## Summary by Sourcery

Introduce artwork-based zoom navigation transitions for detail views and rework playlist search to a pull-to-reveal Apple Music–style interaction, while tightening playlist navigation performance and artwork prefetch behavior.

New Features:
- Add a reusable ZoomNavigationLink component and associated zoom transition helpers to animate artwork tiles into their detail views across playlists, art, and video screens.
- Implement a pull-driven, latched playlist search field that grows out of scroll overscroll instead of using the standard navigation bar search drawer.

Bug Fixes:
- Prevent song rows in playlist detail from accidentally starting playback during the zoom transition by temporarily disabling row hit testing.
- Avoid repeated per-visit work in playlist detail by guarding onAppear logic and moving RecentlyPlayed recording to onDisappear to stop mid-transition mutations.
- Ensure artwork prefetch warmups cannot outlive or overlap newer requests by tracking per-reason request tokens and cancelling correctly when leaving a playlist.

Enhancements:
- Run expensive artwork URL derivation for playlist warmups off the main actor and dedupe URLs more robustly to reduce frame drops when opening large playlists.
- Refine playlist detail layout and scroll handling so the search field reveal is driven by live pull distance rather than fragile initial scroll offsets or geometry wrappers.
- Align playlists and gallery navigation bars and titles with the zoom effect (e.g., inline titles) to avoid distracting header animations during zoom transitions.
- Work around an iOS 26 interactive zoom-pop defect by suppressing the system edge-pan recognizers and replacing them with an explicit back-swipe gesture that uses dismiss().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth zoom transitions when opening playlists, artwork, artists, and videos.
  * Preserved interactive edge-swipe dismissal when using zoom navigation.
  * Added reduced-motion support to disable animated transitions when requested.
  * Redesigned playlist detail search with pull-to-reveal behavior, haptics, focus handling, and cancellation.
* **Performance**
  * Improved artwork prefetching by canceling outdated requests and avoiding duplicate or blocked downloads.
* **Navigation**
  * Refined playlist grid navigation and navigation-bar presentation for a more consistent browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->