### PR TITLE
Suppress the dismissal gesture that actually drives the zoom

### DIFF
--- a/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
+++ b/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
@@ -34,14 +34,16 @@ import SwiftUI
 /// Two further constraints, both learned on device — neither is cosmetic:
 ///
 /// - **Vertical pulls belong to the destination — but only while
-///   `ZoomPushDismissal` is in place.** A push's interactive dismissal is an
-///   *edge* pan, so a downward pull does not compete with it, which is what lets
+///   `ZoomPushDismissal` is in place.** A push is dismissed by a horizontal
+///   gesture, so a downward pull does not compete with it, which is what lets
 ///   `PlaylistDetailView` reveal its search field by pulling. That holds only
-///   because `zoomPushDismissal` suppresses the interactive pop entirely. If
-///   that workaround is ever deleted — and its own documentation says to delete
-///   it once Apple fixes the transition — re-check this: a restored interactive
-///   dismissal, or any move to a modal presentation, reintroduces a vertical
-///   drag-dismiss that will fight the pull and usually win.
+///   because `zoomPushDismissal` suppresses the system dismissal entirely — note
+///   that gesture is *not* edge-limited, so it covers the same content the pull
+///   does and merely disagrees about direction. If that workaround is ever
+///   deleted — and its own documentation says to delete it once Apple fixes the
+///   transition — re-check this: a restored interactive dismissal, or any move
+///   to a modal presentation, reintroduces a vertical drag-dismiss that will
+///   fight the pull and usually win.
 /// - **Mind the source screen's navigation bar.** Zoom deliberately leaves the
 ///   source on screen, so any bar difference between the two screens animates in
 ///   full view instead of being carried off by a slide. A large title has to

--- a/Twinskaraoke/Components/Shared/ZoomPushArrival.swift
+++ b/Twinskaraoke/Components/Shared/ZoomPushArrival.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+private struct ZoomPushIsArrivingKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    /// True while a zoom-pushed screen is still flying in.
+    ///
+    /// `ZoomPushDismissal` publishes it from the push's own transition
+    /// coordinator; it is false everywhere else, including under reduce motion,
+    /// where there is no zoom to wait for.
+    ///
+    /// Read it wherever a *single* tap commits something the user cannot easily
+    /// undo — starting playback, most of all. The zoom does not gate input, so a
+    /// tap aimed at the grid tile behind lands on the arriving screen, over
+    /// whatever happens to sit at that Y coordinate. Scrolling and Back should
+    /// stay live: they cost nothing if they were not meant.
+    var zoomPushIsArriving: Bool {
+        get { self[ZoomPushIsArrivingKey.self] }
+        set { self[ZoomPushIsArrivingKey.self] = newValue }
+    }
+}

--- a/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
+++ b/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
@@ -52,6 +52,11 @@ struct ZoomPushDismissal: ViewModifier {
     /// tile arrives while this screen is still flying in, over whatever sits at
     /// that Y coordinate.
     @State private var isArriving = true
+    @State private var arrivalFallbackTask: Task<Void, Never>?
+
+    /// Long enough that it never pre-empts the ~0.9s transition, short enough
+    /// that a missing signal costs a moment rather than the screen.
+    private static let arrivalFallback = Duration.milliseconds(1500)
 
     func body(content: Content) -> some View {
         content
@@ -73,8 +78,20 @@ struct ZoomPushDismissal: ViewModifier {
             .onAppear {
                 isDismissing = false
                 suppressor.update()
+                // This flag gates playback, so it must clear on its own even if
+                // the arrival signal never comes — a screen whose rows silently
+                // stop working looks alive and is not.
+                arrivalFallbackTask?.cancel()
+                arrivalFallbackTask = Task { @MainActor in
+                    try? await Task.sleep(for: Self.arrivalFallback)
+                    guard !Task.isCancelled else { return }
+                    isArriving = false
+                }
             }
-            .onDisappear { suppressor.update() }
+            .onDisappear {
+                suppressor.update()
+                arrivalFallbackTask?.cancel()
+            }
     }
 }
 
@@ -113,6 +130,12 @@ final class InteractiveDismissalSuppressor {
     weak var navigationController: UINavigationController?
     /// The navigation controller's own child that hosts this screen. Identity is
     /// what tells a real pop apart from SwiftUI churn.
+    ///
+    /// Without it there is nothing to suppress *for*: the release condition
+    /// would never be met, so suppression would outlive the screen and take the
+    /// interactive pop away from every screen underneath it. And the replacement
+    /// gesture is installed on this same controller's view, so suppressing here
+    /// would leave a screen with no way to swipe back at all. Both fail open.
     weak var hostController: UIViewController?
     private var isHolding = false
 
@@ -134,10 +157,7 @@ final class InteractiveDismissalSuppressor {
     }
 
     private var isTopOfStack: Bool {
-        guard let navigationController else { return false }
-        // No host means the responder walk came up empty; assume this screen is
-        // the one on top rather than leaving it unprotected. `deinit` releases.
-        guard let hostController else { return true }
+        guard let navigationController, let hostController else { return false }
         return navigationController.topViewController === hostController
     }
 
@@ -191,6 +211,9 @@ final class NavigationDismissalSuppression {
     private var holders: Set<ObjectIdentifier> = []
     private var disabled: [UIGestureRecognizer] = []
     private var rescanTask: Task<Void, Never>?
+    /// Whether this suppression cycle ever matched anything. Nothing at all means
+    /// the names above no longer describe what iOS installs — see `apply()`.
+    private var hasMatchedDriver = false
 
     private init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -210,6 +233,14 @@ final class NavigationDismissalSuppression {
                 recogniser.isEnabled = true
             }
             disabled = []
+            // A whole visit to a zoom destination without a single match means
+            // matching by name has stopped working — a renamed class in a new
+            // iOS, most likely — and the interactive dismissal is live again
+            // along with the delay it causes. That is silent in every other way,
+            // so it trips here: the regression test pushes a zoom destination,
+            // which makes this a build-time failure rather than a bug report.
+            assert(hasMatchedDriver, "No interactive-dismissal recogniser matched \(Self.driverNames)")
+            hasMatchedDriver = false
             return
         }
         scan()
@@ -238,6 +269,7 @@ final class NavigationDismissalSuppression {
             recogniser.isEnabled = false
         }
         disabled.append(contentsOf: found)
+        hasMatchedDriver = true
     }
 
     private func collect(from view: UIView, into found: inout [UIGestureRecognizer]) {
@@ -321,6 +353,7 @@ private struct ZoomDismissalBridge: UIViewRepresentable {
                     }
                     suppressor.hostController = host
                     // onAppear may have run before the controller was known.
+                    // With no host this suppresses nothing, deliberately.
                     suppressor.update()
                     guard let host else {
                         onArrived?()
@@ -343,6 +376,10 @@ private struct ZoomDismissalBridge: UIViewRepresentable {
                 responder = current.next
                 hops += 1
             }
+            // No navigation controller in the chain, so no transition to wait
+            // for. Saying so matters: the flag this clears gates playback, and
+            // nothing else would ever clear it.
+            onArrived?()
         }
     }
 }
