### PR TITLE
Give the playlist actions and title back their place in the navigation bar

### DIFF
--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -23,6 +23,10 @@ struct PlaylistDetailView: View {
     /// Below 1 so the field trails the finger — ~110pt of pull for a full reveal.
     private static let searchRevealResistance: CGFloat = 0.65
     @State private var searchRevealHeight: CGFloat = 0
+    /// Drives the navigation bar's title and background. The old search field
+    /// hid the title while it was active, because it lived in the bar area; the
+    /// pull-revealed field is content, so the title only follows the scroll.
+    @State private var showsCollapsedTitle = false
     /// Latched once the pull completes, so the field stays put instead of
     /// collapsing the moment the finger lifts.
     @State private var isSearchLatched = false
@@ -269,7 +273,20 @@ struct PlaylistDetailView: View {
             updateSearchReveal(pull: pull)
         }
         .scrollIndicators(.hidden)
+        // Same threshold and wiring as BrowseSongCollectionView, ArtistsView and
+        // DownloadedSongsView: the name belongs in the bar once its own heading
+        // has scrolled away, and the bar stays transparent over the artwork until
+        // then. Inline, never large — the zoom leaves the source screen on
+        // display, so a large title collapsing on push is animated in full view.
+        .collapsedNavigationTitle($showsCollapsedTitle)
         .musicScreenBackground()
+        .navigationTitle(showsCollapsedTitle ? playlist.name : "")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
+        .animation(
+            reduceMotion ? nil : AppMotion.quick,
+            value: showsCollapsedTitle
+        )
         // Add to Library, Download / Remove Downloads and Refresh Playlist live
         // here and nowhere else on this screen. They were reachable only by
         // long-pressing the artwork between the pull-to-reveal search landing and

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -270,6 +270,19 @@ struct PlaylistDetailView: View {
         }
         .scrollIndicators(.hidden)
         .musicScreenBackground()
+        // Add to Library, Download / Remove Downloads and Refresh Playlist live
+        // here and nowhere else on this screen. They were reachable only by
+        // long-pressing the artwork between the pull-to-reveal search landing and
+        // this — a context menu is a shortcut to actions, never their only home.
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                PlaylistMoreMenu(
+                    playlist: playlist,
+                    songs: songs,
+                    onRefresh: refresh
+                )
+            }
+        }
         .alert(
             "Couldn't Remove Song",
             isPresented: Binding(
@@ -835,6 +848,7 @@ private struct PlaylistMoreMenu: View {
                 .contentShape(Circle())
         }
         .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.65, haptic: .selection))
+        .accessibilityIdentifier("PlaylistDetail.moreActions")
     }
 }
 

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -272,6 +272,47 @@ final class TwinskaraokeUITests: XCTestCase {
     return false
   }
 
