### PR TITLE
Take the Shape conformances out of main-actor isolation

### DIFF
--- a/Twinskaraoke/Features/Account/LoginSheet.swift
+++ b/Twinskaraoke/Features/Account/LoginSheet.swift
@@ -299,7 +299,14 @@ private struct DiscordIcon: View {
     }
 }
 
-private struct DiscordShape: Shape {
+// Nonisolated because `Shape` refines `Sendable`: with
+// SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor this struct would otherwise be
+// implicitly main-actor isolated, and an isolated conformance to a Sendable
+// protocol is unsound — SwiftUI evaluates `path(in:)` off the main actor. The
+// Xcode 27 compiler rejects it outright ("conformance … crosses into main
+// actor-isolated code"); 26.x accepts it silently. Pure geometry over `let`
+// constants, so there is nothing here that wants isolation.
+private nonisolated struct DiscordShape: Shape {
     func path(in rect: CGRect) -> Path {
         let w = rect.width
         let h = rect.height

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -557,7 +557,9 @@ private struct QRScannerChrome: View {
     }
 }
 
-private struct QRScannerDimMask: Shape {
+// Nonisolated for the same reason as the bracket shape below: `Shape` refines
+// `Sendable`, so the conformance must not be main-actor isolated.
+private nonisolated struct QRScannerDimMask: Shape {
     let cutoutSide: CGFloat
     let cornerRadius: CGFloat
 
@@ -592,7 +594,11 @@ private struct QRCornerBrackets: View {
     }
 }
 
-private struct QRCornerBracketShape: Shape {
+// Nonisolated because `Shape` refines `Sendable`: under
+// SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor this struct is otherwise implicitly
+// isolated, and SwiftUI calls `path(in:)` off the main actor. Xcode 27 rejects
+// the isolated conformance; 26.x accepts it silently.
+private nonisolated struct QRCornerBracketShape: Shape {
     let cornerRadius: CGFloat
     let lineWidth: CGFloat
 


### PR DESCRIPTION
Xcode 27 beta rejects all three of the app's `Shape` types:

```
LoginSheet.swift:302:30      Conformance of 'DiscordShape' to protocol 'Shape' crosses into main actor-isolated code and can cause data races
QRApproveView.swift:560:34   Conformance of 'QRScannerDimMask' to protocol 'Shape' …
QRApproveView.swift:595:38   Conformance of 'QRCornerBracketShape' to protocol 'Shape' …
```

## Why it is a real defect, not a beta false positive

The SDK declares:

```swift
public protocol Shape : Swift.Sendable, SwiftUICore.Animatable,
    SwiftUICore.View, SwiftUICore._RemoveGlobalActorIsolation
```

`Shape` refines `Sendable`. With `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` these structs are implicitly main-actor isolated, so each conformance is an *isolated* conformance to a `Sendable` protocol — it promises the conformance is usable from any isolation while pinning it to one. SwiftUI evaluates `path(in:)` off the main actor while rendering, so the promise does not hold. Xcode 26.x accepts this silently; 27 added the check. The unsoundness predates the check.

## Fix

`private nonisolated struct` on all three. The isolation lives on the *type*, and that is what makes the conformance isolated, so this fixes it at the source rather than at the witness. Nothing is given up: all three are pure geometry over `let CGFloat`s, with no state that wants isolation.

## Scope — three, and only three

Every SwiftUI/SwiftUICore protocol that refines `Sendable` (`Shape`, `ShapeStyle`, `Layout`, `CustomAnimation`, `VisualEffect`, `FileDocument`, `ReferenceFileDocument`, `AttributedTextValueConstraint`, `MatchedTransitionSourceConfiguration`) cross-referenced against the codebase: `Shape` is the only one conformed to anywhere, and only in these three places. No second wave once this lands.

## Verification, and its limit

**The error is not reproducible on Xcode 26.5 / Swift 6.3.3** — the check does not exist there, including with `-enable-upcoming-feature InferIsolatedConformances`, `-enable-upcoming-feature IsolatedConformances`, or `-strict-concurrency=complete`. Verified everything short of that compiler:

- `nonisolated struct` compiles on 26.5, so this does not break anyone on the release toolchain.
- Both files force-recompiled (they are otherwise cached and produce no diagnostics at all): zero warnings.
- Full iOS UI suite green (14 tests); tvOS and watchOS build clean.
- The diagnosis is read off the protocol declaration in the SDK rather than inferred from the message.

**Worth a build on Xcode 27 before merging** to confirm the three errors are gone — that is the one step that cannot be done from a 26.5 machine.

## Adjacent, deliberately not in this PR

`AuthManager.loginWithDiscord`'s `ASWebAuthenticationSession` completion closure is main-actor inferred (verified: touching isolated state inside it compiles silently, unlike a background `DispatchQueue.async` closure, which warns). It therefore asserts at closure entry if that framework ever calls back off-main, and the `Task { @MainActor }` inside does not protect against it, since the check precedes the body. Safe in practice today because AS delivers on main. The fix would be to write the closure `{ @Sendable [weak self] url, error in … }` — same treatment already applied to the SDWebImage modifiers. Kept out of here so this PR stays exactly the reported build break.

## Summary by Sourcery

Mark SwiftUI Shape conformances as nonisolated to avoid unsound main-actor isolation and Xcode 27 build failures.

Bug Fixes:
- Fix build errors in Xcode 27 by removing main-actor isolation from three Shape conformances used for QR scanner chrome and Discord icon rendering.

Enhancements:
- Clarify actor-isolation rationale in code comments for the Shape-based geometry structs to prevent future concurrency issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Swift concurrency requirements for account login and QR approval screens.
  * Preserved existing QR scanner and login interface rendering and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->