@@ -417,11 +454,16 @@ final class SwipeBackDriver: NSObject, UIGestureRecognizerDelegate {
     /// drag recognise its own tap and start playing: a pan cancels *touches* in
     /// its view, which does nothing to a competing gesture recogniser, so the
     /// only thing that stops the tap is refusing to share the touch with it.
+    ///
+    /// The scroll view's *own pan*, specifically, and not everything attached to
+    /// a scroll view: a tap or zoom recogniser added to one later would
+    /// otherwise inherit permission to run alongside this and undo the above.
     func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
     ) -> Bool {
-        other.view is UIScrollView
+        guard let scrollView = other.view as? UIScrollView else { return false }
+        return other === scrollView.panGestureRecognizer
     }
 
     /// Yield to anything that can genuinely scroll horizontally — a carousel in

--- a/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
+++ b/Twinskaraoke/Components/Shared/ZoomPushDismissal.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 import UIKit
 
-/// Keeps a pushed zoom destination off the interactive-pop path.
+/// Keeps a pushed zoom destination off iOS 26's interactive-dismissal path.
 ///
 /// `.navigationTransition(.zoom)` on a push has an iOS 26 defect: after an
 /// *interactive* dismissal the transition keeps running, and UIKit will not
 /// begin another navigation until it finishes — so the next tap does nothing for
 /// as long as the animation lasts, which scales with how far the finger dragged.
+/// Worse, the outgoing screen keeps hit testing for that whole time, so a tap
+/// meant for the grid underneath lands on the shrinking detail view instead.
 /// Dismissing the same screen with the back button completes immediately.
 /// Reported and unanswered since June 2025:
 /// https://developer.apple.com/forums/thread/789010
@@ -15,48 +17,64 @@ import UIKit
 /// that goes through `dismiss()` — the back-button path. The zoom still
 /// animates; it simply is not finger-driven.
 ///