+  /// The playlist actions must have a home of their own in the toolbar.
+  ///
+  /// They were lost with the navigation-bar block when pull-to-reveal search
+  /// replaced the old search field, leaving `PlaylistMoreMenu` defined but
+  /// unreferenced — which no compiler warning catches for a private type.
+  func testPlaylistDetailToolbarExposesPlaylistActions() throws {
+    let app = launchApp(initialSection: "search")
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
+    openVisibleItem("Public Playlists", identifier: "SearchCategory.PublicPlaylists", in: app)
+    openVisibleItem(
+      "Karaoke Essentials",
+      identifier: "PlaylistList.ui-search-playlist-essentials",
+      in: app
+    )
+
+    let moreActions = app.buttons["PlaylistDetail.moreActions"]
+    XCTAssertTrue(
+      moreActions.waitForExistence(timeout: 8),
+      "Expected the playlist actions menu in the navigation bar."
+    )
+    moreActions.tap()
+
+    // The download entry's title depends on what is already downloaded, and
+    // "Add to Library" is absent for a playlist you own, so assert on the menu
+    // having opened with the actions in it rather than on one exact title.
+    XCTAssertTrue(
+      app.buttons["Refresh Playlist"].waitForExistence(timeout: 5),
+      "Expected the actions menu to open."
+    )
+    for title in ["Play", "Shuffle"] {
+      XCTAssertTrue(app.buttons[title].exists, "Expected \(title) in the actions menu.")
+    }
+    XCTAssertTrue(
+      app.buttons["Download"].exists
+        || app.buttons["Download Remaining"].exists
+        || app.buttons["Remove Downloads"].exists
+        || app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'Downloading'")).count > 0,
+      "Expected a download action in the actions menu."
+    )
+  }
+
   func testAdaptiveMusicShellShowsSidebarOrTabs() throws {
     // In portrait the balanced split view collapses the sidebar out of the
     // hierarchy, so an iPad would fall through to the compact tab assertions

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -304,11 +304,15 @@ final class TwinskaraokeUITests: XCTestCase {
     for title in ["Play", "Shuffle"] {
       XCTAssertTrue(app.buttons[title].exists, "Expected \(title) in the actions menu.")
     }
+    // Three titles rather than one: which download action appears depends on
+    // what the simulator already has on disk, and downloads outlive a launch.
+    // The in-flight "Downloading n…" state is deliberately not among them —
+    // nothing here starts a download, so accepting it would only have widened
+    // what counts as a pass.
     XCTAssertTrue(
       app.buttons["Download"].exists
         || app.buttons["Download Remaining"].exists
-        || app.buttons["Remove Downloads"].exists
-        || app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'Downloading'")).count > 0,
+        || app.buttons["Remove Downloads"].exists,
       "Expected a download action in the actions menu."
     )
   }


### PR DESCRIPTION
Two things disappeared from playlist detail in b4dbc2e (#95), both in the same block, both noticed on a phone rather than in review:

- **The actions menu.** Add to Library, Download, Remove Downloads and Refresh Playlist.
- **The collapsed title.** Scrolling a playlist left the navigation bar empty, so a screen scrolled past its own heading had nothing naming it.

## Why they went

The old search field sat in a `safeAreaInset` next to the navigation-bar staging, and when pull-to-reveal search replaced it, `navigationTitle`, `navigationBarTitleDisplayMode`, `toolbarBackground` and the `toolbar` holding `PlaylistMoreMenu` all went out together.

`PlaylistMoreMenu` survived the edit fully written — just unreferenced. Nothing warns about a private SwiftUI struct nobody uses, and `refresh()` went dead with it. The actions were still reachable by long-pressing the artwork, which is why this went a day without being spotted: a context menu is a shortcut to actions, not the only place they may live. Nothing on screen suggests that pressing and holding the cover art is how you download a playlist.

No tagged release is affected — 1.0.5 shipped two days before the removal.

## Changes

- `toolbar` / `topBarTrailing` / `PlaylistMoreMenu` restored exactly as it was, with an accessibility identifier so it can be asserted on.
- Collapsed title restored with the wiring the other collection screens already use — `collapsedNavigationTitle` at the shared 180pt threshold, inline display mode, and a bar background that fades in with the title so it stays transparent over the artwork until there is a title to carry.
- A UI test opens the menu and checks the actions are in it, so losing the reference again fails a test run instead of waiting to be noticed on a phone.

One deliberate difference from the pre-removal code: the title no longer hides while searching. That condition (`&& !isSearchModeActive`) existed because the old search field occupied the navigation-bar area; the field it protected is now part of the scrolling content, so there is nothing to yield to.

## Testing

- Full iOS UI suite green, including the new `testPlaylistDetailToolbarExposesPlaylistActions` and #96's swipe-back test. tvOS and watchOS build clean.
- The collapsed title was verified against a **real** playlist, not a UI-test one: the fixtures top out at three songs, so their content cannot scroll and nothing collapses — a test asserting on them would pass while proving nothing. Against live data the bar showed no title at rest and the playlist name after a scroll.
- Confirmed on device: menu present with its actions, title appearing on scroll.

## Summary by Sourcery

Restore playlist detail navigation bar title and actions menu, and add test coverage to prevent their regression.

New Features:
- Reinstate a collapsed playlist title in the navigation bar that appears after scrolling past the header while keeping the bar transparent over artwork until needed.
- Restore the playlist actions menu in the playlist detail toolbar, providing a dedicated entry point for play, shuffle, download-related actions, and refresh.

Enhancements:
- Align playlist detail navigation title behavior and bar background with other collection screens, using an inline title that animates in on scroll instead of hiding during search.
- Expose the playlist actions menu button with an accessibility identifier to improve UI automation and accessibility tooling.

Tests:
- Add an iOS UI test that opens a public playlist and asserts the presence and contents of the playlist actions menu in the navigation bar, guarding against future removal of the toolbar actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline playlist title that appears as you scroll through playlist details.
  * Added a “More Actions” menu with options to play, shuffle, refresh the playlist, and manage downloads.
  * Improved toolbar behavior and visual transitions while scrolling.

* **Accessibility**
  * Added an accessibility identifier for the “More Actions” menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->