-/// Note what this buys beyond responsiveness: a push's interactive dismissal is
-/// an *edge* pan (`_UIParallaxTransitionPanGestureRecognizer`), so vertical
-/// pulls stay free for the destination — which is why PlaylistDetailView can
-/// keep its pull-to-reveal search without any staging or arbitration. A modal
-/// presentation adds a vertical drag-dismiss instead, which fights that reveal,
-/// and also covers the LNPopup mini player. Pushing avoids both.
+/// Note what this buys beyond responsiveness: a push is dismissed by a
+/// *horizontal* gesture, so vertical pulls stay free for the destination — which
+/// is why PlaylistDetailView can keep its pull-to-reveal search without any
+/// staging or arbitration. A modal presentation adds a vertical drag-dismiss
+/// instead, which fights that reveal, and also covers the LNPopup mini player.
+/// Pushing avoids both. (Horizontal, not edge-limited: see below.)
+///
+/// **The replacement has to cover the whole screen, not just the edge.** UIKit's
+/// content swipe is not edge-limited: measured on iOS 26.5, a right-swipe
+/// starting 80pt in dismissed the destination. An earlier version of this put a
+/// 20pt gesture strip along the leading edge instead, and suppressing the system
+/// recogniser then had a second effect nobody wanted — with nothing claiming a
+/// horizontal drag over the content, the row underneath received it as a plain
+/// tap and started playing, because a touch that ends inside a button's own
+/// bounds is a tap no matter how far it travelled sideways. So the replacement
+/// is a real pan on the whole screen: it cancels content touches the moment it
+/// begins, and dismisses on release.
 ///
 /// Delete this once Apple fixes the transition, and restore the real
 /// interactive dismissal — finger-tracking is the better interaction.
 struct ZoomPushDismissal: ViewModifier {
     @Environment(\.dismiss) private var dismiss
-    @State private var suppressor = TransitionPanSuppressor()
-
-    /// Mirrors UIKit's screen-edge pan, so the strip cannot swallow content taps.
-    private static let edgeWidth: CGFloat = 20
-    private static let triggerDistance: CGFloat = 60
+    @State private var suppressor = InteractiveDismissalSuppressor()
+    /// Set the instant a dismissal is committed, not on `onDisappear`: that
+    /// fires when the transition *finishes* (measured ~0.9s later), and for the
+    /// whole shrink in between this screen is still on top of the hit-testing
+    /// order. A tap aimed at the tile underneath landed on a song row here and
+    /// started playing it.
+    @State private var isDismissing = false
+    /// True until the push transition finishes. Screens that start playback on a
+    /// single tap read this and hold those taps back: the zoom does not gate
+    /// input, and it runs ~0.9s — measured — so a second tap aimed at the grid
+    /// tile arrives while this screen is still flying in, over whatever sits at
+    /// that Y coordinate.
+    @State private var isArriving = true
 
     func body(content: Content) -> some View {
         content
-            .background(NavigationControllerLocator(suppressor: suppressor))
-            .overlay(alignment: .leading) {
-                Color.clear
-                    .frame(width: Self.edgeWidth)
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 12)
-                            .onEnded { value in
-                                guard value.translation.width > Self.triggerDistance,
-                                      abs(value.translation.height) < value.translation.width
-                                else { return }
-                                AppHaptic.selection.play()
-                                dismiss()
-                            }
-                    )
-                    .ignoresSafeArea()
+            .allowsHitTesting(!isDismissing)
+            .environment(\.zoomPushIsArriving, isArriving)
+            .background(
+                ZoomDismissalBridge(
+                    suppressor: suppressor,
+                    onSwipeBack: {
+                        isDismissing = true
+                        AppHaptic.selection.play()
+                        dismiss()
+                    },
+                    onArrived: { isArriving = false }
+                )
+            )
+            // Both call the same evaluation: it asks whether this screen is the
+            // one on top, rather than trusting appear/disappear to be paired.
+            .onAppear {
+                isDismissing = false
+                suppressor.update()
             }
-            // Bound to the view's own lifecycle. Driving this from
-            // `didMoveToWindow` undid it microseconds later as SwiftUI churned
-            // the backing view, and from `dismantleUIView` it ran a whole visit
-            // late — both produced tests that never had the intended state.
-            .onAppear { suppressor.suppress() }
-            .onDisappear { suppressor.restore() }
+            .onDisappear { suppressor.update() }
     }
 }
 
@@ -78,78 +96,344 @@ private struct ZoomPushDismissalGate: ViewModifier {
     }
 }
 
+/// One per zoom destination on screen. Decides *whether* its screen wants the
+/// interactive dismissal suppressed; the actual disabling is shared per
+/// navigation controller, because the recognisers are too.
 @MainActor
-final class TransitionPanSuppressor {
+final class InteractiveDismissalSuppressor {
     /// Single switch for the private-API dependency below.
     ///
-    /// Everything here hangs off matching `_UIParallaxTransitionPanGestureRecognizer`
-    /// by type name. Turning this off restores stock behaviour — the interactive
-    /// pop comes back, and with it the iOS 26 delay — without touching any call
-    /// site. Flip it if a future iOS renames the class, or if the dependency is
-    /// ever considered a submission risk.
+    /// Everything here hangs off matching UIKit's dismissal recognisers by type
+    /// name. Turning this off restores stock behaviour — the interactive
+    /// dismissal comes back, and with it the iOS 26 delay — without touching any
+    /// call site. Flip it if a future iOS renames the classes, or if the
+    /// dependency is ever considered a submission risk.
     static let isEnabled = true
 
     weak var navigationController: UINavigationController?
-    private var suppressed: [UIGestureRecognizer] = []
+    /// The navigation controller's own child that hosts this screen. Identity is
+    /// what tells a real pop apart from SwiftUI churn.
+    weak var hostController: UIViewController?
+    private var isHolding = false
 
-    func suppress() {
-        guard Self.isEnabled, suppressed.isEmpty, let nav = navigationController else { return }
-        // Both instances, not just `interactivePopGestureRecognizer`: the zoom
-        // installs a second recogniser of the same private class, and only the
-        // first is reachable through that property. Matching on the type name is
-        // unpleasant but narrow, and fails safe — no match, nothing disabled.
-        let targets = (nav.view.gestureRecognizers ?? []).filter { recogniser in
-            String(describing: type(of: recogniser)).contains("ParallaxTransition")
-                && recogniser.isEnabled
-        }
-        guard !targets.isEmpty else { return }
-        for target in targets {
-            target.isEnabled = false
-        }
-        suppressed = targets
+    /// Suppression follows *who is on top*, not SwiftUI's appear/disappear
+    /// pairing. Those fire repeatedly for a single visit — this project's device
+    /// logs show appeared and disappeared 1ms apart, over and over — so
+    /// restoring on every disappear left the screen unprotected for the rest of
+    /// the visit, which is one way the interactive path came back. Asking the
+    /// navigation stack instead is idempotent: churn re-evaluates to the same
+    /// answer, a genuine pop evaluates to false, and a screen pushed on top
+    /// hands suppression over to that screen (or gives it up entirely, so a
+    /// plain push on top keeps its ordinary interactive pop).
+    func update() {
+        guard Self.isEnabled else { return }
+        let wants = isTopOfStack
+        guard wants != isHolding else { return }
+        isHolding = wants
+        suppression?.setHolder(ObjectIdentifier(self), wants: wants)
     }
 
-    func restore() {
-        for recogniser in suppressed {
-            recogniser.isEnabled = true
-        }
-        suppressed = []
+    private var isTopOfStack: Bool {
+        guard let navigationController else { return false }
+        // No host means the responder walk came up empty; assume this screen is
+        // the one on top rather than leaving it unprotected. `deinit` releases.
+        guard let hostController else { return true }
+        return navigationController.topViewController === hostController
+    }
+
+    private var suppression: NavigationDismissalSuppression? {
+        navigationController.map { NavigationDismissalSuppression.attached(to: $0) }
+    }
+
+    isolated deinit {
+        guard isHolding else { return }
+        suppression?.setHolder(ObjectIdentifier(self), wants: false)
     }
 }
 
-/// Hands the enclosing navigation controller to the suppressor; enabling and
-/// disabling is driven by SwiftUI's lifecycle, not by this view.
-private struct NavigationControllerLocator: UIViewRepresentable {
-    let suppressor: TransitionPanSuppressor
+/// Disables the recognisers that drive an interactive dismissal, for as long as
+/// at least one zoom destination on this navigation controller wants that.
+///
+/// Reference counted because the recognisers are shared: with a zoom destination
+/// pushed from another zoom destination — the art gallery does exactly this,
+/// artist then artwork — the parent's teardown would otherwise re-enable them
+/// underneath the child.
+@MainActor
+final class NavigationDismissalSuppression {
+    /// Measured on iOS 26.5, from a pushed `.navigationTransition(.zoom)`
+    /// destination — four recognisers, not the two this used to disable:
+    ///
+    /// - `_UIParallaxTransitionPanGestureRecognizer` ×2 on the navigation
+    ///   controller's view. Only the first is reachable through
+    ///   `interactivePopGestureRecognizer`.
+    /// - `_UIParallaxTransitionPanGestureRecognizer` and
+    ///   `_UIContentSwipeDismissGestureRecognizer` on the destination's own
+    ///   hosting view. **These are the ones that were missed**, and the content
+    ///   swipe is what actually drives the zoom dismissal: it was seen going
+    ///   began → changed while both recognisers on the navigation view sat
+    ///   disabled, popping the screen on the broken interactive path.
+    ///
+    /// Matching on type names is unpleasant but narrow, and fails safe — no
+    /// match, nothing disabled.
+    private static let driverNames = ["ParallaxTransition", "ContentSwipeDismiss"]
 
-    func makeUIView(context: Context) -> LocatorView {
-        let view = LocatorView()
+    private static let table = NSMapTable<UINavigationController, NavigationDismissalSuppression>
+        .weakToStrongObjects()
+
+    static func attached(to navigationController: UINavigationController) -> NavigationDismissalSuppression {
+        if let existing = table.object(forKey: navigationController) { return existing }
+        let created = NavigationDismissalSuppression(navigationController: navigationController)
+        table.setObject(created, forKey: navigationController)
+        return created
+    }
+
+    private weak var navigationController: UINavigationController?
+    private var holders: Set<ObjectIdentifier> = []
+    private var disabled: [UIGestureRecognizer] = []
+    private var rescanTask: Task<Void, Never>?
+
+    private init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    func setHolder(_ holder: ObjectIdentifier, wants: Bool) {
+        let changed = wants ? holders.insert(holder).inserted : holders.remove(holder) != nil
+        guard changed else { return }
+        apply()
+    }
+
+    private func apply() {
+        guard !holders.isEmpty else {
+            rescanTask?.cancel()
+            rescanTask = nil
+            for recogniser in disabled {
+                recogniser.isEnabled = true
+            }
+            disabled = []
+            return
+        }
+        scan()
+        // The destination's own recognisers are installed by the transition, and
+        // there is no callback for that, so one scan on appear can be too early.
+        // A short burst covers the transition window and then stops; a dismissal
+        // recogniser cannot appear later than the transition that owns it.
+        rescanTask?.cancel()
+        rescanTask = Task { @MainActor [weak self] in
+            for step in [50, 200, 500] {
+                try? await Task.sleep(for: .milliseconds(step))
+                guard !Task.isCancelled, let self, !self.holders.isEmpty else { return }
+                self.scan()
+            }
+        }
+    }
+
+    /// Walks the whole navigation view tree, not just its root view: two of the
+    /// four recognisers live on the destination's hosting view.
+    private func scan() {
+        guard let root = navigationController?.view else { return }
+        var found: [UIGestureRecognizer] = []
+        collect(from: root, into: &found)
+        guard !found.isEmpty else { return }
+        for recogniser in found {
+            recogniser.isEnabled = false
+        }
+        disabled.append(contentsOf: found)
+    }
+
+    private func collect(from view: UIView, into found: inout [UIGestureRecognizer]) {
+        for recogniser in view.gestureRecognizers ?? []
+        where recogniser.isEnabled && Self.isDismissalDriver(recogniser) {
+            found.append(recogniser)
+        }
+        for subview in view.subviews {
+            collect(from: subview, into: &found)
+        }
+    }
+
+    private static func isDismissalDriver(_ recogniser: UIGestureRecognizer) -> Bool {
+        let name = String(describing: type(of: recogniser))
+        return driverNames.contains { name.contains($0) }
+    }
+}
+
+/// Finds the enclosing navigation controller and this screen's own view
+/// controller, hands both to the suppressor, and installs the swipe-back pan on
+/// the screen. The decision to suppress is the suppressor's.
+private struct ZoomDismissalBridge: UIViewRepresentable {
+    let suppressor: InteractiveDismissalSuppressor
+    let onSwipeBack: () -> Void
+    let onArrived: () -> Void
+
+    func makeUIView(context: Context) -> BridgeView {
+        let view = BridgeView()
         view.suppressor = suppressor
+        view.swipeBack = context.coordinator
+        view.onArrived = onArrived
+        context.coordinator.onSwipeBack = onSwipeBack
         return view
     }
 
-    func updateUIView(_ view: LocatorView, context: Context) {
+    func updateUIView(_ view: BridgeView, context: Context) {
         view.suppressor = suppressor
+        view.onArrived = onArrived
+        context.coordinator.onSwipeBack = onSwipeBack
     }
 
-    final class LocatorView: UIView {
-        var suppressor: TransitionPanSuppressor?
+    func makeCoordinator() -> SwipeBackDriver { SwipeBackDriver() }
+
+    static func dismantleUIView(_ view: BridgeView, coordinator: SwipeBackDriver) {
+        coordinator.uninstall()
+    }
+
+    final class BridgeView: UIView {
+        var suppressor: InteractiveDismissalSuppressor?
+        var swipeBack: SwipeBackDriver?
+        var onArrived: (() -> Void)?
+
+        /// The push's own transition, asked directly rather than guessed at with
+        /// a delay: `transitionCoordinator` is non-nil for exactly as long as the
+        /// zoom runs, and nil already when a screen appears without one (reduce
+        /// motion, or a re-appear after a sub-screen pops).
+        private func reportArrival(host: UIViewController) {
+            guard let coordinator = host.transitionCoordinator else {
+                onArrived?()
+                return
+            }
+            coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+                self?.onArrived?()
+            }
+        }
 
         override func didMoveToWindow() {
             super.didMoveToWindow()
             guard window != nil, let suppressor else { return }
             var responder: UIResponder? = self
+            var innermostController: UIViewController?
             var hops = 0
             while let current = responder, hops < 60 {
                 if let nav = current as? UINavigationController {
                     suppressor.navigationController = nav
+                    // The screen's own controller is the one whose parent is the
+                    // navigation controller — SwiftUI nests hosting controllers,
+                    // so the innermost one is usually not it.
+                    let host = innermostController.flatMap { controller in
+                        sequence(first: controller, next: \.parent).first { $0.parent === nav }
+                    }
+                    suppressor.hostController = host
                     // onAppear may have run before the controller was known.
-                    suppressor.suppress()
+                    suppressor.update()
+                    guard let host else {
+                        onArrived?()
+                        return
+                    }
+                    // Installed only where the system gesture is suppressed: the
+                    // replacement stands in for it, so the escape hatch has to
+                    // turn off both or neither. On the screen's own view, so it
+                    // dies with the screen instead of outliving it on the
+                    // navigation view.
+                    if InteractiveDismissalSuppressor.isEnabled {
+                        swipeBack?.install(on: host.view)
+                    }
+                    reportArrival(host: host)
                     return
+                }
+                if innermostController == nil, let controller = current as? UIViewController {
+                    innermostController = controller
                 }
                 responder = current.next
                 hops += 1
             }
         }
+    }
+}
+
+/// The replacement for UIKit's suppressed content swipe: same reach, but it
+/// dismisses through `dismiss()` instead of driving the transition interactively.
+@MainActor
+final class SwipeBackDriver: NSObject, UIGestureRecognizerDelegate {
+    /// How far the finger must travel before a release counts as "back", and the
+    /// flick that gets there sooner.
+    private static let triggerDistance: CGFloat = 60
+    private static let flickDistance: CGFloat = 24
+    private static let flickVelocity: CGFloat = 800
+
+    var onSwipeBack: () -> Void = {}
+    private weak var installedView: UIView?
+    private var recogniser: UIPanGestureRecognizer?
+
+    func install(on view: UIView) {
+        guard installedView !== view else { return }
+        uninstall()
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
+        pan.delegate = self
+        pan.maximumNumberOfTouches = 1
+        // Left at its default: cancelling content touches when the pan begins is
+        // what stops a sideways drag across a song row from playing it.
+        view.addGestureRecognizer(pan)
+        recogniser = pan
+        installedView = view
+    }
+
+    func uninstall() {
+        if let recogniser, let installedView {
+            installedView.removeGestureRecognizer(recogniser)
+        }
+        recogniser = nil
+        installedView = nil
+    }
+
+    @objc private func handlePan(_ pan: UIPanGestureRecognizer) {
+        guard pan.state == .ended, let view = pan.view else { return }
+        let sign = Self.backwardSign(in: view)
+        let translation = pan.translation(in: view).x * sign
+        let velocity = pan.velocity(in: view).x * sign
+        guard abs(pan.translation(in: view).y) < translation else { return }
+        let isDecided = translation > Self.triggerDistance
+            || (translation > Self.flickDistance && velocity > Self.flickVelocity)
+        guard isDecided else { return }
+        onSwipeBack()
+    }
+
+    /// "Back" is leftward in a right-to-left layout, as it is for the system
+    /// gesture this replaces. No RTL localisation ships today; this is one line
+    /// rather than a surprise when one does.
+    private static func backwardSign(in view: UIView) -> CGFloat {
+        view.effectiveUserInterfaceLayoutDirection == .rightToLeft ? -1 : 1
+    }
+
+    /// Rightward and horizontal, judged on the opening movement. Anything else —
+    /// including the vertical pull that reveals PlaylistDetailView's search
+    /// field — is none of this gesture's business.
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let pan = gestureRecognizer as? UIPanGestureRecognizer, let view = pan.view
+        else { return false }
+        let velocity = pan.velocity(in: view)
+        let backward = velocity.x * Self.backwardSign(in: view)
+        return backward > 0 && backward > abs(velocity.y) * 1.5
+    }
+
+    /// Scrolling must keep working while this is armed — but nothing else may
+    /// run alongside. Blanket simultaneity let the row underneath a sideways
+    /// drag recognise its own tap and start playing: a pan cancels *touches* in
+    /// its view, which does nothing to a competing gesture recogniser, so the
+    /// only thing that stops the tap is refusing to share the touch with it.
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+        other.view is UIScrollView
+    }
+
+    /// Yield to anything that can genuinely scroll horizontally — a carousel in
+    /// a destination owns its own sideways drags. None of today's zoom
+    /// destinations has one; this is so adding one does not break it.
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRequireFailureOf other: UIGestureRecognizer
+    ) -> Bool {
+        guard let scrollView = other.view as? UIScrollView,
+              other === scrollView.panGestureRecognizer
+        else { return false }
+        return scrollView.contentSize.width > scrollView.bounds.width + 1
     }
 }

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -35,13 +35,22 @@ struct PlaylistDetailView: View {
     @State private var prefetchedIDs: [String] = []
     @State private var prefetchTask: Task<Void, Never>?
     @State private var removalErrorSong: Song?
-    /// Song rows ignore touches until the push has settled. The zoom
-    /// transition does not gate input, so a second tap aimed at the grid
-    /// tile lands on this screen as it arrives under the finger — and at
-    /// that same Y coordinate there is a song row, which started playing.
-    /// Scrolling, Back and the action buttons stay live throughout.
-    @State private var rowsAcceptTouches = false
+    /// Everything that starts playback — song rows *and* Play/Shuffle — ignores
+    /// touches until the push has settled. The zoom transition does not gate
+    /// input, so a second tap aimed at the grid tile lands on this screen as it
+    /// arrives under the finger, and at that Y coordinate there is either a song
+    /// row or an action button. Both started playing; the buttons were exempt
+    /// from this gate until they were caught doing it. Scrolling and Back stay
+    /// live throughout.
+    ///
+    /// Two conditions, because neither covers the other: the transition itself
+    /// says when the zoom is done (measured at ~0.9s, far longer than the delay
+    /// below used to allow), and the delay covers the arrivals that have no
+    /// transition to ask — reduce motion, or coming back from a sub-screen.
+    @Environment(\.zoomPushIsArriving) private var isArriving
+    @State private var hasSettledAfterAppear = false
     @State private var rowArmingTask: Task<Void, Never>?
+    private var playbackTapsArmed: Bool { hasSettledAfterAppear && !isArriving }
     /// onAppear fires repeatedly for one visit — device logs show appeared and
     /// disappeared 1ms apart, over and over. Everything below it is one-shot
     /// work: reload cancels and restarts the network load, and record() writes
@@ -282,7 +291,7 @@ struct PlaylistDetailView: View {
             rowArmingTask = Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(350))
                 guard !Task.isCancelled else { return }
-                rowsAcceptTouches = true
+                hasSettledAfterAppear = true
             }
             schedulePrefetch()
 
@@ -367,7 +376,7 @@ struct PlaylistDetailView: View {
                 RecentlyPlayedStore.shared.record(playlist)
             }
             rowArmingTask?.cancel()
-            rowsAcceptTouches = false
+            hasSettledAfterAppear = false
             prefetchTask?.cancel()
             // Same class of post-teardown work as the prefetches below:
             // favoritesRefreshTask starts a network fetch after a one-second
@@ -618,7 +627,7 @@ struct PlaylistDetailView: View {
                         }
                     }
                 }
-                .allowsHitTesting(rowsAcceptTouches)
+                .allowsHitTesting(playbackTapsArmed)
             }
             .environment(\.playlistSongRemoval, songRemovalContext)
             .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
@@ -670,6 +679,9 @@ struct PlaylistDetailView: View {
             .accessibilityLabel("Shuffle playlist")
         }
         .padding(.horizontal, horizontalPadding)
+        // Gated here rather than around the caller: the wide overview puts these
+        // buttons beside the artwork, outside `playlistSongsContent`.
+        .allowsHitTesting(playbackTapsArmed)
     }
 
     private func play(_ song: Song, context: [Song]) {

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -180,6 +180,98 @@ final class TwinskaraokeUITests: XCTestCase {
     )
   }
 
+  /// Swiping a zoom-pushed screen away must not start playback.
+  ///
+  /// Two ways it did, both measured on iOS 26.5 before `ZoomPushDismissal`
+  /// disabled `_UIContentSwipeDismissGestureRecognizer`: the outgoing screen kept
+  /// hit testing for the ~0.9s the interactive dismissal ran, so a tap aimed at
+  /// the list behind it landed on a song row; and once that recogniser was gone,
+  /// a sideways drag over a row was delivered as a plain tap on the row.
+  func testSwipingBackFromPlaylistDetailStartsNoPlayback() throws {
+    let app = launchApp(initialSection: "search")
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
+    openVisibleItem("Public Playlists", identifier: "SearchCategory.PublicPlaylists", in: app)
+    XCTAssertTrue(app.staticTexts["Karaoke Essentials"].waitForExistence(timeout: 8))
+
+    let tile = element(identifier: "PlaylistList.ui-search-playlist-essentials", in: app)
+    XCTAssertTrue(tile.waitForExistence(timeout: 8))
+    tile.tap()
+    scrollToVisibleItem(
+      "Wake Me Up Before You Go-Go",
+      identifier: "PlaylistDetail.song.0.ui-search-song-1",
+      in: app
+    )
+    let songRow = element(identifier: "PlaylistDetail.song.0.ui-search-song-1", in: app)
+    XCTAssertTrue(
+      songRow.waitForExistence(timeout: 8),
+      "Expected a song row on screen, so the swipe below crosses one."
+    )
+
+    // Deliberately across the song row rather than along the leading edge: the
+    // gesture this replaces was never edge-limited.
+    let swipeY = songRow.frame.midY
+    let origin = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+    origin.withOffset(CGVector(dx: 34, dy: swipeY)).press(
+      forDuration: 0.05,
+      thenDragTo: origin.withOffset(CGVector(dx: 170, dy: swipeY + 5)),
+      withVelocity: 250,
+      thenHoldForDuration: 0
+    )
+
+    // Immediately, while the screen is still shrinking, and at the row's own Y:
+    // that is where the outgoing screen used to claim the touch. Once it is gone
+    // the same point is the playlist list, where a tap opens a playlist and
+    // starts nothing.
+    origin.withOffset(CGVector(dx: 200, dy: swipeY)).tap()
+
+    XCTAssertFalse(
+      app.otherElements["MiniPlayerBar"].waitForExistence(timeout: 3),
+      "Neither the swipe nor a tap during the shrink may start playback."
+    )
+
+    // Keeps the assertion above honest: a deliberate tap on a row still plays,
+    // so its absence means the swipe was ignored rather than playback being
+    // unobservable here. Relaunched because the tap above may have opened a
+    // playlist of its own.
+    app.terminate()
+    app.launch()
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
+    openVisibleItem("Public Playlists", identifier: "SearchCategory.PublicPlaylists", in: app)
+    openVisibleItem(
+      "Karaoke Essentials",
+      identifier: "PlaylistList.ui-search-playlist-essentials",
+      in: app
+    )
+    scrollToVisibleItem(
+      "Wake Me Up Before You Go-Go",
+      identifier: "PlaylistDetail.song.0.ui-search-song-1",
+      in: app
+    )
+    let firstSong = element(identifier: "PlaylistDetail.song.0.ui-search-song-1", in: app)
+    XCTAssertTrue(firstSong.waitForExistence(timeout: 8))
+    // The arriving screen holds playback taps back until the zoom finishes.
+    XCTAssertTrue(
+      waitUntil(timeout: 5) { firstSong.isHittable && self.tapStartsPlayback(firstSong, in: app) },
+      "A deliberate tap on a song row must start playback."
+    )
+  }
+
+  /// Taps and reports whether the mini player showed up, so the caller can retry
+  /// while the screen is still arriving.
+  private func tapStartsPlayback(_ element: XCUIElement, in app: XCUIApplication) -> Bool {
+    element.tap()
+    return app.otherElements["MiniPlayerBar"].waitForExistence(timeout: 1.5)
+  }
+
+  private func waitUntil(timeout: TimeInterval, _ condition: () -> Bool) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if condition() { return true }
+      Thread.sleep(forTimeInterval: 0.25)
+    }
+    return false
+  }
+
   func testAdaptiveMusicShellShowsSidebarOrTabs() throws {
     // In portrait the balanced split view collapses the sidebar out of the
     // hierarchy, so an iPad would fall through to the compact tab assertions


### PR DESCRIPTION
Follow-up to #95. Two reports from device testing, one cause.

- Swiping a zoom destination away left the app unresponsive for seconds, depending on how you swiped.
- Tapping a playlist straight after that swipe sometimes started playing something, without a song ever being tapped.

## What was wrong

`ZoomPushDismissal` disabled two `_UIParallaxTransitionPanGestureRecognizer`s on the navigation controller's view. Measured on iOS 26.5, the destination's **own hosting view carries two more** — another parallax pan and a `_UIContentSwipeDismissGestureRecognizer` — and both stayed enabled for the entire visit.

The content swipe is the one that dismisses a zoom. It was observed going `began → changed` and popping the screen while both recognisers on the navigation view sat disabled. So the interactive path the file exists to avoid was never closed, and every swipe that missed the 20pt replacement strip took it — which is why the delay depended on how you swiped. It scales with the drag; a moderate one measured ~1.5s.

It is also **not edge-limited**: a right-swipe starting 80pt into the screen dismissed the destination.

The stray playback is the same event seen from the other side. During that dismissal the outgoing screen keeps hit testing, because `onDisappear` only fires when the transition ends ~0.9s later. A tap aimed at the tile behind it landed on the shrinking detail view — instrumentation caught two songs starting that way (`Wake Me Up Before You Go-Go`, then `Hero`).

## Changes

- **Scan the whole navigation view tree** and match `ContentSwipeDismiss` as well as `ParallaxTransition`, so all four recognisers are actually disabled.
- **Reference count per navigation controller.** A zoom destination pushed from another zoom destination — the art gallery does exactly this, artist then artwork — previously had its recognisers re-enabled by the parent's teardown.
- **Follow which view controller is on top** instead of trusting SwiftUI's appear/disappear pairing. Those fire repeatedly for one visit, so a spurious disappear used to un-suppress a screen that was still there.
- **Replace the gesture rather than narrow it.** A pan over the whole screen, since the system gesture was never edge-limited, dismissing through `dismiss()` on release (60pt, or a 24pt flick). It refuses simultaneous recognition with everything except scroll views: with nothing claiming a horizontal drag, the row underneath received it as a plain tap and started playing, because a touch ending inside a button's bounds is a tap however far it travelled sideways. `cancelsTouchesInView` does nothing to a competing recogniser. Yields to horizontally scrollable content, and mirrors for right-to-left.
- **The outgoing screen goes inert** the instant a dismissal is committed, not on `onDisappear`.
- **The arriving screen holds playback taps** until the push transition reports completion, through a new `zoomPushIsArriving` environment value, replacing a 350ms timer that expired well inside the ~0.9s zoom. `PlaylistDetailView` applies it to song rows *and* Play/Shuffle — the action buttons were exempt from that gate entirely until they were caught starting playback. Scrolling and Back stay live throughout.
- The `isEnabled` escape hatch now gates the replacement gesture too, so flipping it really does restore stock behaviour.

## Testing

- New UI test drives the swipe across a song row and taps the tile position during the shrink. It **fails with the suppression switched off** and passes with it, and ends by tapping a row deliberately so the "no playback" assertion cannot pass vacuously.
- Full iOS UI suite green (13 tests); tvOS and watchOS build clean.
- Verified on device: swipe-back from every zoom destination including the nested artwork case, stray taps after a swipe, sideways drags over rows, and pull-to-reveal search on a playlist.

## Behaviour change worth knowing

Swipe-back keeps its full-screen reach but is no longer finger-tracked — it commits on release, so a half-swipe and back now cancels instead of rubber-banding. That is inherent to routing the dismissal through `dismiss()`; the file documents restoring the real interactive dismissal once Apple fixes the underlying defect (reported and unanswered since June 2025: https://developer.apple.com/forums/thread/789010).

## Summary by Sourcery

Prevent interactive zoom dismissals from blocking navigation and causing stray playback by fully suppressing system dismissal gestures and routing swipe-back through a controlled replacement pan gesture.

Bug Fixes:
- Ensure swipe-back from zoom-pushed screens no longer leaves the app temporarily unresponsive or starts playback without an explicit tap.
- Stop taps during zoom push and dismissal transitions from landing on outgoing or arriving playlist detail views and unintentionally starting songs.

Enhancements:
- Share interactive dismissal suppression per navigation controller with reference counting so nested zoom destinations remain protected.
- Track the actual top view controller instead of SwiftUI appear/disappear events to decide when suppression should be active.
- Add a full-screen, horizontal pan-based swipe-back gesture that mirrors the system dismissal while avoiding edge-only strips and respecting scroll views.
- Make zoom-pushed screens inert as soon as dismissal is committed and gate playback-triggering taps using a new zoomPushIsArriving environment value.
- Extend playback tap gating in PlaylistDetailView to cover Play and Shuffle buttons in addition to song rows.
- Expose a zoomPushIsArriving environment value so other views can react to the zoom push lifecycle.

Tests:
- Add a UI test that swipes back from a playlist detail screen and asserts that neither the swipe nor a tap during the shrink starts playback, while a deliberate tap still does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-screen swipe-back navigation for dismissing screens, including right-to-left layout support.
  * Improved handling of zoom transition arrival states.

* **Bug Fixes**
  * Prevented accidental playback when swiping during playlist dismissal.
  * Play, Shuffle, and playlist row controls now activate only after transitions have settled.

* **Tests**
  * Added UI coverage for dismissal gestures and playback-tap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->