### PR TITLE
macos native target

### DIFF
--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -111,6 +111,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		00728E6A614F7CF94D24315C /* Exceptions for "TwinskaraokeMacApp" folder in "Twinskaraoke Mac App" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 5DA46CA312C58DE7DB9D897B /* Twinskaraoke Mac App */;
+		};
 		D01D91C82FA07A4100E300C5 /* Exceptions for "Twinskaraoke" folder in "Twinskaraoke" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -145,6 +152,7 @@
 		9C112CB9C663FE29A9452A2F /* TwinskaraokeMacApp */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				00728E6A614F7CF94D24315C /* Exceptions for "TwinskaraokeMacApp" folder in "Twinskaraoke Mac App" target */,
 			);
 			path = TwinskaraokeMacApp;
 			sourceTree = "<group>";
@@ -797,6 +805,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TwinskaraokeMacApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Twinskaraoke;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -831,6 +840,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TwinskaraokeMacApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Twinskaraoke;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6B9B0FBB9503BD62326D2B0D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B789992B5FC6B90FC2528F9 /* Cocoa.framework */; };
 		93D8E68C2F9B5FA60090FBFA /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 93D8E68B2F9B5FA60090FBFA /* SDWebImageSwiftUI */; };
 		D0BB0000000000000000E00B /* TwinskaraokeWatchWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D0BB0000000000000000E00A /* TwinskaraokeWatchWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D0C385982FB0BD870055284E /* Spleeter in Frameworks */ = {isa = PBXBuildFile; productRef = D0C385972FB0BD870055284E /* Spleeter */; };
@@ -97,6 +98,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		33CB3DD4ECD8C15D69EDD6DE /* Twinskaraoke Mac App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Twinskaraoke Mac App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B789992B5FC6B90FC2528F9 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		D0AA0000000000000000E00A /* Twinskaraoke TV App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Twinskaraoke TV App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BB0000000000000000E00A /* TwinskaraokeWatchWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TwinskaraokeWatchWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0F981B52F94C10900FD69AB /* Twinskaraoke.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Twinskaraoke.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,8 +142,17 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		9C112CB9C663FE29A9452A2F /* TwinskaraokeMacApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = TwinskaraokeMacApp;
+			sourceTree = "<group>";
+		};
 		D0A500002FBD000100000001 /* TwinskaraokeShared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = TwinskaraokeShared;
 			sourceTree = "<group>";
 		};
@@ -178,27 +190,43 @@
 		};
 		D1A000052FAD000100000005 /* TwinskaraokeTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = TwinskaraokeTests;
 			sourceTree = "<group>";
 		};
 		D1A000062FAD000100000006 /* TwinskaraokeUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = TwinskaraokeUITests;
 			sourceTree = "<group>";
 		};
 		D1A000072FAD000100000007 /* TwinskaraokeWatchAppTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = TwinskaraokeWatchAppTests;
 			sourceTree = "<group>";
 		};
 		D1A000082FAD000100000008 /* TwinskaraokeWatchAppUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = TwinskaraokeWatchAppUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		553C27659840CF311C04C6C8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6B9B0FBB9503BD62326D2B0D /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D0AA0000000000000000E005 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -261,9 +289,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8C0263F917FCAAD4E520C8CF /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				6B789992B5FC6B90FC2528F9 /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
 		D0DB31F62FA8A3F80089C24C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8C0263F917FCAAD4E520C8CF /* OS X */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -282,6 +319,7 @@
 				D1A000082FAD000100000008 /* TwinskaraokeWatchAppUITests */,
 				D0DB31F62FA8A3F80089C24C /* Frameworks */,
 				D0F981B62F94C10900FD69AB /* Products */,
+				9C112CB9C663FE29A9452A2F /* TwinskaraokeMacApp */,
 			);
 			sourceTree = "<group>";
 		};
@@ -296,6 +334,7 @@
 				D1A000022FAD000100000002 /* TwinskaraokeUITests.xctest */,
 				D1A000032FAD000100000003 /* Twinskaraoke Watch AppTests.xctest */,
 				D1A000042FAD000100000004 /* Twinskaraoke Watch AppUITests.xctest */,
+				33CB3DD4ECD8C15D69EDD6DE /* Twinskaraoke Mac App.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -303,6 +342,27 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		5DA46CA312C58DE7DB9D897B /* Twinskaraoke Mac App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 82E389AD91C3DCF2095408FE /* Build configuration list for PBXNativeTarget "Twinskaraoke Mac App" */;
+			buildPhases = (
+				AF3FD74579D40D20E2AACBF0 /* Sources */,
+				553C27659840CF311C04C6C8 /* Frameworks */,
+				A9813A5D13F2AE72AE0E8AB2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D0A500002FBD000100000001 /* TwinskaraokeShared */,
+				9C112CB9C663FE29A9452A2F /* TwinskaraokeMacApp */,
+			);
+			name = "Twinskaraoke Mac App";
+			productName = "Twinskaraoke Mac App";
+			productReference = 33CB3DD4ECD8C15D69EDD6DE /* Twinskaraoke Mac App.app */;
+			productType = "com.apple.product-type.application";
+		};
 		D0AA0000000000000000E003 /* Twinskaraoke TV App */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D0AA0000000000000000E007 /* Build configuration list for PBXNativeTarget "Twinskaraoke TV App" */;
@@ -320,8 +380,6 @@
 				D0AA0000000000000000E002 /* TwinskaraokeTVApp */,
 			);
 			name = "Twinskaraoke TV App";
-			packageProductDependencies = (
-			);
 			productName = "Twinskaraoke TV App";
 			productReference = D0AA0000000000000000E00A /* Twinskaraoke TV App.app */;
 			productType = "com.apple.product-type.application";
@@ -343,8 +401,6 @@
 				D0BB0000000000000000E001 /* TwinskaraokeWatchWidgets */,
 			);
 			name = TwinskaraokeWatchWidgets;
-			packageProductDependencies = (
-			);
 			productName = TwinskaraokeWatchWidgets;
 			productReference = D0BB0000000000000000E00A /* TwinskaraokeWatchWidgets.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -395,8 +451,6 @@
 				D1A000052FAD000100000005 /* TwinskaraokeTests */,
 			);
 			name = TwinskaraokeTests;
-			packageProductDependencies = (
-			);
 			productName = TwinskaraokeTests;
 			productReference = D1A000012FAD000100000001 /* TwinskaraokeTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -418,8 +472,6 @@
 				D1A000062FAD000100000006 /* TwinskaraokeUITests */,
 			);
 			name = TwinskaraokeUITests;
-			packageProductDependencies = (
-			);
 			productName = TwinskaraokeUITests;
 			productReference = D1A000022FAD000100000002 /* TwinskaraokeUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -443,8 +495,6 @@
 				D0F981DC2F94C10A00FD69AB /* TwinskaraokeWatchApp */,
 			);
 			name = "Twinskaraoke Watch App";
-			packageProductDependencies = (
-			);
 			productName = "Twinskaraoke Watch App";
 			productReference = D0F981D82F94C10A00FD69AB /* Twinskaraoke Watch App.app */;
 			productType = "com.apple.product-type.application";
@@ -466,8 +516,6 @@
 				D1A000072FAD000100000007 /* TwinskaraokeWatchAppTests */,
 			);
 			name = "Twinskaraoke Watch AppTests";
-			packageProductDependencies = (
-			);
 			productName = "Twinskaraoke Watch AppTests";
 			productReference = D1A000032FAD000100000003 /* Twinskaraoke Watch AppTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -489,8 +537,6 @@
 				D1A000082FAD000100000008 /* TwinskaraokeWatchAppUITests */,
 			);
 			name = "Twinskaraoke Watch AppUITests";
-			packageProductDependencies = (
-			);
 			productName = "Twinskaraoke Watch AppUITests";
 			productReference = D1A000042FAD000100000004 /* Twinskaraoke Watch AppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -566,11 +612,19 @@
 				D0F981F02F94C10B00FD69AB /* Twinskaraoke Watch AppUITests */,
 				D0AA0000000000000000E003 /* Twinskaraoke TV App */,
 				D0BB0000000000000000E003 /* TwinskaraokeWatchWidgets */,
+				5DA46CA312C58DE7DB9D897B /* Twinskaraoke Mac App */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		A9813A5D13F2AE72AE0E8AB2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D0AA0000000000000000E006 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -630,6 +684,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		AF3FD74579D40D20E2AACBF0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D0AA0000000000000000E004 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -722,6 +783,74 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		5B1A014CE7225A17D4464070 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TwinskaraokeMacApp/TwinskaraokeMac.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SXA95NB9A4;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Twinskaraoke;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.magnettileman.Twinskaraoke;
+				PRODUCT_NAME = Twinskaraoke;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		A095B85321C326FB5C8D692E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TwinskaraokeMacApp/TwinskaraokeMac.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SXA95NB9A4;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Twinskaraoke;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.magnettileman.Twinskaraoke;
+				PRODUCT_NAME = Twinskaraoke;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
 		D0AA0000000000000000E008 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1339,6 +1468,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		82E389AD91C3DCF2095408FE /* Build configuration list for PBXNativeTarget "Twinskaraoke Mac App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A095B85321C326FB5C8D692E /* Release */,
+				5B1A014CE7225A17D4464070 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D0AA0000000000000000E007 /* Build configuration list for PBXNativeTarget "Twinskaraoke TV App" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		33CB3DD4ECD8C15D69EDD6DE /* Twinskaraoke Mac App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Twinskaraoke Mac App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CB3DD4ECD8C15D69EDD6DE /* Twinskaraoke Mac App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "Twinskaraoke Mac App.app"; path = Twinskaraoke.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B789992B5FC6B90FC2528F9 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		D0AA0000000000000000E00A /* Twinskaraoke TV App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Twinskaraoke TV App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BB0000000000000000E00A /* TwinskaraokeWatchWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TwinskaraokeWatchWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -159,8 +159,6 @@
 		};
 		D0A500002FBD000100000001 /* TwinskaraokeShared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = TwinskaraokeShared;
 			sourceTree = "<group>";
 		};
@@ -198,29 +196,21 @@
 		};
 		D1A000052FAD000100000005 /* TwinskaraokeTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = TwinskaraokeTests;
 			sourceTree = "<group>";
 		};
 		D1A000062FAD000100000006 /* TwinskaraokeUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = TwinskaraokeUITests;
 			sourceTree = "<group>";
 		};
 		D1A000072FAD000100000007 /* TwinskaraokeWatchAppTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = TwinskaraokeWatchAppTests;
 			sourceTree = "<group>";
 		};
 		D1A000082FAD000100000008 /* TwinskaraokeWatchAppUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = TwinskaraokeWatchAppUITests;
 			sourceTree = "<group>";
 		};
@@ -363,8 +353,8 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				D0A500002FBD000100000001 /* TwinskaraokeShared */,
 				9C112CB9C663FE29A9452A2F /* TwinskaraokeMacApp */,
+				D0A500002FBD000100000001 /* TwinskaraokeShared */,
 			);
 			name = "Twinskaraoke Mac App";
 			productName = "Twinskaraoke Mac App";

--- a/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke Mac App.xcscheme
+++ b/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke Mac App.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
-               BuildableName = "Twinskaraoke Mac App.app"
+               BuildableName = "Twinskaraoke.app"
                BlueprintName = "Twinskaraoke Mac App"
                ReferencedContainer = "container:Twinskaraoke.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
-            BuildableName = "Twinskaraoke Mac App.app"
+            BuildableName = "Twinskaraoke.app"
             BlueprintName = "Twinskaraoke Mac App"
             ReferencedContainer = "container:Twinskaraoke.xcodeproj">
          </BuildableReference>
@@ -54,7 +54,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
-            BuildableName = "Twinskaraoke Mac App.app"
+            BuildableName = "Twinskaraoke.app"
             BlueprintName = "Twinskaraoke Mac App"
             ReferencedContainer = "container:Twinskaraoke.xcodeproj">
          </BuildableReference>
@@ -71,7 +71,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
-            BuildableName = "Twinskaraoke Mac App.app"
+            BuildableName = "Twinskaraoke.app"
             BlueprintName = "Twinskaraoke Mac App"
             ReferencedContainer = "container:Twinskaraoke.xcodeproj">
          </BuildableReference>

--- a/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke Mac App.xcscheme
+++ b/Twinskaraoke.xcodeproj/xcshareddata/xcschemes/Twinskaraoke Mac App.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
+               BuildableName = "Twinskaraoke Mac App.app"
+               BlueprintName = "Twinskaraoke Mac App"
+               ReferencedContainer = "container:Twinskaraoke.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
+            BuildableName = "Twinskaraoke Mac App.app"
+            BlueprintName = "Twinskaraoke Mac App"
+            ReferencedContainer = "container:Twinskaraoke.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
+            BuildableName = "Twinskaraoke Mac App.app"
+            BlueprintName = "Twinskaraoke Mac App"
+            ReferencedContainer = "container:Twinskaraoke.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5DA46CA312C58DE7DB9D897B"
+            BuildableName = "Twinskaraoke Mac App.app"
+            BlueprintName = "Twinskaraoke Mac App"
+            ReferencedContainer = "container:Twinskaraoke.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Twinskaraoke/Models/Account/ProfileModels.swift
+++ b/Twinskaraoke/Models/Account/ProfileModels.swift
@@ -1,54 +1,12 @@
 import Foundation
 import SwiftUI
 
-struct ProfileResponse: Decodable {
-    let profile: Profile
-    let badges: [Badge]?
-}
-
-struct Profile: Decodable {
-    let displayName: String
-    let avatarUrl: String?
-    let level: Int?
-    let levelTitle: String?
-    let totalXP: Int?
-    let totalBadges: Int?
-    let unlockedBadges: Int?
-    let levelProgress: Double?
-    let xpToNextLevel: Int?
-}
-
-struct Badge: Decodable, Identifiable {
-    let id: String
-    let name: String
-    let description: String?
-    let rarity: Int
-    let unlocked: Bool
-    let currentProgress: Int
-    let conditionValue: Int
-    let media: BadgeMedia?
-    var iconURL: URL? {
-        ArtworkURLBuilder.imageURL(
-            cloudflareID: media?.cloudflareId,
-            path: nil,
-            variant: .thumbnail
-        )
-    }
-}
-
-struct BadgeMedia: Decodable {
-    let cloudflareId: String?
-}
-
-struct UploadLimits: Decodable {
-    let maxSongs: Int
-    let maxStorageBytes: Int64
-    let usedStorageBytes: Int64
-    let currentSongCount: Int
-    let currentPlaylistCount: Int
-    let playlistLimit: Int
-    let songPerPlaylistLimit: Int
-}
+// These shapes now live in TwinskaraokeShared/Models/AccountProfile.swift so
+// the Mac and tvOS profile screens decode the same payloads as iOS. The local
+// spellings stay as aliases: they are used across the iOS feature code, and the
+// field lists were already identical, so there is nothing to migrate.
+typealias Profile = UserProfile
+typealias Badge = AccountBadge
 
 enum ProfileTheme {
     static let gradient = LinearGradient(

--- a/TwinskaraokeMacApp/App/ContentView.swift
+++ b/TwinskaraokeMacApp/App/ContentView.swift
@@ -32,6 +32,13 @@ struct ContentView: View {
             await playlists.loadIfNeeded()
             FavoritesManager.shared.loadIfNeeded()
         }
+        // This .task runs once for the window's lifetime, so signing in or out
+        // would otherwise leave the sidebar showing the previous user's
+        // playlists (or the public fallback) until a manual refresh.
+        .onChange(of: auth.isLoggedIn) { _, _ in
+            playlists.invalidate()
+            Task { await playlists.reload() }
+        }
     }
 
     private var sidebar: some View {
@@ -48,6 +55,20 @@ struct ContentView: View {
             Section("Playlists") {
                 if playlists.isLoading && playlists.playlists.isEmpty {
                     ProgressView().controlSize(.small)
+                } else if playlists.playlists.isEmpty, let error = playlists.errorMessage {
+                    // Previously this section just rendered nothing, making a
+                    // failed load indistinguishable from an empty account.
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Button("Try Again") {
+                            Task { await playlists.reload() }
+                        }
+                        .buttonStyle(.link)
+                        .font(.caption)
+                    }
+                    .padding(.vertical, 2)
                 }
                 ForEach(playlists.playlists) { playlist in
                     Label(playlist.name, systemImage: "music.note.list")

--- a/TwinskaraokeMacApp/App/ContentView.swift
+++ b/TwinskaraokeMacApp/App/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum MacDestination: Hashable {
     case home
     case search
+    case library
     case favorites
     case playlist(id: String, name: String)
     case account
@@ -27,17 +28,35 @@ struct ContentView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
         }
+        // Account belongs in the window toolbar, not the sidebar list: the
+        // Playlists section grows without bound, and a sidebar row below it
+        // scrolls out of reach as soon as the user has a dozen playlists.
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    selection = .account
+                } label: {
+                    AccountToolbarIcon(auth: auth)
+                }
+                .help(auth.isLoggedIn ? (auth.username ?? "Account") : "Sign in to Twinskaraoke")
+                .accessibilityLabel(auth.isLoggedIn ? (auth.username ?? "Account") : "Sign In")
+            }
+        }
         .environment(auth)
         .task {
             await playlists.loadIfNeeded()
             FavoritesManager.shared.loadIfNeeded()
+            await auth.refreshAccount()
         }
         // This .task runs once for the window's lifetime, so signing in or out
         // would otherwise leave the sidebar showing the previous user's
         // playlists (or the public fallback) until a manual refresh.
         .onChange(of: auth.isLoggedIn) { _, _ in
             playlists.invalidate()
-            Task { await playlists.reload() }
+            Task {
+                await playlists.reload()
+                await auth.refreshAccount()
+            }
         }
     }
 
@@ -48,13 +67,23 @@ struct ContentView: View {
                     .tag(MacDestination.home)
                 Label("Search", systemImage: "magnifyingglass")
                     .tag(MacDestination.search)
+                Label("Library", systemImage: "books.vertical")
+                    .tag(MacDestination.library)
                 Label("Favourites", systemImage: "heart")
                     .tag(MacDestination.favorites)
             }
 
             Section("Playlists") {
-                if playlists.isLoading && playlists.playlists.isEmpty {
+                if !auth.isLoggedIn {
+                    Text("Sign in to see your playlists")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if playlists.isLoading && playlists.playlists.isEmpty {
                     ProgressView().controlSize(.small)
+                } else if playlists.playlists.isEmpty, playlists.errorMessage == nil {
+                    Text("No playlists yet")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 } else if playlists.playlists.isEmpty, let error = playlists.errorMessage {
                     // Previously this section just rendered nothing, making a
                     // failed load indistinguishable from an empty account.
@@ -75,25 +104,17 @@ struct ContentView: View {
                         .tag(MacDestination.playlist(id: playlist.id, name: playlist.name))
                 }
             }
-
-            Section {
-                Label(auth.isLoggedIn ? (auth.username ?? "Account") : "Sign In",
-                      systemImage: "person.crop.circle")
-                    .tag(MacDestination.account)
+            // Refresh lives here rather than in the toolbar: macOS merges the
+            // sidebar and detail toolbars into one window toolbar, so a second
+            // arrow.clockwise button sat next to the detail view's own refresh.
+            .contextMenu {
+                Button("Refresh Playlists") {
+                    Task { await playlists.reload() }
+                }
             }
         }
         .listStyle(.sidebar)
         .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
-        .toolbar {
-            ToolbarItem {
-                Button {
-                    Task { await playlists.reload() }
-                } label: {
-                    Label("Refresh", systemImage: "arrow.clockwise")
-                }
-                .help("Refresh playlists")
-            }
-        }
     }
 
     @ViewBuilder
@@ -103,6 +124,8 @@ struct ContentView: View {
             HomeView()
         case .search:
             SearchView()
+        case .library:
+            LibraryView(selection: $selection)
         case .favorites:
             FavoritesView()
         case .playlist(let id, let name):

--- a/TwinskaraokeMacApp/App/ContentView.swift
+++ b/TwinskaraokeMacApp/App/ContentView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+enum MacDestination: Hashable {
+    case home
+    case search
+    case favorites
+    case playlist(id: String, name: String)
+    case account
+}
+
+struct ContentView: View {
+    @Environment(MacAudioManager.self) private var audio
+    @State private var auth = MacAuthManager.shared
+    @State private var playlists = MacPlaylistsViewModel()
+    @State private var selection: MacDestination? = .home
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+        } detail: {
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        // The player bar spans the whole window rather than living inside the
+        // detail pane — the Music.app arrangement, and the reason this reads as
+        // a Mac app instead of a resized iPad one.
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            PlayerBar()
+        }
+        .environment(auth)
+        .task {
+            await playlists.loadIfNeeded()
+            FavoritesManager.shared.loadIfNeeded()
+        }
+    }
+
+    private var sidebar: some View {
+        List(selection: $selection) {
+            Section {
+                Label("Home", systemImage: "house")
+                    .tag(MacDestination.home)
+                Label("Search", systemImage: "magnifyingglass")
+                    .tag(MacDestination.search)
+                Label("Favourites", systemImage: "heart")
+                    .tag(MacDestination.favorites)
+            }
+
+            Section("Playlists") {
+                if playlists.isLoading && playlists.playlists.isEmpty {
+                    ProgressView().controlSize(.small)
+                }
+                ForEach(playlists.playlists) { playlist in
+                    Label(playlist.name, systemImage: "music.note.list")
+                        .tag(MacDestination.playlist(id: playlist.id, name: playlist.name))
+                }
+            }
+
+            Section {
+                Label(auth.isLoggedIn ? (auth.username ?? "Account") : "Sign In",
+                      systemImage: "person.crop.circle")
+                    .tag(MacDestination.account)
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    Task { await playlists.reload() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .help("Refresh playlists")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        switch selection {
+        case .home, nil:
+            HomeView()
+        case .search:
+            SearchView()
+        case .favorites:
+            FavoritesView()
+        case .playlist(let id, let name):
+            PlaylistDetailView(playlistID: id, playlistName: name)
+                // Rebuild the view (and its view model) when the selection
+                // moves to a different playlist.
+                .id(id)
+        case .account:
+            AccountView()
+        }
+    }
+}

--- a/TwinskaraokeMacApp/App/TwinskaraokeMacApp.swift
+++ b/TwinskaraokeMacApp/App/TwinskaraokeMacApp.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+@main
+struct TwinskaraokeMacApp: App {
+    @AppStorage(AppLanguage.storageKey) private var languageMode: String = AppLanguage.system.rawValue
+    @State private var audio = MacAudioManager.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.locale, Locale(identifier: resolvedLanguage.localeIdentifier))
+                .environment(audio)
+                .tint(.appAccent)
+                .injectReduceMotion()
+                .frame(minWidth: 900, minHeight: 560)
+        }
+        .defaultSize(width: 1180, height: 760)
+        .commands {
+            // Transport in the menu bar, with the shortcuts Mac users expect
+            // from a media app. This is the main affordance Catalyst couldn't
+            // have given us for free.
+            CommandMenu("Playback") {
+                Button(audio.isPlaying ? "Pause" : "Play") {
+                    audio.togglePlayPause()
+                }
+                .keyboardShortcut(.space, modifiers: [])
+                .disabled(audio.currentSong == nil)
+
+                Button("Next") { audio.playNext() }
+                    .keyboardShortcut(.rightArrow, modifiers: .command)
+                    .disabled(!audio.canPlayNext)
+
+                Button("Previous") { audio.playPrevious() }
+                    .keyboardShortcut(.leftArrow, modifiers: .command)
+                    .disabled(!audio.canPlayPrevious)
+
+                Divider()
+
+                Picker("Repeat Mode", selection: Bindable(audio).playbackMode) {
+                    ForEach(MacPlaybackMode.allCases, id: \.self) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+            }
+        }
+    }
+
+    private var resolvedLanguage: AppLanguage {
+        AppLanguage(rawValue: languageMode) ?? .system
+    }
+}

--- a/TwinskaraokeMacApp/Components/AccountToolbarIcon.swift
+++ b/TwinskaraokeMacApp/Components/AccountToolbarIcon.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Toolbar account button contents: the user's avatar once signed in, falling
+/// back to the system person glyph. Kept small and circular so it reads as an
+/// avatar rather than another toolbar action.
+struct AccountToolbarIcon: View {
+    let auth: MacAuthManager
+
+    private let size: CGFloat = 20
+
+    var body: some View {
+        Group {
+            if auth.isLoggedIn, let url = auth.avatarURL {
+                MacRemoteImage(url: url) { image in
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    fallback
+                }
+                .frame(width: size, height: size)
+                .clipShape(Circle())
+                .overlay(Circle().strokeBorder(.separator, lineWidth: 0.5))
+            } else {
+                fallback
+            }
+        }
+        .frame(width: size, height: size)
+    }
+
+    private var fallback: some View {
+        Image(systemName: auth.isLoggedIn ? "person.crop.circle.fill" : "person.crop.circle")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .foregroundStyle(auth.isLoggedIn ? Color.appAccent : .secondary)
+    }
+}

--- a/TwinskaraokeMacApp/Components/PlayerBar.swift
+++ b/TwinskaraokeMacApp/Components/PlayerBar.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Persistent transport strip pinned to the bottom of the window.
+///
+/// The Mac idiom for a media app, and the deliberate replacement for the iOS
+/// LNPopup miniplayer — that library is iOS/Catalyst-only, and a drag-up popup
+/// would be wrong here regardless.
+struct PlayerBar: View {
+    @Environment(MacAudioManager.self) private var audio
+    @State private var scrubTime: Double?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(spacing: 14) {
+                nowPlaying
+                Spacer(minLength: 12)
+                transport
+                Spacer(minLength: 12)
+                volume
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .background(.bar)
+    }
+
+    // MARK: - Sections
+
+    private var nowPlaying: some View {
+        HStack(spacing: 10) {
+            SongArtwork(url: audio.currentSong?.thumbnailURL, size: 42)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(audio.currentSong?.displayTitle ?? "Nothing Playing")
+                    .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+                Text(audio.currentSong?.displayArtist ?? "—")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(minWidth: 140, alignment: .leading)
+        }
+        .frame(maxWidth: 280, alignment: .leading)
+    }
+
+    private var transport: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 18) {
+                Button { audio.playPrevious() } label: {
+                    Image(systemName: "backward.fill")
+                }
+                .disabled(!audio.canPlayPrevious)
+
+                Button { audio.togglePlayPause() } label: {
+                    Image(systemName: playPauseIcon)
+                        .font(.system(size: 22))
+                }
+                .disabled(audio.currentSong == nil)
+
+                Button { audio.playNext() } label: {
+                    Image(systemName: "forward.fill")
+                }
+                .disabled(!audio.canPlayNext)
+
+                Button { audio.cycleMode() } label: {
+                    Image(systemName: audio.playbackMode.iconName)
+                }
+                .help(audio.playbackMode.label)
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 14))
+
+            scrubber
+        }
+        .frame(maxWidth: 460)
+    }
+
+    private var scrubber: some View {
+        HStack(spacing: 8) {
+            Text(Self.timeText(displayedTime))
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 38, alignment: .trailing)
+
+            Slider(
+                value: Binding(
+                    get: { displayedTime },
+                    set: { scrubTime = $0 }
+                ),
+                in: 0...max(audio.duration, 1),
+                onEditingChanged: { editing in
+                    // Commit on release only: seeking on every drag frame makes
+                    // AVPlayer stutter.
+                    guard !editing, let target = scrubTime else { return }
+                    audio.seek(to: target)
+                    scrubTime = nil
+                }
+            )
+            .controlSize(.mini)
+            .disabled(audio.duration <= 0)
+
+            Text(Self.timeText(audio.duration))
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 38, alignment: .leading)
+        }
+    }
+
+    private var volume: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "speaker.fill")
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+            Slider(value: Bindable(audio).volume, in: 0...1)
+                .controlSize(.mini)
+                .frame(width: 80)
+            Image(systemName: "speaker.wave.3.fill")
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: 160, alignment: .trailing)
+    }
+
+    // MARK: - Helpers
+
+    private var displayedTime: Double {
+        scrubTime ?? audio.currentTime
+    }
+
+    private var playPauseIcon: String {
+        if audio.isLoading { return "hourglass" }
+        return audio.isPlaying ? "pause.circle.fill" : "play.circle.fill"
+    }
+
+    private static func timeText(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "0:00" }
+        let total = Int(seconds.rounded())
+        return String(format: "%d:%02d", total / 60, total % 60)
+    }
+}

--- a/TwinskaraokeMacApp/Components/SongRow.swift
+++ b/TwinskaraokeMacApp/Components/SongRow.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+/// One song line in a list. Double-click or the hover play button starts it in
+/// the context of the list it came from, so the queue matches what's on screen.
+struct SongRow: View {
+    let song: Song
+    let context: [Song]
+
+    @Environment(MacAudioManager.self) private var audio
+    @State private var favorites = FavoritesManager.shared
+    @State private var isHovering = false
+
+    private var isCurrent: Bool { audio.currentSong?.id == song.id }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ZStack {
+                SongArtwork(url: song.rowImageURL, size: 36)
+                if isHovering || isCurrent {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(.black.opacity(0.45))
+                        .frame(width: 36, height: 36)
+                    Image(systemName: isCurrent && audio.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.white)
+                }
+            }
+            .onTapGesture(perform: playOrToggle)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(song.displayTitle)
+                    .font(.system(size: 13, weight: isCurrent ? .semibold : .regular))
+                    .foregroundStyle(isCurrent ? Color.appAccent : .primary)
+                    .lineLimit(1)
+                Text(song.displayArtist)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            Button {
+                favorites.toggle(songID: song.id)
+            } label: {
+                Image(systemName: favorites.isFavorite(song.id) ? "heart.fill" : "heart")
+                    .foregroundStyle(favorites.isFavorite(song.id) ? Color.appAccent : .secondary)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovering || favorites.isFavorite(song.id) ? 1 : 0)
+            .help(favorites.isFavorite(song.id) ? "Remove from favourites" : "Add to favourites")
+
+            Text(song.durationText)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 42, alignment: .trailing)
+        }
+        .padding(.vertical, 3)
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .onTapGesture(count: 2, perform: playOrToggle)
+        .contextMenu {
+            Button("Play") { audio.play(song: song, context: context) }
+            Button(favorites.isFavorite(song.id) ? "Remove from Favourites" : "Add to Favourites") {
+                favorites.toggle(songID: song.id)
+            }
+        }
+    }
+
+    private func playOrToggle() {
+        if isCurrent {
+            audio.togglePlayPause()
+        } else {
+            audio.play(song: song, context: context)
+        }
+    }
+}
+
+/// Shared empty/error/loading presentation so every screen behaves the same.
+struct StateMessage: View {
+    let systemImage: String
+    let title: String
+    var subtitle: String?
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: systemImage)
+                .font(.system(size: 30))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.headline)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(40)
+    }
+}
+
+/// Horizontal artwork shelf used by Home.
+struct SongShelf: View {
+    let title: String
+    let songs: [Song]
+
+    @Environment(MacAudioManager.self) private var audio
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+                .padding(.horizontal, 20)
+
+            ScrollView(.horizontal) {
+                LazyHStack(spacing: 14) {
+                    ForEach(songs) { song in
+                        SongCard(song: song, context: songs)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 4)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+struct SongCard: View {
+    let song: Song
+    let context: [Song]
+
+    @Environment(MacAudioManager.self) private var audio
+    @State private var isHovering = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ZStack {
+                SongArtwork(url: song.imageURL, size: 136, cornerRadius: 8)
+                if isHovering {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(.black.opacity(0.4))
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 34))
+                        .foregroundStyle(.white)
+                }
+            }
+            .frame(width: 136, height: 136)
+
+            Text(song.displayTitle)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+            Text(song.displayArtist)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(width: 136, alignment: .leading)
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .onTapGesture { audio.play(song: song, context: context) }
+    }
+}

--- a/TwinskaraokeMacApp/Components/SongRow.swift
+++ b/TwinskaraokeMacApp/Components/SongRow.swift
@@ -7,7 +7,10 @@ struct SongRow: View {
     let context: [Song]
 
     @Environment(MacAudioManager.self) private var audio
-    @State private var favorites = FavoritesManager.shared
+    // A plain reference, not @State: FavoritesManager is @Observable, so
+    // SwiftUI tracks the properties this body reads. @State implied per-view
+    // ownership of a process-wide singleton, which reads as a local copy.
+    private let favorites = FavoritesManager.shared
     @State private var isHovering = false
 
     private var isCurrent: Bool { audio.currentSong?.id == song.id }
@@ -105,8 +108,6 @@ struct StateMessage: View {
 struct SongShelf: View {
     let title: String
     let songs: [Song]
-
-    @Environment(MacAudioManager.self) private var audio
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/TwinskaraokeMacApp/Features/AccountView.swift
+++ b/TwinskaraokeMacApp/Features/AccountView.swift
@@ -65,6 +65,22 @@ struct AccountView: View {
             .keyboardShortcut(.defaultAction)
             .controlSize(.large)
             .disabled(auth.isLoading || username.isEmpty || password.isEmpty)
+
+            HStack(spacing: 8) {
+                VStack { Divider() }
+                Text("or").font(.caption).foregroundStyle(.secondary)
+                VStack { Divider() }
+            }
+            .frame(width: 280)
+
+            Button {
+                Task { await auth.loginWithDiscord() }
+            } label: {
+                Label("Sign in with Discord", systemImage: "bubble.left.and.bubble.right.fill")
+                    .frame(width: 200)
+            }
+            .controlSize(.large)
+            .disabled(auth.isLoading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(40)

--- a/TwinskaraokeMacApp/Features/AccountView.swift
+++ b/TwinskaraokeMacApp/Features/AccountView.swift
@@ -4,31 +4,66 @@ struct AccountView: View {
     @Environment(MacAuthManager.self) private var auth
     @State private var username = ""
     @State private var password = ""
+    /// QR pairing is the default: it's the fastest path in when the phone app
+    /// is already signed in, same reasoning as tvOS.
+    @State private var usePasswordSignIn = false
 
     var body: some View {
         Group {
             if auth.isLoggedIn {
                 signedIn
-            } else {
+            } else if usePasswordSignIn {
                 signInForm
+            } else {
+                QRSignInPanel(auth: auth) {
+                    usePasswordSignIn = true
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .navigationTitle("Account")
     }
 
     private var signedIn: some View {
-        VStack(spacing: 14) {
-            Image(systemName: "person.crop.circle.fill")
-                .font(.system(size: 54))
-                .foregroundStyle(Color.appAccent)
-            Text(auth.username ?? "Signed in")
-                .font(.title2.weight(.semibold))
-            Button("Sign Out", role: .destructive) {
-                auth.logout()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                ProfileHeader(auth: auth)
+
+                if let error = auth.profileError {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .font(.callout)
+                        .foregroundStyle(.orange)
+                }
+
+                if let limits = auth.uploadLimits {
+                    UploadLimitsSection(limits: limits)
+                }
+
+                if !auth.badges.isEmpty {
+                    BadgesSection(badges: auth.badges)
+                }
+
+                HStack {
+                    Button("Sign Out", role: .destructive) { auth.logout() }
+                    Spacer()
+                    Button {
+                        Task { await auth.refreshAccount() }
+                    } label: {
+                        if auth.isRefreshingProfile {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    .disabled(auth.isRefreshingProfile)
+                }
+                .padding(.top, 4)
             }
-            .controlSize(.large)
+            .padding(24)
+            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: .infinity)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task { await auth.refreshAccount() }
     }
 
     private var signInForm: some View {
@@ -80,6 +115,12 @@ struct AccountView: View {
                     .frame(width: 200)
             }
             .controlSize(.large)
+            .disabled(auth.isLoading)
+
+            Button("Scan a code instead") {
+                usePasswordSignIn = false
+            }
+            .buttonStyle(.link)
             .disabled(auth.isLoading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/TwinskaraokeMacApp/Features/AccountView.swift
+++ b/TwinskaraokeMacApp/Features/AccountView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct AccountView: View {
+    @Environment(MacAuthManager.self) private var auth
+    @State private var username = ""
+    @State private var password = ""
+
+    var body: some View {
+        Group {
+            if auth.isLoggedIn {
+                signedIn
+            } else {
+                signInForm
+            }
+        }
+        .navigationTitle("Account")
+    }
+
+    private var signedIn: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "person.crop.circle.fill")
+                .font(.system(size: 54))
+                .foregroundStyle(Color.appAccent)
+            Text(auth.username ?? "Signed in")
+                .font(.title2.weight(.semibold))
+            Button("Sign Out", role: .destructive) {
+                auth.logout()
+            }
+            .controlSize(.large)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var signInForm: some View {
+        VStack(spacing: 14) {
+            Text("Sign in to Twinskaraoke")
+                .font(.title2.weight(.semibold))
+            Text("Your favourites and playlists follow your account.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 10) {
+                TextField("Username", text: $username)
+                SecureField("Password", text: $password)
+                    .onSubmit(submit)
+            }
+            .textFieldStyle(.roundedBorder)
+            .frame(width: 280)
+
+            if let error = auth.errorMessage {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .frame(width: 280)
+            }
+
+            Button(action: submit) {
+                if auth.isLoading {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text("Sign In").frame(width: 100)
+                }
+            }
+            .keyboardShortcut(.defaultAction)
+            .controlSize(.large)
+            .disabled(auth.isLoading || username.isEmpty || password.isEmpty)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(40)
+    }
+
+    private func submit() {
+        guard !auth.isLoading else { return }
+        Task {
+            await auth.login(username: username, password: password)
+            if auth.isLoggedIn { password = "" }
+        }
+    }
+}

--- a/TwinskaraokeMacApp/Features/HomeView.swift
+++ b/TwinskaraokeMacApp/Features/HomeView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+struct HomeView: View {
+    @State private var model = BrowseViewModel()
+
+    var body: some View {
+        Group {
+            if model.isLoading && model.trending.isEmpty && model.latest.isEmpty {
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = model.errorMessage, model.trending.isEmpty, model.latest.isEmpty {
+                StateMessage(
+                    systemImage: "exclamationmark.triangle",
+                    title: "Couldn't load Home",
+                    subtitle: error
+                )
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        if !model.trending.isEmpty {
+                            SongShelf(title: "Trending This Week", songs: model.trending)
+                        }
+                        if !model.latest.isEmpty {
+                            SongShelf(title: "Latest Releases", songs: model.latest)
+                        }
+                    }
+                    .padding(.vertical, 20)
+                }
+            }
+        }
+        .navigationTitle("Home")
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    Task { await model.reload() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .disabled(model.isLoading)
+            }
+        }
+        .task { await model.loadIfNeeded() }
+    }
+}
+
+struct SearchView: View {
+    @State private var model = MacSearchViewModel()
+    @FocusState private var searchFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search songs or artists", text: Bindable(model).query)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 14))
+                    .focused($searchFocused)
+                    .onChange(of: model.query) { _, _ in model.queryChanged() }
+                if !model.query.isEmpty {
+                    Button { model.clear() } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                if model.isSearching {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            .padding(10)
+            .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .padding(16)
+
+            Divider()
+
+            content
+        }
+        .navigationTitle("Search")
+        .onAppear { searchFocused = true }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let error = model.errorMessage {
+            StateMessage(systemImage: "exclamationmark.triangle", title: "Search failed", subtitle: error)
+        } else if model.query.trimmingCharacters(in: .whitespacesAndNewlines).count < 2 {
+            StateMessage(
+                systemImage: "magnifyingglass",
+                title: "Search Twinskaraoke",
+                subtitle: "Type at least two characters to find songs."
+            )
+        } else if model.results.isEmpty && !model.isSearching {
+            StateMessage(systemImage: "questionmark.circle", title: "No results")
+        } else {
+            List(model.results) { song in
+                SongRow(song: song, context: model.results)
+            }
+            .listStyle(.inset)
+        }
+    }
+}
+
+struct FavoritesView: View {
+    @State private var model = MacFavoritesViewModel()
+    @Environment(MacAuthManager.self) private var auth
+
+    var body: some View {
+        Group {
+            if !auth.isLoggedIn {
+                StateMessage(
+                    systemImage: "person.crop.circle.badge.questionmark",
+                    title: "Sign in to see favourites",
+                    subtitle: "Your favourites sync with your Twinskaraoke account."
+                )
+            } else if model.isLoading && model.songs.isEmpty {
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = model.errorMessage, model.songs.isEmpty {
+                StateMessage(systemImage: "exclamationmark.triangle", title: "Couldn't load", subtitle: error)
+            } else if model.songs.isEmpty {
+                StateMessage(
+                    systemImage: "heart",
+                    title: "No favourites yet",
+                    subtitle: "Songs you favourite will show up here."
+                )
+            } else {
+                List(model.songs) { song in
+                    SongRow(song: song, context: model.songs)
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle("Favourites")
+        .task { if auth.isLoggedIn { await model.reload() } }
+    }
+}
+
+struct PlaylistDetailView: View {
+    let playlistID: String
+    let playlistName: String
+
+    @State private var model = MacPlaylistDetailViewModel()
+
+    var body: some View {
+        Group {
+            if model.isLoading && model.songs.isEmpty {
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = model.errorMessage, model.songs.isEmpty {
+                StateMessage(systemImage: "exclamationmark.triangle", title: "Couldn't load", subtitle: error)
+            } else if model.songs.isEmpty {
+                StateMessage(systemImage: "music.note.list", title: "This playlist is empty")
+            } else {
+                List(model.songs) { song in
+                    SongRow(song: song, context: model.songs)
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle(playlistName)
+        .task { await model.load(playlistID: playlistID) }
+    }
+}

--- a/TwinskaraokeMacApp/Features/LibraryView.swift
+++ b/TwinskaraokeMacApp/Features/LibraryView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Browse public playlists.
+///
+/// These used to be poured into the sidebar's Playlists section as a signed-out
+/// fallback, which pushed everything else out of reach. A grid in the detail
+/// pane is where a hundred playlists actually belong.
+struct LibraryView: View {
+    @State private var model = MacLibraryViewModel()
+    @Binding var selection: MacDestination?
+
+    private let columns = [GridItem(.adaptive(minimum: 150, maximum: 200), spacing: 16)]
+
+    var body: some View {
+        Group {
+            if model.isLoading && model.playlists.isEmpty {
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = model.errorMessage, model.playlists.isEmpty {
+                StateMessage(
+                    systemImage: "exclamationmark.triangle",
+                    title: "Couldn't load the library",
+                    subtitle: error
+                )
+            } else if model.playlists.isEmpty {
+                StateMessage(systemImage: "books.vertical", title: "Nothing here yet")
+            } else {
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 18) {
+                        ForEach(model.playlists) { playlist in
+                            PlaylistCard(playlist: playlist) {
+                                selection = .playlist(id: playlist.id, name: playlist.name)
+                            }
+                        }
+                    }
+                    .padding(20)
+                }
+            }
+        }
+        .navigationTitle("Library")
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    Task { await model.reload() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .disabled(model.isLoading)
+            }
+        }
+        .task { await model.loadIfNeeded() }
+    }
+}
+
+struct PlaylistCard: View {
+    let playlist: Playlist
+    let onOpen: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ZStack {
+                SongArtwork(url: playlist.imageURL, size: 150, cornerRadius: 8)
+                if isHovering {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(.black.opacity(0.35))
+                    Image(systemName: "arrow.right.circle.fill")
+                        .font(.system(size: 30))
+                        .foregroundStyle(.white)
+                }
+            }
+            .frame(width: 150, height: 150)
+
+            Text(playlist.name)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+            Text(playlist.songCountText)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: 150, alignment: .leading)
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .onTapGesture(perform: onOpen)
+        .help(playlist.name)
+    }
+}

--- a/TwinskaraokeMacApp/Features/LibraryView.swift
+++ b/TwinskaraokeMacApp/Features/LibraryView.swift
@@ -58,30 +58,35 @@ struct PlaylistCard: View {
     @State private var isHovering = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            ZStack {
-                SongArtwork(url: playlist.imageURL, size: 150, cornerRadius: 8)
-                if isHovering {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(.black.opacity(0.35))
-                    Image(systemName: "arrow.right.circle.fill")
-                        .font(.system(size: 30))
-                        .foregroundStyle(.white)
+        // A Button rather than onTapGesture: tap gestures are pointer-only, so
+        // the cards were unreachable by keyboard.
+        Button(action: onOpen) {
+            VStack(alignment: .leading, spacing: 6) {
+                ZStack {
+                    SongArtwork(url: playlist.imageURL, size: 150, cornerRadius: 8)
+                    if isHovering {
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(.black.opacity(0.35))
+                        Image(systemName: "arrow.right.circle.fill")
+                            .font(.system(size: 30))
+                            .foregroundStyle(.white)
+                    }
                 }
-            }
-            .frame(width: 150, height: 150)
+                .frame(width: 150, height: 150)
 
-            Text(playlist.name)
-                .font(.system(size: 12, weight: .medium))
-                .lineLimit(1)
-            Text(playlist.songCountText)
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
+                Text(playlist.name)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                Text(playlist.songCountText)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 150, alignment: .leading)
+            .contentShape(Rectangle())
         }
-        .frame(width: 150, alignment: .leading)
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
         .onHover { isHovering = $0 }
-        .onTapGesture(perform: onOpen)
         .help(playlist.name)
+        .accessibilityLabel("\(playlist.name), \(playlist.songCountText)")
     }
 }

--- a/TwinskaraokeMacApp/Features/ProfileSections.swift
+++ b/TwinskaraokeMacApp/Features/ProfileSections.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+/// Avatar, display name, level and XP progress. Mirrors the tvOS
+/// `profileHeader`, laid out horizontally for a Mac window.
+struct ProfileHeader: View {
+    let auth: MacAuthManager
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 18) {
+            avatar
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(auth.profile?.displayName ?? auth.username ?? "Signed in")
+                    .font(.title2.weight(.semibold))
+
+                HStack(spacing: 10) {
+                    if let level = auth.profile?.level {
+                        Text("Level \(level)")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Color.appAccent)
+                    }
+                    if let title = auth.profile?.levelTitle, !title.isEmpty {
+                        Text(title)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let totalXP = auth.profile?.totalXP {
+                    Text("\(totalXP.formatted()) XP")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let progress = auth.profile?.levelProgress {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ProgressView(value: min(max(progress, 0), 1))
+                            .progressViewStyle(.linear)
+                            .tint(.appAccent)
+                            .frame(maxWidth: 320)
+                        if let xp = auth.profile?.xpToNextLevel {
+                            Text("\(xp.formatted()) XP to next level")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if auth.profile == nil, auth.isRefreshingProfile {
+                    ProgressView().controlSize(.small)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var avatar: some View {
+        Group {
+            if let url = auth.avatarURL {
+                MacRemoteImage(url: url) { image in
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    placeholderAvatar
+                }
+            } else {
+                placeholderAvatar
+            }
+        }
+        .frame(width: 72, height: 72)
+        .clipShape(Circle())
+        .overlay(Circle().strokeBorder(.separator, lineWidth: 1))
+    }
+
+    private var placeholderAvatar: some View {
+        Circle()
+            .fill(Color.secondary.opacity(0.15))
+            .overlay {
+                Image(systemName: "person.crop.circle.fill")
+                    .font(.system(size: 34))
+                    .foregroundStyle(.secondary)
+            }
+    }
+}
+
+struct UploadLimitsSection: View {
+    let limits: UploadLimits
+
+    private let columns = [GridItem(.adaptive(minimum: 150), spacing: 12)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Upload Limits")
+                .font(.headline)
+
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+                metric("Songs", "\(limits.currentSongCount) / \(limits.maxSongs)")
+                metric("Storage", "\(Self.bytes(limits.usedStorageBytes)) / \(Self.bytes(limits.maxStorageBytes))")
+                metric("Playlists", "\(limits.currentPlaylistCount) / \(limits.playlistLimit)")
+                metric("Songs per playlist", "\(limits.songPerPlaylistLimit)")
+            }
+        }
+    }
+
+    private func metric(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private static func bytes(_ count: Int64) -> String {
+        // allowsNonnumericFormatting defaults to true, which renders 0 as
+        // "Zero KB" — reads as a bug next to "1 GB".
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        formatter.allowsNonnumericFormatting = false
+        return formatter.string(fromByteCount: count)
+    }
+}
+
+struct BadgesSection: View {
+    let badges: [AccountBadge]
+
+    private let columns = [GridItem(.adaptive(minimum: 96, maximum: 130), spacing: 14)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Badges").font(.headline)
+                Text("\(badges.filter(\.unlocked).count) of \(badges.count) unlocked")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            LazyVGrid(columns: columns, spacing: 14) {
+                ForEach(badges) { badge in
+                    BadgeCard(badge: badge)
+                }
+            }
+        }
+    }
+}
+
+struct BadgeCard: View {
+    let badge: AccountBadge
+
+    var body: some View {
+        VStack(spacing: 6) {
+            MacRemoteImage(url: badge.iconURL) { image in
+                image.resizable().aspectRatio(contentMode: .fit)
+            } placeholder: {
+                Image(systemName: "rosette")
+                    .font(.system(size: 24))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 52, height: 52)
+            // Locked badges are dimmed and desaturated rather than hidden, so
+            // there's something to aim for.
+            .saturation(badge.unlocked ? 1 : 0)
+            .opacity(badge.unlocked ? 1 : 0.35)
+
+            Text(badge.name)
+                .font(.caption)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .foregroundStyle(badge.unlocked ? .primary : .secondary)
+
+            if !badge.unlocked, badge.conditionValue > 0 {
+                Text("\(badge.currentProgress)/\(badge.conditionValue)")
+                    .font(.system(size: 10, design: .rounded))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .help(badge.description ?? badge.name)
+    }
+}

--- a/TwinskaraokeMacApp/Features/QRSignInPanel.swift
+++ b/TwinskaraokeMacApp/Features/QRSignInPanel.swift
@@ -1,0 +1,172 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+
+/// Pairing half of the Mac sign-in screen: renders the current pairing code and
+/// reflects `MacAuthManager.qrPhase` while a signed-in phone approves it.
+///
+/// Mirrors `TVQRSignInPanel`, scaled down — a Mac window is closer than a TV
+/// across the room, so the code doesn't need to be 320pt.
+struct QRSignInPanel: View {
+    let auth: MacAuthManager
+    let onUsePassword: () -> Void
+
+    private let codeSize: CGFloat = 200
+
+    var body: some View {
+        VStack(spacing: 16) {
+            codeArea
+                .frame(width: codeSize, height: codeSize)
+
+            statusText
+
+            VStack(spacing: 8) {
+                if auth.qrPhase == .expired || auth.qrError != nil {
+                    Button {
+                        auth.startQRSignIn()
+                    } label: {
+                        Label("New Code", systemImage: "arrow.clockwise")
+                    }
+                    .controlSize(.large)
+                }
+
+                Button("Sign in with password instead") {
+                    // Choosing password sign-in retires the code: otherwise an
+                    // already-scanned code could complete authentication behind
+                    // a user who opted out of pairing.
+                    auth.cancelQRSignIn()
+                    onUsePassword()
+                }
+                .buttonStyle(.link)
+            }
+        }
+        .padding(28)
+        .task {
+            // Only mint a code if there isn't a live one; re-opening the pane
+            // shouldn't invalidate a code someone is mid-scan on.
+            if auth.qrSession == nil, auth.qrPhase == .idle {
+                auth.startQRSignIn()
+            }
+        }
+        .onDisappear {
+            // Ordinary navigation away leaves a live code alone so the phone
+            // can approve it off-screen. Sessions end on their own via approval
+            // or expiry, so nothing leaks by waiting.
+            switch auth.qrPhase {
+            case .waiting, .completing:
+                break
+            case .idle, .creating, .expired:
+                auth.cancelQRSignIn()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var codeArea: some View {
+        switch auth.qrPhase {
+        case .waiting, .completing:
+            if let session = auth.qrSession, let image = Self.qrImage(for: session.payload) {
+                Image(decorative: image, scale: 1, orientation: .up)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(12)
+                    .background(.white, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .opacity(auth.qrPhase == .completing ? 0.35 : 1)
+                    .overlay {
+                        if auth.qrPhase == .completing {
+                            ProgressView()
+                        }
+                    }
+                    .animation(.easeOut(duration: 0.2), value: auth.qrPhase)
+            } else {
+                placeholder { ProgressView() }
+            }
+
+        case .expired:
+            placeholder {
+                VStack(spacing: 8) {
+                    Image(systemName: "clock.badge.xmark")
+                        .font(.system(size: 30, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    Text("Code expired").font(.headline)
+                }
+            }
+
+        case .idle, .creating:
+            placeholder {
+                if auth.qrError == nil {
+                    ProgressView()
+                } else {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 28, weight: .semibold))
+                        .foregroundStyle(.orange)
+                }
+            }
+        }
+    }
+
+    private func placeholder(@ViewBuilder content: () -> some View) -> some View {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(Color.secondary.opacity(0.12))
+            .overlay { content() }
+    }
+
+    @ViewBuilder
+    private var statusText: some View {
+        if let error = auth.qrError {
+            Label(error, systemImage: "exclamationmark.triangle.fill")
+                .font(.subheadline)
+                .foregroundStyle(.orange)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 280)
+        } else {
+            VStack(spacing: 6) {
+                Text(headline)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+
+                if auth.qrPhase == .waiting, let session = auth.qrSession {
+                    Text(session.shortCode)
+                        .font(.system(size: 20, weight: .bold, design: .monospaced))
+                        .tracking(4)
+                        .foregroundStyle(Color.appAccent)
+                        .textSelection(.enabled)
+                    Text("Check this matches the code on your phone before approving.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: 280)
+                }
+            }
+        }
+    }
+
+    private var headline: String {
+        switch auth.qrPhase {
+        case .idle, .creating: "Preparing your sign-in code…"
+        case .waiting: "Scan with the Twinskaraoke app"
+        case .completing: "Signing you in…"
+        case .expired: "That code timed out for security. Get a new one."
+        }
+    }
+
+    // MARK: - QR rendering
+
+    private static let ciContext = CIContext(options: nil)
+
+    /// Rendered at native module size and scaled with nearest-neighbour so the
+    /// code stays crisp on a Retina display instead of being interpolated.
+    private static func qrImage(for payload: String) -> CGImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(payload.utf8)
+        filter.correctionLevel = "M"
+        guard let output = filter.outputImage else { return nil }
+
+        let scale = 12.0
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        return ciContext.createCGImage(scaled, from: scaled.extent)
+    }
+}

--- a/TwinskaraokeMacApp/Info.plist
+++ b/TwinskaraokeMacApp/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Partial plist: GENERATE_INFOPLIST_FILE stays on and Xcode merges the
+	     generated keys over this base. Only keys with no INFOPLIST_KEY_ build
+	     setting equivalent belong here — CFBundleURLTypes is an array of
+	     dictionaries and cannot be expressed as a build setting. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>org.magnettileman.Twinskaraoke.auth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<!-- Discord OAuth redirects to neurokaraoke://auth. Without this
+				     registration ASWebAuthenticationSession never gets the
+				     callback and sign-in hangs on the consent screen. -->
+				<string>neurokaraoke</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/TwinskaraokeMacApp/Models/BrowseViewModel.swift
+++ b/TwinskaraokeMacApp/Models/BrowseViewModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Observation
+
+/// Backs the Home screen: a trending shelf and a latest-releases shelf.
+@MainActor
+@Observable
+final class BrowseViewModel {
+    private(set) var trending: [Song] = []
+    private(set) var latest: [Song] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private var hasLoaded = false
+
+    func loadIfNeeded() async {
+        guard !hasLoaded else { return }
+        await reload()
+    }
+
+    func reload() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        // Kick both off together, then unwrap each separately: one shelf
+        // failing shouldn't blank the other.
+        async let trendingTask = KaraokeAPIClient.trendingSongs(days: 7, take: 24)
+        async let latestTask = KaraokeAPIClient.latestReleases(pageSize: 48, take: 24)
+
+        do {
+            trending = try await trendingTask
+        } catch {
+            noteFailure(error)
+        }
+        do {
+            latest = try await latestTask
+        } catch {
+            noteFailure(error)
+        }
+
+        hasLoaded = !trending.isEmpty || !latest.isEmpty
+    }
+
+    private func noteFailure(_ error: Error) {
+        guard !(error is CancellationError), errorMessage == nil else { return }
+        errorMessage = "Couldn't load songs. Check your connection and try again."
+    }
+}

--- a/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
+++ b/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
@@ -7,6 +7,9 @@ final class MacPlaylistsViewModel {
     private(set) var playlists: [Playlist] = []
     private(set) var isLoading = false
     private(set) var errorMessage: String?
+    /// True when the list is public playlists rather than the user's own,
+    /// so callers can tell "signed out" apart from "you have no playlists".
+    private(set) var isShowingPublicFallback = false
 
     private var hasLoaded = false
 
@@ -19,19 +22,44 @@ final class MacPlaylistsViewModel {
         isLoading = true
         errorMessage = nil
         defer { isLoading = false }
+
+        // /api/playlists is auth-only and 401s when signed out. Mirror
+        // HomeViewModel.fetchTopPicks: fall back to the public list so the
+        // always-visible sidebar has something browsable either way.
+        let own = try? await KaraokeAPIClient.playlists(
+            startIndex: 0,
+            pageSize: 60,
+            isSetlist: false,
+            sortDescending: true
+        )
+        if let own, !own.isEmpty {
+            playlists = own
+            isShowingPublicFallback = false
+            hasLoaded = true
+            return
+        }
+
         do {
-            playlists = try await KaraokeAPIClient.playlists(
+            playlists = try await KaraokeAPIClient.publicPlaylists(
                 startIndex: 0,
-                pageSize: 60,
-                isSetlist: false,
-                sortDescending: true
+                pageSize: 60
             )
+            isShowingPublicFallback = true
             hasLoaded = true
         } catch is CancellationError {
             return
         } catch {
+            // Only surface an error if we have nothing at all to show.
+            playlists = []
             errorMessage = "Couldn't load playlists."
         }
+    }
+
+    /// Called when the signed-in user changes: their playlists are a different
+    /// set, so drop the cached load and fetch again.
+    func invalidate() {
+        hasLoaded = false
+        isShowingPublicFallback = false
     }
 }
 

--- a/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
+++ b/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
@@ -9,6 +9,11 @@ final class MacPlaylistsViewModel {
     private(set) var errorMessage: String?
 
     private var hasLoaded = false
+    /// Bumped by `invalidate()`. A response carrying a stale generation is
+    /// discarded rather than assigned — without this, a slow request issued for
+    /// the previous account could land after a switch and show one user's
+    /// private playlists to the next.
+    private var generation = 0
 
     func loadIfNeeded() async {
         guard !hasLoaded else { return }
@@ -19,9 +24,12 @@ final class MacPlaylistsViewModel {
     /// playlists used to fall back into this list, which buried the rest of the
     /// sidebar under dozens of rows nobody asked for — they live in Library now.
     func reload() async {
+        let requestGeneration = generation
         isLoading = true
         errorMessage = nil
-        defer { isLoading = false }
+        defer {
+            if requestGeneration == generation { isLoading = false }
+        }
 
         guard CredentialStore.isAuthenticated else {
             playlists = []
@@ -30,25 +38,32 @@ final class MacPlaylistsViewModel {
         }
 
         do {
-            playlists = try await KaraokeAPIClient.playlists(
+            let loaded = try await KaraokeAPIClient.playlists(
                 startIndex: 0,
                 pageSize: 60,
                 isSetlist: false,
                 sortDescending: true
             )
+            guard requestGeneration == generation else { return }
+            playlists = loaded
             hasLoaded = true
         } catch is CancellationError {
             return
         } catch {
+            guard requestGeneration == generation else { return }
             playlists = []
             errorMessage = "Couldn't load your playlists."
         }
     }
 
     /// Called when the signed-in user changes: their playlists are a different
-    /// set, so drop the cached load and fetch again.
+    /// set, so drop the cached load, clear what's on screen, and reject any
+    /// response still in flight for the previous account.
     func invalidate() {
         hasLoaded = false
+        generation &+= 1
+        playlists = []
+        errorMessage = nil
     }
 }
 

--- a/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
+++ b/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class MacPlaylistsViewModel {
+    private(set) var playlists: [Playlist] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private var hasLoaded = false
+
+    func loadIfNeeded() async {
+        guard !hasLoaded else { return }
+        await reload()
+    }
+
+    func reload() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            playlists = try await KaraokeAPIClient.playlists(
+                startIndex: 0,
+                pageSize: 60,
+                isSetlist: false,
+                sortDescending: true
+            )
+            hasLoaded = true
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = "Couldn't load playlists."
+        }
+    }
+}
+
+/// Songs for one playlist, loaded on demand when a playlist is opened.
+@MainActor
+@Observable
+final class MacPlaylistDetailViewModel {
+    private(set) var songs: [Song] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private var loadedID: String?
+
+    func load(playlistID: String) async {
+        guard loadedID != playlistID else { return }
+        isLoading = true
+        errorMessage = nil
+        songs = []
+        defer { isLoading = false }
+        do {
+            songs = try await KaraokeAPIClient.playlistSongs(id: playlistID)
+            loadedID = playlistID
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = "Couldn't load this playlist."
+        }
+    }
+}
+
+/// The signed-in user's favourites, shown as its own sidebar destination.
+@MainActor
+@Observable
+final class MacFavoritesViewModel {
+    private(set) var songs: [Song] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    func reload() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            songs = try await KaraokeAPIClient.favoriteSongs()
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = "Couldn't load your favourites."
+        }
+    }
+}

--- a/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
+++ b/TwinskaraokeMacApp/Models/PlaylistsViewModel.swift
@@ -7,9 +7,59 @@ final class MacPlaylistsViewModel {
     private(set) var playlists: [Playlist] = []
     private(set) var isLoading = false
     private(set) var errorMessage: String?
-    /// True when the list is public playlists rather than the user's own,
-    /// so callers can tell "signed out" apart from "you have no playlists".
-    private(set) var isShowingPublicFallback = false
+
+    private var hasLoaded = false
+
+    func loadIfNeeded() async {
+        guard !hasLoaded else { return }
+        await reload()
+    }
+
+    /// The sidebar lists only the signed-in user's own playlists. Public
+    /// playlists used to fall back into this list, which buried the rest of the
+    /// sidebar under dozens of rows nobody asked for — they live in Library now.
+    func reload() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        guard CredentialStore.isAuthenticated else {
+            playlists = []
+            hasLoaded = true
+            return
+        }
+
+        do {
+            playlists = try await KaraokeAPIClient.playlists(
+                startIndex: 0,
+                pageSize: 60,
+                isSetlist: false,
+                sortDescending: true
+            )
+            hasLoaded = true
+        } catch is CancellationError {
+            return
+        } catch {
+            playlists = []
+            errorMessage = "Couldn't load your playlists."
+        }
+    }
+
+    /// Called when the signed-in user changes: their playlists are a different
+    /// set, so drop the cached load and fetch again.
+    func invalidate() {
+        hasLoaded = false
+    }
+}
+
+/// Public playlists, shown in Library. Available signed out, which is why it's
+/// separate from the user's own list rather than a fallback inside it.
+@MainActor
+@Observable
+final class MacLibraryViewModel {
+    private(set) var playlists: [Playlist] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
 
     private var hasLoaded = false
 
@@ -22,44 +72,17 @@ final class MacPlaylistsViewModel {
         isLoading = true
         errorMessage = nil
         defer { isLoading = false }
-
-        // /api/playlists is auth-only and 401s when signed out. Mirror
-        // HomeViewModel.fetchTopPicks: fall back to the public list so the
-        // always-visible sidebar has something browsable either way.
-        let own = try? await KaraokeAPIClient.playlists(
-            startIndex: 0,
-            pageSize: 60,
-            isSetlist: false,
-            sortDescending: true
-        )
-        if let own, !own.isEmpty {
-            playlists = own
-            isShowingPublicFallback = false
-            hasLoaded = true
-            return
-        }
-
         do {
             playlists = try await KaraokeAPIClient.publicPlaylists(
                 startIndex: 0,
-                pageSize: 60
+                pageSize: 100
             )
-            isShowingPublicFallback = true
             hasLoaded = true
         } catch is CancellationError {
             return
         } catch {
-            // Only surface an error if we have nothing at all to show.
-            playlists = []
-            errorMessage = "Couldn't load playlists."
+            errorMessage = "Couldn't load the library."
         }
-    }
-
-    /// Called when the signed-in user changes: their playlists are a different
-    /// set, so drop the cached load and fetch again.
-    func invalidate() {
-        hasLoaded = false
-        isShowingPublicFallback = false
     }
 }
 

--- a/TwinskaraokeMacApp/Models/SearchViewModel.swift
+++ b/TwinskaraokeMacApp/Models/SearchViewModel.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class MacSearchViewModel {
+    var query = ""
+    private(set) var results: [Song] = []
+    private(set) var isSearching = false
+    private(set) var errorMessage: String?
+
+    private var searchTask: Task<Void, Never>?
+    private static let debounce = Duration.milliseconds(300)
+
+    /// Debounced so typing doesn't fire a request per keystroke. Cancelling the
+    /// previous task also cancels its in-flight URLSession work.
+    func queryChanged() {
+        searchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard trimmed.count >= 2 else {
+            results = []
+            errorMessage = nil
+            isSearching = false
+            return
+        }
+
+        searchTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.debounce)
+            guard !Task.isCancelled else { return }
+            await self?.performSearch(trimmed)
+        }
+    }
+
+    private func performSearch(_ text: String) async {
+        isSearching = true
+        errorMessage = nil
+        defer { isSearching = false }
+        do {
+            let songs = try await KaraokeAPIClient.searchSongs(query: text, pageSize: 50)
+            guard !Task.isCancelled else { return }
+            results = songs
+        } catch is CancellationError {
+            return
+        } catch {
+            results = []
+            errorMessage = "Search failed. Please try again."
+        }
+    }
+
+    func clear() {
+        searchTask?.cancel()
+        query = ""
+        results = []
+        errorMessage = nil
+    }
+}

--- a/TwinskaraokeMacApp/Services/MacAudioManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAudioManager.swift
@@ -1,0 +1,331 @@
+import AVFoundation
+import Foundation
+import MediaPlayer
+import Observation
+import SwiftUI
+
+enum MacPlaybackMode: String, CaseIterable {
+    case listLoop
+    case songLoop
+    case shuffle
+
+    var iconName: String {
+        switch self {
+        case .listLoop: "repeat"
+        case .songLoop: "repeat.1"
+        case .shuffle: "shuffle"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .listLoop: "Repeat All"
+        case .songLoop: "Repeat One"
+        case .shuffle: "Shuffle"
+        }
+    }
+}
+
+/// Playback for the Mac app.
+///
+/// Deliberately not a port of the tvOS `AudioManager`: everything here that
+/// differs from that file is because `AVAudioSession` does not exist on macOS.
+/// There is no category to set, no session to activate, and no interruption
+/// notification — the system mixes and ducks apps itself. What survives the
+/// platform change is `AVPlayer` plus the `MediaPlayer` now-playing/remote
+/// command surface, both of which are fully supported natively.
+@MainActor
+@Observable
+final class MacAudioManager {
+    static let shared = MacAudioManager()
+
+    private(set) var currentSong: Song?
+    private(set) var isPlaying = false
+    private(set) var isLoading = false
+    private(set) var playbackError: String?
+    var currentTime: Double = 0
+    private(set) var duration: Double = 0
+    private(set) var queue: [Song] = []
+    private(set) var currentIndex = 0
+    var playbackMode: MacPlaybackMode = .listLoop
+    var volume: Float = 1.0 {
+        didSet { player?.volume = volume }
+    }
+
+    private var player: AVPlayer?
+    private var timeObserver: Any?
+    private var endObserver: NSObjectProtocol?
+    private var statusObservation: NSKeyValueObservation?
+    /// Indices that failed to load, so a broken queue can't spin forever.
+    private var failedIndices: Set<Int> = []
+
+    private init() {
+        configureRemoteCommands()
+    }
+
+    var progress: Double {
+        guard duration > 0 else { return 0 }
+        return min(max(currentTime / duration, 0), 1)
+    }
+
+    var upNext: [Song] {
+        guard !queue.isEmpty, currentIndex + 1 < queue.count else { return [] }
+        return Array(queue[(currentIndex + 1)...])
+    }
+
+    var canPlayNext: Bool { !queue.isEmpty }
+    var canPlayPrevious: Bool { !queue.isEmpty }
+
+    // MARK: - Transport
+
+    func play(song: Song, context: [Song] = []) {
+        let playbackQueue = context.isEmpty ? [song] : context
+        let index = playbackQueue.firstIndex { $0.id == song.id } ?? 0
+        queue = playbackQueue
+        currentIndex = index
+        failedIndices.removeAll()
+        startCurrent()
+    }
+
+    func togglePlayPause() {
+        guard player != nil else {
+            if let song = currentSong { play(song: song, context: queue) }
+            return
+        }
+        isPlaying ? pause() : resume()
+    }
+
+    func pause() {
+        player?.pause()
+        isPlaying = false
+        updateNowPlayingPlaybackState()
+    }
+
+    func resume() {
+        guard let player else { return }
+        player.play()
+        isPlaying = true
+        updateNowPlayingPlaybackState()
+    }
+
+    func playNext() {
+        guard !queue.isEmpty else { return }
+        switch playbackMode {
+        case .shuffle:
+            currentIndex = randomIndex(excluding: queue.count > 1 ? currentIndex : nil)
+        case .listLoop, .songLoop:
+            currentIndex = (currentIndex + 1) % queue.count
+        }
+        startCurrent()
+    }
+
+    func playPrevious() {
+        guard !queue.isEmpty else { return }
+        // Match the platform convention: past ~3s, restart the track instead
+        // of leaving the song.
+        if currentTime > 3 {
+            seek(to: 0)
+            return
+        }
+        currentIndex = currentIndex == 0 ? queue.count - 1 : currentIndex - 1
+        startCurrent()
+    }
+
+    func seek(to seconds: Double) {
+        guard let player, duration > 0 else { return }
+        let clamped = min(max(seconds, 0), duration)
+        player.seek(to: CMTime(seconds: clamped, preferredTimescale: 600)) { [weak self] _ in
+            Task { @MainActor in
+                self?.currentTime = clamped
+                self?.updateNowPlayingPlaybackState()
+            }
+        }
+    }
+
+    func cycleMode() {
+        let modes = MacPlaybackMode.allCases
+        let next = (modes.firstIndex(of: playbackMode).map { $0 + 1 } ?? 0) % modes.count
+        playbackMode = modes[next]
+    }
+
+    // MARK: - Loading
+
+    private func startCurrent() {
+        guard queue.indices.contains(currentIndex) else { return }
+        let song = queue[currentIndex]
+        currentSong = song
+        playbackError = nil
+
+        guard let url = song.audioURL else {
+            handleFailure("This song has no playable audio.")
+            return
+        }
+
+        teardownPlayer()
+        isLoading = true
+        currentTime = 0
+        duration = 0
+
+        let item = AVPlayerItem(url: url)
+        let player = AVPlayer(playerItem: item)
+        player.volume = volume
+        self.player = player
+
+        statusObservation = item.observe(\.status, options: [.new]) { [weak self] item, _ in
+            Task { @MainActor in
+                guard let self else { return }
+                switch item.status {
+                case .readyToPlay:
+                    self.isLoading = false
+                    self.failedIndices.remove(self.currentIndex)
+                    let seconds = item.duration.seconds
+                    self.duration = seconds.isFinite ? seconds : 0
+                    player.play()
+                    self.isPlaying = true
+                    self.updateNowPlayingInfo()
+                case .failed:
+                    self.handleFailure(item.error?.localizedDescription ?? "Couldn't play this song.")
+                default:
+                    break
+                }
+            }
+        }
+
+        timeObserver = player.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 0.25, preferredTimescale: 600),
+            queue: .main
+        ) { [weak self] time in
+            Task { @MainActor in
+                guard let self else { return }
+                self.currentTime = time.seconds.isFinite ? time.seconds : 0
+                if self.duration == 0, let itemDuration = self.player?.currentItem?.duration.seconds,
+                   itemDuration.isFinite, itemDuration > 0 {
+                    self.duration = itemDuration
+                }
+            }
+        }
+
+        endObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.handleReachedEnd() }
+        }
+    }
+
+    private func handleReachedEnd() {
+        if playbackMode == .songLoop {
+            seek(to: 0)
+            resume()
+            return
+        }
+        // Single-song queue with no loop: stop rather than restart.
+        if queue.count <= 1, playbackMode != .shuffle {
+            isPlaying = false
+            currentTime = 0
+            updateNowPlayingPlaybackState()
+            return
+        }
+        playNext()
+    }
+
+    private func handleFailure(_ message: String) {
+        isLoading = false
+        isPlaying = false
+        playbackError = message
+        failedIndices.insert(currentIndex)
+        // Every remaining track failed — stop instead of cycling the queue.
+        guard failedIndices.count < queue.count, queue.count > 1 else { return }
+        playNext()
+    }
+
+    private func randomIndex(excluding excluded: Int?) -> Int {
+        let candidates = queue.indices.filter { $0 != excluded }
+        return candidates.randomElement() ?? currentIndex
+    }
+
+    private func teardownPlayer() {
+        if let timeObserver, let player {
+            player.removeTimeObserver(timeObserver)
+        }
+        timeObserver = nil
+        if let endObserver {
+            NotificationCenter.default.removeObserver(endObserver)
+        }
+        endObserver = nil
+        statusObservation?.invalidate()
+        statusObservation = nil
+        player?.pause()
+        player = nil
+        isPlaying = false
+    }
+
+    // MARK: - Now Playing / remote commands
+
+    private func configureRemoteCommands() {
+        let center = MPRemoteCommandCenter.shared()
+        center.playCommand.addTarget { [weak self] _ in
+            Task { @MainActor in self?.resume() }
+            return .success
+        }
+        center.pauseCommand.addTarget { [weak self] _ in
+            Task { @MainActor in self?.pause() }
+            return .success
+        }
+        center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            Task { @MainActor in self?.togglePlayPause() }
+            return .success
+        }
+        center.nextTrackCommand.addTarget { [weak self] _ in
+            Task { @MainActor in self?.playNext() }
+            return .success
+        }
+        center.previousTrackCommand.addTarget { [weak self] _ in
+            Task { @MainActor in self?.playPrevious() }
+            return .success
+        }
+        center.changePlaybackPositionCommand.addTarget { [weak self] event in
+            guard let event = event as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
+            Task { @MainActor in self?.seek(to: event.positionTime) }
+            return .success
+        }
+    }
+
+    private func updateNowPlayingInfo() {
+        guard let song = currentSong else {
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            return
+        }
+        var info: [String: Any] = [
+            MPMediaItemPropertyTitle: song.title,
+            MPMediaItemPropertyPlaybackDuration: duration,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: currentTime,
+            MPNowPlayingInfoPropertyPlaybackRate: isPlaying ? 1.0 : 0.0,
+        ]
+        let artist = song.displayArtist
+        if !artist.isEmpty {
+            info[MPMediaItemPropertyArtist] = artist
+        }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        loadNowPlayingArtwork(for: song)
+    }
+
+    private func loadNowPlayingArtwork(for song: Song) {
+        guard let url = song.thumbnailURL else { return }
+        Task { @MainActor in
+            guard let image = await MacImageCache.shared.image(for: url),
+                  currentSong?.id == song.id else { return }
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        }
+    }
+
+    private func updateNowPlayingPlaybackState() {
+        guard var info = MPNowPlayingInfoCenter.default().nowPlayingInfo else { return }
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTime
+        info[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+    }
+}

--- a/TwinskaraokeMacApp/Services/MacAudioManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAudioManager.swift
@@ -58,6 +58,10 @@ final class MacAudioManager {
     private var statusObservation: NSKeyValueObservation?
     /// Indices that failed to load, so a broken queue can't spin forever.
     private var failedIndices: Set<Int> = []
+    /// Whether playback should begin once the item becomes ready. A pause
+    /// issued while still loading used to be overwritten by the unconditional
+    /// `play()` in the `.readyToPlay` observer.
+    private var wantsPlaybackWhenReady = true
 
     private init() {
         configureRemoteCommands()
@@ -73,8 +77,10 @@ final class MacAudioManager {
         return Array(queue[(currentIndex + 1)...])
     }
 
-    var canPlayNext: Bool { !queue.isEmpty }
-    var canPlayPrevious: Bool { !queue.isEmpty }
+    // Once every index has failed there is nothing left to advance to, so the
+    // transport buttons should stop pretending otherwise.
+    var canPlayNext: Bool { !queue.isEmpty && failedIndices.count < queue.count }
+    var canPlayPrevious: Bool { !queue.isEmpty && failedIndices.count < queue.count }
 
     // MARK: - Transport
 
@@ -96,12 +102,14 @@ final class MacAudioManager {
     }
 
     func pause() {
+        wantsPlaybackWhenReady = false
         player?.pause()
         isPlaying = false
         updateNowPlayingPlaybackState()
     }
 
     func resume() {
+        wantsPlaybackWhenReady = true
         guard let player else { return }
         player.play()
         isPlaying = true
@@ -163,6 +171,7 @@ final class MacAudioManager {
 
         teardownPlayer()
         isLoading = true
+        wantsPlaybackWhenReady = true
         currentTime = 0
         duration = 0
 
@@ -180,8 +189,11 @@ final class MacAudioManager {
                     self.failedIndices.remove(self.currentIndex)
                     let seconds = item.duration.seconds
                     self.duration = seconds.isFinite ? seconds : 0
-                    player.play()
-                    self.isPlaying = true
+                    // Honour a pause the user issued while this was loading.
+                    if self.wantsPlaybackWhenReady {
+                        player.play()
+                        self.isPlaying = true
+                    }
                     self.updateNowPlayingInfo()
                 case .failed:
                     self.handleFailure(item.error?.localizedDescription ?? "Couldn't play this song.")
@@ -240,9 +252,18 @@ final class MacAudioManager {
         playNext()
     }
 
+    /// Excludes indices already known to have failed, not just the current one.
+    /// `handleFailure` -> `playNext` -> `startCurrent` -> `handleFailure` runs on
+    /// one call stack for songs with no audio URL, and the recursion only ends
+    /// when `failedIndices` covers the queue. Re-picking a failed index made no
+    /// progress, so a queue with several unplayable songs could recurse without
+    /// bound.
     private func randomIndex(excluding excluded: Int?) -> Int {
-        let candidates = queue.indices.filter { $0 != excluded }
-        return candidates.randomElement() ?? currentIndex
+        let candidates = queue.indices.filter { $0 != excluded && !failedIndices.contains($0) }
+        if let pick = candidates.randomElement() { return pick }
+        // Nothing unplayed left: fall back to any index other than the current
+        // one so the caller's own exhaustion guard can end the walk.
+        return queue.indices.filter { $0 != excluded }.randomElement() ?? currentIndex
     }
 
     private func teardownPlayer() {
@@ -295,6 +316,7 @@ final class MacAudioManager {
     private func updateNowPlayingInfo() {
         guard let song = currentSong else {
             MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            MPNowPlayingInfoCenter.default().playbackState = .stopped
             return
         }
         var info: [String: Any] = [
@@ -308,6 +330,7 @@ final class MacAudioManager {
             info[MPMediaItemPropertyArtist] = artist
         }
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        MPNowPlayingInfoCenter.default().playbackState = isPlaying ? .playing : .paused
         loadNowPlayingArtwork(for: song)
     }
 
@@ -323,9 +346,14 @@ final class MacAudioManager {
     }
 
     private func updateNowPlayingPlaybackState() {
-        guard var info = MPNowPlayingInfoCenter.default().nowPlayingInfo else { return }
+        let center = MPNowPlayingInfoCenter.default()
+        // macOS drives the system Now Playing panel and the media keys from
+        // playbackState, not from the playback rate in nowPlayingInfo — unlike
+        // iOS, where the rate alone is enough.
+        center.playbackState = isPlaying ? .playing : (currentSong == nil ? .stopped : .paused)
+        guard var info = center.nowPlayingInfo else { return }
         info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTime
         info[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        center.nowPlayingInfo = info
     }
 }

--- a/TwinskaraokeMacApp/Services/MacAuthManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAuthManager.swift
@@ -1,5 +1,26 @@
+import AppKit
+import AuthenticationServices
+import CryptoKit
 import Foundation
 import Observation
+import Security
+
+/// On macOS `ASPresentationAnchor` is an `NSWindow`, where iOS uses a `UIWindow`.
+/// That difference is the whole reason this flow needed porting rather than
+/// sharing — the rest of the OAuth exchange is platform-neutral.
+private final class WebAuthPresentationContextProvider:
+    NSObject, ASWebAuthenticationPresentationContextProviding
+{
+    private let anchor: ASPresentationAnchor
+
+    init(anchor: ASPresentationAnchor) {
+        self.anchor = anchor
+    }
+
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        anchor
+    }
+}
 
 /// Username/password sign-in for the Mac app.
 ///
@@ -21,19 +42,34 @@ final class MacAuthManager {
     private(set) var isLoading = false
     var errorMessage: String?
 
+    private var webAuthSession: ASWebAuthenticationSession?
+    private var webAuthContextProvider: WebAuthPresentationContextProvider?
+
     private enum Endpoint {
         static var login: String { "\(StorageHost.api)/api/auth/login" }
+        static var nkTokenExchange: String { "\(StorageHost.idk)/api/auth/discord-token" }
+
+        static let discordAuth = "https://discord.com/oauth2/authorize"
+        static let discordToken = "https://discord.com/api/oauth2/token"
+        static let discordUser = "https://discord.com/api/users/@me"
+        static let discordClientId = "1447802634621943850"
+        static let redirectUri = "neurokaraoke://auth"
+        static let callbackScheme = "neurokaraoke"
     }
 
     private enum AuthError: LocalizedError {
         case http(Int, String)
         case parse
+        case invalidCallback
+        case cancelled
 
         var errorDescription: String? {
             switch self {
             case .http(401, _): "Incorrect username or password."
             case .http(let code, _): "The server returned an error (\(code))."
             case .parse: "Couldn't read the server's response."
+            case .invalidCallback: "Authentication failed — please try again."
+            case .cancelled: ""
             }
         }
     }
@@ -94,6 +130,162 @@ final class MacAuthManager {
         }
     }
 
+    // MARK: - Discord OAuth
+
+    func loginWithDiscord() async {
+        guard webAuthSession == nil else { return }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            guard let anchor = Self.activePresentationAnchor() else {
+                throw AuthError.invalidCallback
+            }
+            let verifier = Self.makeVerifier()
+            let state = Self.makeVerifier()
+
+            var components = URLComponents(string: Endpoint.discordAuth)!
+            components.queryItems = [
+                .init(name: "client_id", value: Endpoint.discordClientId),
+                .init(name: "redirect_uri", value: Endpoint.redirectUri),
+                .init(name: "response_type", value: "code"),
+                .init(name: "scope", value: "identify"),
+                .init(name: "code_challenge", value: Self.makeChallenge(verifier)),
+                .init(name: "code_challenge_method", value: "S256"),
+                .init(name: "state", value: state),
+            ]
+            guard let authURL = components.url else { throw AuthError.invalidCallback }
+
+            let callbackURL = try await presentWebAuth(url: authURL, anchor: anchor)
+
+            // Reject a callback whose state doesn't match the one we generated:
+            // that is the CSRF guard PKCE relies on.
+            guard
+                let callback = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+                callback.queryItems?.first(where: { $0.name == "state" })?.value == state,
+                let code = callback.queryItems?.first(where: { $0.name == "code" })?.value
+            else { throw AuthError.invalidCallback }
+
+            let discordToken = try await exchangeDiscordCode(code, verifier: verifier)
+            let nkToken = try await exchangeForNKToken(discordToken)
+            let profile = try await fetchDiscordProfile(discordToken)
+
+            try CredentialStore.saveToken(nkToken)
+            isLoggedIn = true
+            userID = profile.id
+            username = profile.username
+            avatar = profile.avatar
+            FavoritesManager.shared.reload()
+        } catch {
+            webAuthSession = nil
+            webAuthContextProvider = nil
+            // A user-cancelled sheet isn't an error worth showing.
+            if case AuthError.cancelled = error { return }
+            if Self.isCancellation(error) { return }
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func presentWebAuth(url: URL, anchor: ASPresentationAnchor) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: Endpoint.callbackScheme
+            ) { [weak self] callbackURL, error in
+                Task { @MainActor [weak self] in
+                    self?.webAuthSession = nil
+                    self?.webAuthContextProvider = nil
+                }
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let callbackURL else {
+                    continuation.resume(throwing: AuthError.cancelled)
+                    return
+                }
+                continuation.resume(returning: callbackURL)
+            }
+
+            let provider = WebAuthPresentationContextProvider(anchor: anchor)
+            session.presentationContextProvider = provider
+            session.prefersEphemeralWebBrowserSession = true
+            webAuthContextProvider = provider
+            webAuthSession = session
+
+            guard session.start() else {
+                webAuthSession = nil
+                webAuthContextProvider = nil
+                continuation.resume(throwing: AuthError.invalidCallback)
+                return
+            }
+        }
+    }
+
+    private func exchangeDiscordCode(_ code: String, verifier: String) async throws -> String {
+        var request = URLRequest(url: URL(string: Endpoint.discordToken)!)
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.requestTimeout
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let redirect = Endpoint.redirectUri
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? Endpoint.redirectUri
+        request.httpBody = """
+            client_id=\(Endpoint.discordClientId)\
+            &grant_type=authorization_code\
+            &code=\(code)\
+            &redirect_uri=\(redirect)\
+            &code_verifier=\(verifier)
+            """.data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try Self.check(response, data)
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let accessToken = json["access_token"] as? String
+        else { throw AuthError.parse }
+        return accessToken
+    }
+
+    private func exchangeForNKToken(_ discordToken: String) async throws -> String {
+        var request = URLRequest(url: URL(string: Endpoint.nkTokenExchange)!)
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.requestTimeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["accessToken": discordToken])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try Self.check(response, data)
+        guard let token = Self.exchangedToken(from: data) else { throw AuthError.parse }
+        return token
+    }
+
+    private struct DiscordProfile {
+        let id: String
+        let username: String
+        let avatar: String?
+    }
+
+    private func fetchDiscordProfile(_ token: String) async throws -> DiscordProfile {
+        var request = URLRequest(url: URL(string: Endpoint.discordUser)!)
+        request.timeoutInterval = Self.requestTimeout
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try Self.check(response, data)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AuthError.parse
+        }
+        let id = json["id"] as? String ?? ""
+        let name = json["global_name"] as? String ?? json["username"] as? String ?? ""
+        let avatarID = json["avatar"] as? String
+        return DiscordProfile(
+            id: id,
+            username: name,
+            avatar: avatarID.map { "https://cdn.discordapp.com/avatars/\(id)/\($0).png" }
+        )
+    }
+
     func logout() {
         CredentialStore.deleteToken()
         isLoggedIn = false
@@ -102,6 +294,80 @@ final class MacAuthManager {
         avatar = nil
         errorMessage = nil
         FavoritesManager.shared.clear()
+    }
+
+    // MARK: - Helpers
+
+    private static let requestTimeout: TimeInterval = 15
+
+    private static func check(_ response: URLResponse, _ data: Data) throws {
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw AuthError.http(
+                (response as? HTTPURLResponse)?.statusCode ?? 0,
+                String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+    }
+
+    private static func isCancellation(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == ASWebAuthenticationSessionErrorDomain
+            && nsError.code == ASWebAuthenticationSessionError.Code.canceledLogin.rawValue
+    }
+
+    /// macOS equivalent of the iOS anchor lookup: a key `NSWindow` instead of a
+    /// key `UIWindow` from the connected scenes.
+    private static func activePresentationAnchor() -> ASPresentationAnchor? {
+        NSApplication.shared.keyWindow
+            ?? NSApplication.shared.mainWindow
+            ?? NSApplication.shared.windows.first
+    }
+
+    private static func makeVerifier() -> String {
+        var bytes = [UInt8](repeating: 0, count: 64)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return base64URL(Data(bytes))
+    }
+
+    private static func makeChallenge(_ verifier: String) -> String {
+        base64URL(Data(SHA256.hash(data: Data(verifier.utf8))))
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// The exchange endpoint has returned a bare string, a quoted JSON string
+    /// and an object across versions, so accept all three — same handling as
+    /// `AuthManager.exchangedToken(from:)` on iOS.
+    static func exchangedToken(from data: Data) -> String? {
+        let raw = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !raw.isEmpty else { return nil }
+
+        if let json = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) {
+            if let object = json as? [String: Any] {
+                return validatedToken(object["token"] as? String ?? object["accessToken"] as? String)
+            }
+            if let string = json as? String {
+                return validatedToken(string)
+            }
+            return nil
+        }
+        return validatedToken(raw)
+    }
+
+    private static func validatedToken(_ candidate: String?) -> String? {
+        guard let token = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty,
+              token.utf8.count <= 8_192
+        else { return nil }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~+/="))
+        guard token.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return token
     }
 
     /// Same claim URIs the iOS target reads — the token is issued by one server

--- a/TwinskaraokeMacApp/Services/MacAuthManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAuthManager.swift
@@ -45,6 +45,86 @@ final class MacAuthManager {
     private var webAuthSession: ASWebAuthenticationSession?
     private var webAuthContextProvider: WebAuthPresentationContextProvider?
 
+    // MARK: - Profile
+
+    private(set) var profile: UserProfile?
+    private(set) var badges: [AccountBadge] = []
+    private(set) var uploadLimits: UploadLimits?
+    private(set) var isRefreshingProfile = false
+    private(set) var profileError: String?
+
+    /// Fetches profile, badges and upload limits. Mirrors
+    /// `TVAuthManager.refreshAccount` — same endpoints, same partial-failure
+    /// handling, so one endpoint being down doesn't blank the whole screen.
+    func refreshAccount() async {
+        guard isLoggedIn, CredentialStore.token != nil, !isRefreshingProfile else { return }
+        isRefreshingProfile = true
+        profileError = nil
+        defer { isRefreshingProfile = false }
+
+        async let fetchedProfile = try? Self.authorizedData(path: "/api/badge/profile")
+        async let fetchedLimits = try? Self.authorizedData(path: "/api/user/upload-limits")
+        let (profileData, limitsData) = await (fetchedProfile, fetchedLimits)
+
+        var didFail = false
+        if let profileData {
+            do {
+                let response = try JSONDecoder().decode(ProfileResponse.self, from: profileData)
+                profile = response.profile
+                badges = response.badges ?? []
+                if let avatarUrl = response.profile.avatarUrl, !avatarUrl.isEmpty {
+                    avatar = avatarUrl
+                }
+            } catch {
+                didFail = true
+            }
+        } else {
+            didFail = true
+        }
+
+        if let limitsData {
+            do {
+                uploadLimits = try JSONDecoder().decode(UploadLimits.self, from: limitsData)
+            } catch {
+                didFail = true
+            }
+        } else {
+            didFail = true
+        }
+
+        if didFail {
+            profileError = "Some account details couldn't be refreshed. Try again."
+        }
+    }
+
+    private static func authorizedData(path: String) async throws -> Data {
+        let request = try KaraokeAPIClient.request(path: path)
+        return try await KaraokeAPIClient.data(for: request)
+    }
+
+    /// Resolved avatar for the toolbar button and profile header. Prefers the
+    /// profile payload, falling back to the JWT's Discord avatar claim.
+    var avatarURL: URL? {
+        if let profile, let url = profile.avatarURL { return url }
+        guard let avatar, !avatar.isEmpty else { return nil }
+        return URL(string: avatar)
+    }
+
+    // MARK: - QR pairing state
+
+    private(set) var qrSession: QRSignIn.Session?
+    private(set) var qrPhase: QRPhase = .idle
+    private(set) var qrError: String?
+    @ObservationIgnored private var qrTask: Task<Void, Never>?
+
+    enum QRPhase: Equatable {
+        case idle
+        case creating
+        case waiting
+        case completing
+        case expired
+    }
+
     private enum Endpoint {
         static var login: String { "\(StorageHost.api)/api/auth/login" }
         static var nkTokenExchange: String { "\(StorageHost.idk)/api/auth/discord-token" }
@@ -57,7 +137,9 @@ final class MacAuthManager {
         static let callbackScheme = "neurokaraoke"
     }
 
-    private enum AuthError: LocalizedError {
+    // nonisolated: referenced from the ASWebAuthenticationSession completion
+    // handler, which macOS invokes on a background XPC queue.
+    private nonisolated enum AuthError: LocalizedError {
         case http(Int, String)
         case parse
         case invalidCallback
@@ -188,15 +270,24 @@ final class MacAuthManager {
     }
 
     private func presentWebAuth(url: URL, anchor: ASPresentationAnchor) async throws -> URL {
-        try await withCheckedThrowingContinuation { continuation in
+        // Clearing the session here rather than inside the completion handler:
+        // control is back on the main actor once the continuation resumes, so
+        // the handler itself never has to touch isolated state.
+        defer {
+            webAuthSession = nil
+            webAuthContextProvider = nil
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
             let session = ASWebAuthenticationSession(
                 url: url,
                 callbackURLScheme: Endpoint.callbackScheme
-            ) { [weak self] callbackURL, error in
-                Task { @MainActor [weak self] in
-                    self?.webAuthSession = nil
-                    self?.webAuthContextProvider = nil
-                }
+            ) { @Sendable callbackURL, error in
+                // macOS calls this on an XPC queue, not the main thread — iOS
+                // calls it on the main thread, which is why the iOS AuthManager
+                // gets away with the same shape. @Sendable forces the closure
+                // nonisolated, so Swift 6 doesn't insert a main-actor check
+                // that would trap here (EXC_BREAKPOINT).
                 if let error {
                     continuation.resume(throwing: error)
                     return
@@ -287,13 +378,145 @@ final class MacAuthManager {
     }
 
     func logout() {
+        // A live pairing code outliving sign-out could complete behind the
+        // user and silently sign them back in.
+        cancelQRSignIn()
         CredentialStore.deleteToken()
         isLoggedIn = false
         username = nil
         userID = nil
         avatar = nil
         errorMessage = nil
+        profile = nil
+        badges = []
+        uploadLimits = nil
+        profileError = nil
         FavoritesManager.shared.clear()
+    }
+
+    // MARK: - QR device pairing
+
+    /// Requests a pairing code and polls until a signed-in phone approves it.
+    /// Safe to call repeatedly; any in-flight attempt is replaced. Ported from
+    /// `TVAuthManager` — the Mac has a keyboard, but pairing from a phone that
+    /// is already signed in is still the fastest way in.
+    func startQRSignIn() {
+        qrTask?.cancel()
+        qrError = nil
+        qrSession = nil
+        qrPhase = .creating
+        qrTask = Task { [weak self] in
+            await self?.runQRSignIn()
+        }
+    }
+
+    func cancelQRSignIn() {
+        qrTask?.cancel()
+        qrTask = nil
+        qrSession = nil
+        qrPhase = .idle
+        qrError = nil
+    }
+
+    private func runQRSignIn() async {
+        var session: QRSignIn.Session
+        do {
+            session = try await QRSignIn.createSession()
+        } catch {
+            guard !Task.isCancelled else { return }
+            qrError = Self.friendlyMessage(for: error)
+            qrPhase = .idle
+            return
+        }
+
+        guard !Task.isCancelled else { return }
+        qrSession = session
+        qrPhase = .waiting
+
+        let start = Date()
+        // A single network blip shouldn't discard a code the user is already
+        // pointing a phone at; only give up after it keeps failing.
+        var consecutiveFailures = 0
+
+        while !Task.isCancelled {
+            if session.isExpired {
+                qrPhase = .expired
+                return
+            }
+
+            // Tight while the user is most likely mid-scan, slower after.
+            let interval: Double = Date().timeIntervalSince(start) < 30 ? 2 : 5
+            try? await Task.sleep(for: .seconds(interval))
+            guard !Task.isCancelled else { return }
+
+            do {
+                let poll = try await QRSignIn.status(of: session.id)
+                guard !Task.isCancelled, qrSession?.id == session.id else { return }
+                // The server owns the deadline; the value from createSession is
+                // only a placeholder until the first poll lands.
+                if let expiresAt = poll.expiresAt, expiresAt != session.expiresAt {
+                    session.expiresAt = expiresAt
+                    qrSession = session
+                }
+
+                switch poll.status {
+                case .pending:
+                    consecutiveFailures = 0
+                case .expired:
+                    qrPhase = .expired
+                    return
+                case let .approved(token):
+                    qrPhase = .completing
+                    completeQRSignIn(token: token)
+                    return
+                }
+            } catch {
+                guard !Task.isCancelled, qrSession?.id == session.id else { return }
+                consecutiveFailures += 1
+                if consecutiveFailures >= 3 {
+                    qrError = Self.friendlyMessage(for: error)
+                    qrPhase = .idle
+                    return
+                }
+            }
+        }
+    }
+
+    private func completeQRSignIn(token: String) {
+        // Without readable claims the session would persist with an empty
+        // username, so fail loudly rather than half-committing.
+        guard let claims = Self.parseJWT(token) else {
+            qrError = "That sign-in couldn't be completed. Try again."
+            qrPhase = .idle
+            return
+        }
+        do {
+            try CredentialStore.saveToken(token)
+        } catch {
+            // Include the OSStatus: a bare "couldn't save" gave no way to tell
+            // a Keychain entitlement problem from a transient failure.
+            if case CredentialStore.StoreError.keychain(let status) = error {
+                qrError = "Couldn't save your sign-in (Keychain error \(status))."
+            } else {
+                qrError = "Couldn't save your sign-in. Try again."
+            }
+            qrPhase = .idle
+            return
+        }
+        isLoggedIn = true
+        userID = claims.id
+        username = claims.username
+        avatar = claims.avatar
+        qrSession = nil
+        qrPhase = .idle
+        FavoritesManager.shared.reload()
+    }
+
+    private static func friendlyMessage(for error: Error) -> String {
+        if let serviceError = error as? QRSignIn.ServiceError {
+            return serviceError.errorDescription ?? "Something went wrong. Try again."
+        }
+        return (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 
     // MARK: - Helpers

--- a/TwinskaraokeMacApp/Services/MacAuthManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAuthManager.swift
@@ -22,14 +22,15 @@ private final class WebAuthPresentationContextProvider:
     }
 }
 
-/// Username/password sign-in for the Mac app.
+/// Sign-in and account state for the Mac app.
 ///
-/// The tvOS target signs in by QR code because typing on a remote is painful;
-/// a Mac has a keyboard, so this mirrors the iOS `AuthManager.login` flow
-/// against the same `/api/auth/login` endpoint and the same Keychain-backed
-/// `CredentialStore`. Discord OAuth is intentionally left out of this first
-/// version — it needs an `ASWebAuthenticationSession` presentation anchor,
-/// which is a separate piece of AppKit wiring.
+/// Offers all three routes the other targets have between them:
+/// - QR device pairing (the default), ported from `TVAuthManager`
+/// - Username/password against `/api/auth/login`, as on iOS
+/// - Discord OAuth via `ASWebAuthenticationSession` with an `NSWindow` anchor
+///
+/// All three land on the same Keychain-backed `CredentialStore`, and the
+/// profile/badge/upload-limit fetch mirrors `TVAuthManager.refreshAccount`.
 @MainActor
 @Observable
 final class MacAuthManager {
@@ -103,11 +104,27 @@ final class MacAuthManager {
     }
 
     /// Resolved avatar for the toolbar button and profile header. Prefers the
-    /// profile payload, falling back to the JWT's Discord avatar claim.
+    /// profile payload, falling back to the stored avatar claim.
+    ///
+    /// The fallback cannot just be `URL(string:)`: `parseJWT` returns the raw
+    /// `urn:discord:avatar` claim, which is a bare hash or a storage-relative
+    /// path rather than an absolute URL. Only the Discord OAuth path stores a
+    /// full CDN URL, so password sign-in, QR sign-in and session restore all
+    /// showed the placeholder. Same resolution `UserProfile.avatarURL` uses.
     var avatarURL: URL? {
         if let profile, let url = profile.avatarURL { return url }
         guard let avatar, !avatar.isEmpty else { return nil }
-        return URL(string: avatar)
+        if let url = URL(string: avatar), url.scheme != nil { return url }
+        // A bare 32-hex Discord avatar hash needs the user id to form a CDN URL.
+        if let userID, Self.looksLikeDiscordAvatarHash(avatar) {
+            return URL(string: "https://cdn.discordapp.com/avatars/\(userID)/\(avatar).png")
+        }
+        return URL(string: "\(StorageHost.base)\(ArtworkURLBuilder.normalizedPath(avatar))")
+    }
+
+    private static func looksLikeDiscordAvatarHash(_ value: String) -> Bool {
+        let trimmed = value.hasPrefix("a_") ? String(value.dropFirst(2)) : value
+        return trimmed.count == 32 && trimmed.allSatisfy(\.isHexDigit)
     }
 
     // MARK: - QR pairing state
@@ -184,6 +201,10 @@ final class MacAuthManager {
             guard let url = URL(string: Endpoint.login) else { throw AuthError.parse }
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
+            // Without this the request inherits URLSession's 60s default, so a
+            // stalled connection leaves the sign-in button spinning for a
+            // minute. Every other request in this file bounds itself.
+            request.timeoutInterval = Self.requestTimeout
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONSerialization.data(
                 withJSONObject: ["username": trimmed, "password": password]
@@ -339,7 +360,11 @@ final class MacAuthManager {
     }
 
     private func exchangeForNKToken(_ discordToken: String) async throws -> String {
-        var request = URLRequest(url: URL(string: Endpoint.nkTokenExchange)!)
+        // nkTokenExchange interpolates StorageHost.idk, which is resolved at
+        // runtime — unlike the literal Discord endpoints, it can be malformed,
+        // and force-unwrapping it would crash rather than surface an error.
+        guard let url = URL(string: Endpoint.nkTokenExchange) else { throw AuthError.parse }
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = Self.requestTimeout
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -509,6 +534,9 @@ final class MacAuthManager {
         avatar = claims.avatar
         qrSession = nil
         qrPhase = .idle
+        // A transient poll failure earlier in this run may have set qrError;
+        // leaving it would show a stale error beside a signed-in account.
+        qrError = nil
         FavoritesManager.shared.reload()
     }
 

--- a/TwinskaraokeMacApp/Services/MacAuthManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAuthManager.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Observation
+
+/// Username/password sign-in for the Mac app.
+///
+/// The tvOS target signs in by QR code because typing on a remote is painful;
+/// a Mac has a keyboard, so this mirrors the iOS `AuthManager.login` flow
+/// against the same `/api/auth/login` endpoint and the same Keychain-backed
+/// `CredentialStore`. Discord OAuth is intentionally left out of this first
+/// version — it needs an `ASWebAuthenticationSession` presentation anchor,
+/// which is a separate piece of AppKit wiring.
+@MainActor
+@Observable
+final class MacAuthManager {
+    static let shared = MacAuthManager()
+
+    private(set) var isLoggedIn = false
+    private(set) var username: String?
+    private(set) var userID: String?
+    private(set) var avatar: String?
+    private(set) var isLoading = false
+    var errorMessage: String?
+
+    private enum Endpoint {
+        static var login: String { "\(StorageHost.api)/api/auth/login" }
+    }
+
+    private enum AuthError: LocalizedError {
+        case http(Int, String)
+        case parse
+
+        var errorDescription: String? {
+            switch self {
+            case .http(401, _): "Incorrect username or password."
+            case .http(let code, _): "The server returned an error (\(code))."
+            case .parse: "Couldn't read the server's response."
+            }
+        }
+    }
+
+    private init() {
+        restoreSession()
+    }
+
+    private func restoreSession() {
+        guard let token = CredentialStore.token, !token.isEmpty else { return }
+        let claims = Self.parseJWT(token)
+        isLoggedIn = true
+        userID = claims?.id
+        username = claims?.username
+        avatar = claims?.avatar
+    }
+
+    func login(username rawUsername: String, password: String) async {
+        let trimmed = rawUsername.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !password.isEmpty else {
+            errorMessage = "Please fill in all fields."
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            guard let url = URL(string: Endpoint.login) else { throw AuthError.parse }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(
+                withJSONObject: ["username": trimmed, "password": password]
+            )
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                throw AuthError.http(status, String(data: data, encoding: .utf8) ?? "")
+            }
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let token = json["token"] as? String
+            else { throw AuthError.parse }
+
+            try CredentialStore.saveToken(token)
+            let claims = Self.parseJWT(token)
+            isLoggedIn = true
+            userID = claims?.id ?? trimmed
+            self.username = claims?.username ?? trimmed
+            avatar = claims?.avatar
+
+            FavoritesManager.shared.reload()
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    func logout() {
+        CredentialStore.deleteToken()
+        isLoggedIn = false
+        username = nil
+        userID = nil
+        avatar = nil
+        errorMessage = nil
+        FavoritesManager.shared.clear()
+    }
+
+    /// Same claim URIs the iOS target reads — the token is issued by one server
+    /// for every platform, so the shapes must not drift.
+    private static func parseJWT(_ jwt: String) -> (id: String, username: String, avatar: String?)? {
+        let parts = jwt.split(separator: ".")
+        guard parts.count == 3 else { return nil }
+        var base64 = String(parts[1])
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+        base64 = base64.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        guard
+            let data = Data(base64Encoded: base64),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        let id = json["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"] as? String ?? ""
+        let name = json["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"] as? String ?? ""
+        let avatar = (json["urn:discord:avatar"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        guard !id.isEmpty, !name.isEmpty else { return nil }
+        return (id, name, avatar)
+    }
+}

--- a/TwinskaraokeMacApp/Services/MacImageCache.swift
+++ b/TwinskaraokeMacApp/Services/MacImageCache.swift
@@ -1,0 +1,164 @@
+import AppKit
+import SwiftUI
+
+/// In-memory + disk artwork cache for the Mac app.
+///
+/// Mirrors `TVImageCache` rather than pulling in SDWebImage: the Mac target
+/// only needs artwork for rows, the sidebar and the player bar, so keeping the
+/// dependency out means this target links nothing beyond system frameworks.
+/// The lock is confined to the synchronous `fetchPlan`/`finishFetch` helpers —
+/// under Swift 6 holding an `NSLock` across an `await` is a hard error.
+final class MacImageCache: @unchecked Sendable {
+    static let shared = MacImageCache()
+
+    private let memory = NSCache<NSURL, NSImage>()
+    private let disk = URLCache(memoryCapacity: 16 * 1024 * 1024, diskCapacity: 128 * 1024 * 1024)
+    /// Guards `inFlight` and `failures` (NSCache/URLCache are already thread-safe).
+    private let stateLock = NSLock()
+    private var inFlight: [NSURL: Task<NSImage?, Never>] = [:]
+    /// Short-lived negative cache so scrolling doesn't hammer a dead host.
+    private var failures: [NSURL: Date] = [:]
+    private static let negativeTTL: TimeInterval = 30
+
+    private init() {
+        memory.countLimit = 400
+        memory.totalCostLimit = 64 * 1024 * 1024
+    }
+
+    /// Synchronous lookup so a view can render artwork on first layout instead
+    /// of flashing a placeholder for one frame.
+    func cachedImage(for url: URL) -> NSImage? {
+        memory.object(forKey: url as NSURL)
+    }
+
+    func image(for url: URL) async -> NSImage? {
+        let key = url as NSURL
+        if let cached = memory.object(forKey: key) { return cached }
+
+        let request = URLRequest(url: url)
+        if let stored = disk.cachedResponse(for: request), let image = NSImage(data: stored.data) {
+            memory.setObject(image, forKey: key, cost: Self.memoryCost(for: image, fallback: stored.data.count))
+            return image
+        }
+
+        switch fetchPlan(for: key, request: request) {
+        case .knownFailure:
+            return nil
+        case .coalesce(let task):
+            _ = await task.value
+            return memory.object(forKey: key)
+        case .start(let task):
+            let image = await task.value
+            finishFetch(for: key, image: image)
+            return image
+        }
+    }
+
+    private enum FetchPlan {
+        case knownFailure
+        case coalesce(Task<NSImage?, Never>)
+        case start(Task<NSImage?, Never>)
+    }
+
+    private func fetchPlan(for key: NSURL, request: URLRequest) -> FetchPlan {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        if let failedAt = failures[key], Date().timeIntervalSince(failedAt) < Self.negativeTTL {
+            return .knownFailure
+        }
+        if let task = inFlight[key] {
+            return .coalesce(task)
+        }
+        let task = Task<NSImage?, Never> { [memory, disk] in
+            guard let (data, response) = try? await URLSession.shared.data(for: request),
+                  let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+                  let image = NSImage(data: data)
+            else { return nil }
+            memory.setObject(image, forKey: key, cost: Self.memoryCost(for: image, fallback: data.count))
+            disk.storeCachedResponse(CachedURLResponse(response: response, data: data), for: request)
+            return image
+        }
+        inFlight[key] = task
+        return .start(task)
+    }
+
+    private static func memoryCost(for image: NSImage, fallback: Int) -> Int {
+        if let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+            return cgImage.bytesPerRow * cgImage.height
+        }
+        let estimated = Int(image.size.width * image.size.height * 4)
+        return estimated > 0 ? estimated : fallback
+    }
+
+    private func finishFetch(for key: NSURL, image: NSImage?) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        inFlight[key] = nil
+        guard image == nil else { return }
+        if failures.count > 256 {
+            let now = Date()
+            failures = failures.filter { now.timeIntervalSince($0.value) < Self.negativeTTL }
+        }
+        failures[key] = Date()
+    }
+}
+
+/// Drop-in cached async image that serves repeated loads from `MacImageCache`.
+struct MacRemoteImage<Content: View, Placeholder: View>: View {
+    let url: URL?
+    @ViewBuilder let content: (Image) -> Content
+    @ViewBuilder let placeholder: () -> Placeholder
+
+    @State private var image: NSImage?
+
+    init(
+        url: URL?,
+        @ViewBuilder content: @escaping (Image) -> Content,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.url = url
+        self.content = content
+        self.placeholder = placeholder
+        // Seed from the memory cache so an already-loaded image renders on the
+        // first frame rather than flashing the placeholder.
+        _image = State(initialValue: url.flatMap { MacImageCache.shared.cachedImage(for: $0) })
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                content(Image(nsImage: image))
+            } else {
+                placeholder()
+            }
+        }
+        .task(id: url) {
+            guard image == nil, let url else { return }
+            image = await MacImageCache.shared.image(for: url)
+        }
+    }
+}
+
+/// Square artwork tile with the app's standard placeholder, used by rows, the
+/// grid cards and the player bar so they stay visually identical.
+struct SongArtwork: View {
+    let url: URL?
+    var size: CGFloat
+    var cornerRadius: CGFloat = 6
+
+    var body: some View {
+        MacRemoteImage(url: url) { image in
+            image.resizable().aspectRatio(contentMode: .fill)
+        } placeholder: {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(Color.secondary.opacity(0.15))
+                .overlay {
+                    Image(systemName: "music.note")
+                        .font(.system(size: max(10, size * 0.34)))
+                        .foregroundStyle(.secondary)
+                }
+        }
+        .frame(width: size, height: size)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+}

--- a/TwinskaraokeMacApp/Services/MacImageCache.swift
+++ b/TwinskaraokeMacApp/Services/MacImageCache.swift
@@ -133,8 +133,22 @@ struct MacRemoteImage<Content: View, Placeholder: View>: View {
             }
         }
         .task(id: url) {
-            guard image == nil, let url else { return }
-            image = await MacImageCache.shared.image(for: url)
+            guard let url else {
+                image = nil
+                return
+            }
+            // Reset on URL change before the guard: `image` still holds the
+            // previous URL's artwork, and `image == nil` alone would skip the
+            // load. SwiftUI recycles row identity in List and LazyVGrid, so a
+            // scrolled row or an advancing player bar kept the old artwork.
+            let cached = MacImageCache.shared.cachedImage(for: url)
+            image = cached
+            guard cached == nil else { return }
+            let loaded = await MacImageCache.shared.image(for: url)
+            // The task is cancelled and restarted when `url` changes, so a late
+            // response here still belongs to the URL we were asked for.
+            guard !Task.isCancelled else { return }
+            image = loaded
         }
     }
 }

--- a/TwinskaraokeMacApp/TwinskaraokeMac.entitlements
+++ b/TwinskaraokeMacApp/TwinskaraokeMac.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Mac App Store requires the sandbox. Deliberately does NOT carry
+	     com.apple.developer.carplay-audio from the iOS entitlements: that is an
+	     iOS-only entitlement and a Mac provisioning profile cannot vend it. -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<!-- Outgoing only: the app talks to the Twinskaraoke API and CDN. -->
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -59,16 +59,6 @@
     "@%@" : {
 
     },
-    "%@ %lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ %2$lld"
-          }
-        }
-      }
-    },
     "%@ artwork" : {
       "localizations" : {
         "de" : {
@@ -2146,6 +2136,12 @@
           }
         }
       }
+    },
+    "Add to favourites" : {
+
+    },
+    "Add to Favourites" : {
+
     },
     "Add to Library" : {
       "localizations" : {
@@ -4810,19 +4806,22 @@
         }
       }
     },
-    "Couldn't load lyrics" : {
-
-    },
     "Couldn’t add the song to “%@”. Try again." : {
 
     },
     "Couldn’t create the playlist. Try again." : {
 
     },
-    "Couldn’t remove song" : {
+    "Couldn't load lyrics" : {
+
+    },
+    "Couldn’t remove “%@”. Try again." : {
 
     },
     "Couldn't Remove Song" : {
+
+    },
+    "Couldn’t remove song" : {
 
     },
     "Couldn't save" : {
@@ -4835,9 +4834,6 @@
           }
         }
       }
-    },
-    "Couldn’t remove “%@”. Try again." : {
-
     },
     "Cover by %@" : {
       "localizations" : {
@@ -7048,6 +7044,9 @@
           }
         }
       }
+    },
+    "Favourites" : {
+
     },
     "Featured" : {
       "localizations" : {
@@ -10908,6 +10907,9 @@
         }
       }
     },
+    "Next" : {
+
+    },
     "NEXT" : {
       "localizations" : {
         "de" : {
@@ -12783,6 +12785,9 @@
     "Opens your playlist." : {
 
     },
+    "or" : {
+
+    },
     "OR" : {
       "localizations" : {
         "de" : {
@@ -14332,6 +14337,9 @@
         }
       }
     },
+    "Previous" : {
+
+    },
     "Previous track" : {
       "localizations" : {
         "de" : {
@@ -15406,6 +15414,9 @@
     "Recently Played" : {
 
     },
+    "Refresh" : {
+
+    },
     "Refresh Library" : {
       "localizations" : {
         "de" : {
@@ -15511,6 +15522,9 @@
       }
     },
     "Refresh Playlist" : {
+
+    },
+    "Refresh playlists" : {
 
     },
     "Refresh Profile" : {
@@ -16150,6 +16164,12 @@
         }
       }
     },
+    "Remove from favourites" : {
+
+    },
+    "Remove from Favourites" : {
+
+    },
     "Remove from Library" : {
       "localizations" : {
         "de" : {
@@ -16415,6 +16435,9 @@
           }
         }
       }
+    },
+    "Repeat Mode" : {
+
     },
     "Repeat One" : {
       "localizations" : {
@@ -17526,6 +17549,9 @@
           }
         }
       }
+    },
+    "Search songs or artists" : {
+
     },
     "Search unavailable" : {
       "localizations" : {
@@ -19073,6 +19099,9 @@
           }
         }
       }
+    },
+    "Sign in with Discord" : {
+
     },
     "Sign in with your Twinskaraoke username and password to see your profile, badges, and upload limits." : {
 
@@ -22918,13 +22947,13 @@
         }
       }
     },
+    "Your favourites and playlists follow your account." : {
+
+    },
     "Your karaoke profile,\nright on Apple TV." : {
 
     },
     "Yours" : {
-
-    },
-    "Zoom Test" : {
 
     }
   },

--- a/TwinskaraokeShared/Models/AccountProfile.swift
+++ b/TwinskaraokeShared/Models/AccountProfile.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Account profile, badge and upload-limit shapes returned by
+/// `/api/badge/profile` and `/api/user/upload-limits`.
+///
+/// These began life inside the tvOS `TVAuthManager`; they moved here when the
+/// Mac app needed the same profile screen. Nothing in them is platform
+/// specific — plain `Decodable` value types over Foundation — so every target
+/// that already compiles `TwinskaraokeShared` gets them for free.
+
+struct ProfileResponse: Decodable, Sendable {
+    let profile: UserProfile
+    let badges: [AccountBadge]?
+}
+
+struct UserProfile: Decodable, Sendable {
+    let displayName: String
+    let avatarUrl: String?
+    let level: Int?
+    let levelTitle: String?
+    let totalXP: Int?
+    let totalBadges: Int?
+    let unlockedBadges: Int?
+    let levelProgress: Double?
+    let xpToNextLevel: Int?
+
+    var avatarURL: URL? {
+        Self.remoteURL(from: avatarUrl)
+    }
+
+    private static func remoteURL(from value: String?) -> URL? {
+        guard let value, !value.isEmpty else { return nil }
+        if let url = URL(string: value), url.scheme != nil {
+            return url
+        }
+        return URL(string: "\(StorageHost.base)\(ArtworkURLBuilder.normalizedPath(value))")
+    }
+}
+
+struct AccountBadge: Decodable, Identifiable, Sendable {
+    let id: String
+    let name: String
+    let description: String?
+    let rarity: Int
+    let unlocked: Bool
+    let currentProgress: Int
+    let conditionValue: Int
+    let media: BadgeMedia?
+
+    var iconURL: URL? {
+        ArtworkURLBuilder.imageURL(
+            cloudflareID: media?.cloudflareId,
+            path: nil,
+            variant: .thumbnail
+        )
+    }
+}
+
+struct BadgeMedia: Decodable, Sendable {
+    let cloudflareId: String?
+}
+
+struct UploadLimits: Decodable, Sendable {
+    let maxSongs: Int
+    let maxStorageBytes: Int64
+    let usedStorageBytes: Int64
+    let currentSongCount: Int
+    let currentPlaylistCount: Int
+    let playlistLimit: Int
+    let songPerPlaylistLimit: Int
+}

--- a/TwinskaraokeShared/Models/Song.swift
+++ b/TwinskaraokeShared/Models/Song.swift
@@ -263,7 +263,7 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   private static let neuroArtistNames: Set<String> = ["Neuro", "Neuro v1", "Neuro v2"]
 
   private var neuroFallbackImageURL: URL? {
-    #if os(watchOS) || os(tvOS)
+    #if os(watchOS) || os(tvOS) || os(macOS)
     return nil
     #else
     let artists = coverArtists ?? []
@@ -274,7 +274,7 @@ nonisolated struct Song: Codable, Identifiable, Equatable, Sendable {
   }
 
   var fallbackArtCredit: String? {
-    #if os(watchOS) || os(tvOS)
+    #if os(watchOS) || os(tvOS) || os(macOS)
     return nil
     #else
     guard !hasOwnArtwork else { return nil }

--- a/TwinskaraokeShared/Services/CredentialStore.swift
+++ b/TwinskaraokeShared/Services/CredentialStore.swift
@@ -145,6 +145,12 @@ nonisolated enum CredentialStore {
     /// legacy one instead of being unable to sign in at all. Resolved a single
     /// time per process so save, read and delete can never disagree about which
     /// keychain holds the item.
+    /// Only an entitlement-shaped failure counts as "this build cannot use the
+    /// data-protection keychain". Statuses like `errSecInteractionNotAllowed`
+    /// (keychain locked) or `errSecAuthFailed` are transient: treating those as
+    /// a negative would make this launch read the legacy keychain only, hide a
+    /// token a previous launch wrote to the data-protection one, sign the user
+    /// out, and then write a second divergent token on the next save.
     private static let usesDataProtectionKeychain: Bool = {
       var probe: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
@@ -154,12 +160,15 @@ nonisolated enum CredentialStore {
         kSecUseDataProtectionKeychain as String: true,
       ]
       let status = SecItemAdd(probe as CFDictionary, nil)
-      guard status == errSecSuccess || status == errSecDuplicateItem else {
-        return false
+      if status == errSecSuccess || status == errSecDuplicateItem {
+        probe.removeValue(forKey: kSecValueData as String)
+        SecItemDelete(probe as CFDictionary)
+        return true
       }
-      probe.removeValue(forKey: kSecValueData as String)
-      SecItemDelete(probe as CFDictionary)
-      return true
+      // errSecMissingEntitlement: ad-hoc/unsigned build with no
+      // application-identifier. errSecNotAvailable: no keychain available to
+      // this process at all. Anything else, keep the modern keychain.
+      return !(status == errSecMissingEntitlement || status == errSecNotAvailable)
     }()
 
     private static let probeAccount = "nk.keychainProbe"

--- a/TwinskaraokeShared/Services/CredentialStore.swift
+++ b/TwinskaraokeShared/Services/CredentialStore.swift
@@ -120,14 +120,50 @@ nonisolated enum CredentialStore {
     ]
     #if os(macOS)
       // macOS defaults SecItem to the legacy file-based keychain, which ignores
-      // kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly and prompts the user
-      // on access. Opt into the data-protection keychain so the Mac app behaves
-      // like the iOS one. Must be set identically on every query for the same
-      // item, which is why it lives here rather than at the call sites.
-      query[kSecUseDataProtectionKeychain as String] = true
+      // kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly and can prompt on
+      // access. Prefer the data-protection keychain so the Mac app behaves like
+      // the iOS one — but only when this build can actually use it. Must be set
+      // identically on every query for the same item, which is why it lives
+      // here rather than at the call sites.
+      if usesDataProtectionKeychain {
+        query[kSecUseDataProtectionKeychain as String] = true
+      }
     #endif
     return query
   }
+
+  #if os(macOS)
+    /// The macOS data-protection keychain requires an `application-identifier`
+    /// or `keychain-access-groups` entitlement, which only a properly
+    /// team-signed build carries. Ad-hoc and unsigned local builds have
+    /// neither, and every SecItem call there fails with
+    /// `errSecMissingEntitlement (-34018)` — which reads to the user as
+    /// "couldn't save your sign-in".
+    ///
+    /// Probing once beats assuming: a shipping signed build gets the modern
+    /// keychain, and a developer's local build silently falls back to the
+    /// legacy one instead of being unable to sign in at all. Resolved a single
+    /// time per process so save, read and delete can never disagree about which
+    /// keychain holds the item.
+    private static let usesDataProtectionKeychain: Bool = {
+      var probe: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: probeAccount,
+        kSecValueData as String: Data("probe".utf8),
+        kSecUseDataProtectionKeychain as String: true,
+      ]
+      let status = SecItemAdd(probe as CFDictionary, nil)
+      guard status == errSecSuccess || status == errSecDuplicateItem else {
+        return false
+      }
+      probe.removeValue(forKey: kSecValueData as String)
+      SecItemDelete(probe as CFDictionary)
+      return true
+    }()
+
+    private static let probeAccount = "nk.keychainProbe"
+  #endif
 
   private static func readTokenFromKeychain() -> String? {
     var query = baseQuery

--- a/TwinskaraokeShared/Services/CredentialStore.swift
+++ b/TwinskaraokeShared/Services/CredentialStore.swift
@@ -113,11 +113,20 @@ nonisolated enum CredentialStore {
   }
 
   private static var baseQuery: [String: Any] {
-    [
+    var query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
       kSecAttrAccount as String: tokenAccount,
     ]
+    #if os(macOS)
+      // macOS defaults SecItem to the legacy file-based keychain, which ignores
+      // kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly and prompts the user
+      // on access. Opt into the data-protection keychain so the Mac app behaves
+      // like the iOS one. Must be set identically on every query for the same
+      // item, which is why it lives here rather than at the call sites.
+      query[kSecUseDataProtectionKeychain as String] = true
+    #endif
+    return query
   }
 
   private static func readTokenFromKeychain() -> String? {

--- a/TwinskaraokeShared/Services/QRSignInService.swift
+++ b/TwinskaraokeShared/Services/QRSignInService.swift
@@ -33,7 +33,7 @@ import Foundation
 /// accepts as a subdomain of the first-party host `neurokaraoke.com`
 /// (`QRApproveView.trustedQRHosts`). Rebuilding it here would risk drifting out
 /// of that allowlist.
-nonisolated enum TVQRSignIn {
+nonisolated enum QRSignIn {
     // MARK: - Contract
 
     enum Route {

--- a/TwinskaraokeTVApp/Features/Account/AccountView.swift
+++ b/TwinskaraokeTVApp/Features/Account/AccountView.swift
@@ -257,7 +257,7 @@ struct AccountView: View {
         .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 28))
     }
 
-    private func limitsSection(_ limits: TVUploadLimits) -> some View {
+    private func limitsSection(_ limits: UploadLimits) -> some View {
         VStack(alignment: .leading, spacing: 24) {
             TVSectionHeader(
                 title: "Account Usage",
@@ -304,7 +304,7 @@ struct AccountView: View {
                 spacing: 32
             ) {
                 ForEach(auth.badges) { badge in
-                    TVBadgeCard(badge: badge)
+                    AccountBadgeCardView(badge: badge)
                 }
             }
         }
@@ -388,8 +388,8 @@ private struct TVAccountMetric: View {
     }
 }
 
-private struct TVBadgeCard: View {
-    let badge: TVBadge
+private struct AccountBadgeCardView: View {
+    let badge: AccountBadge
 
     @FocusState private var isFocused: Bool
 

--- a/TwinskaraokeTVApp/Services/TVAuthManager.swift
+++ b/TwinskaraokeTVApp/Services/TVAuthManager.swift
@@ -1,68 +1,6 @@
 import Foundation
 import Observation
 
-struct TVProfileResponse: Decodable, Sendable {
-    let profile: TVProfile
-    let badges: [TVBadge]?
-}
-
-struct TVProfile: Decodable, Sendable {
-    let displayName: String
-    let avatarUrl: String?
-    let level: Int?
-    let levelTitle: String?
-    let totalXP: Int?
-    let totalBadges: Int?
-    let unlockedBadges: Int?
-    let levelProgress: Double?
-    let xpToNextLevel: Int?
-
-    var avatarURL: URL? {
-        Self.remoteURL(from: avatarUrl)
-    }
-
-    private static func remoteURL(from value: String?) -> URL? {
-        guard let value, !value.isEmpty else { return nil }
-        if let url = URL(string: value), url.scheme != nil {
-            return url
-        }
-        return URL(string: "\(StorageHost.base)\(ArtworkURLBuilder.normalizedPath(value))")
-    }
-}
-
-struct TVBadge: Decodable, Identifiable, Sendable {
-    let id: String
-    let name: String
-    let description: String?
-    let rarity: Int
-    let unlocked: Bool
-    let currentProgress: Int
-    let conditionValue: Int
-    let media: TVBadgeMedia?
-
-    var iconURL: URL? {
-        ArtworkURLBuilder.imageURL(
-            cloudflareID: media?.cloudflareId,
-            path: nil,
-            variant: .thumbnail
-        )
-    }
-}
-
-struct TVBadgeMedia: Decodable, Sendable {
-    let cloudflareId: String?
-}
-
-struct TVUploadLimits: Decodable, Sendable {
-    let maxSongs: Int
-    let maxStorageBytes: Int64
-    let usedStorageBytes: Int64
-    let currentSongCount: Int
-    let currentPlaylistCount: Int
-    let playlistLimit: Int
-    let songPerPlaylistLimit: Int
-}
-
 @MainActor
 @Observable
 final class TVAuthManager {
@@ -70,15 +8,15 @@ final class TVAuthManager {
     private(set) var currentUsername: String?
     private(set) var currentUserId: String?
     private(set) var currentAvatar: String?
-    private(set) var profile: TVProfile?
-    private(set) var badges: [TVBadge] = []
-    private(set) var uploadLimits: TVUploadLimits?
+    private(set) var profile: UserProfile?
+    private(set) var badges: [AccountBadge] = []
+    private(set) var uploadLimits: UploadLimits?
     private(set) var isAuthenticating = false
     private(set) var isRefreshing = false
     private(set) var authError: String?
     private(set) var profileError: String?
 
-    private(set) var qrSession: TVQRSignIn.Session?
+    private(set) var qrSession: QRSignIn.Session?
     private(set) var qrPhase: QRPhase = .idle
     private(set) var qrError: String?
 
@@ -217,9 +155,9 @@ final class TVAuthManager {
     }
 
     private func runQRSignIn() async {
-        var session: TVQRSignIn.Session
+        var session: QRSignIn.Session
         do {
-            session = try await TVQRSignIn.createSession()
+            session = try await QRSignIn.createSession()
         } catch {
             guard !Task.isCancelled else { return }
             qrError = friendlyMessage(for: error)
@@ -248,7 +186,7 @@ final class TVAuthManager {
             guard !Task.isCancelled else { return }
 
             do {
-                let poll = try await TVQRSignIn.status(of: session.id)
+                let poll = try await QRSignIn.status(of: session.id)
                 guard !Task.isCancelled, qrSession?.id == session.id else { return }
                 // The server owns the deadline; the value from `createSession`
                 // is only a placeholder until the first poll lands.
@@ -318,7 +256,7 @@ final class TVAuthManager {
         var didFail = false
         if let profileData {
             do {
-                let response = try JSONDecoder().decode(TVProfileResponse.self, from: profileData)
+                let response = try JSONDecoder().decode(ProfileResponse.self, from: profileData)
                 profile = response.profile
                 badges = response.badges ?? []
                 persistAvatar(response.profile.avatarUrl)
@@ -331,7 +269,7 @@ final class TVAuthManager {
 
         if let limitsData {
             do {
-                uploadLimits = try JSONDecoder().decode(TVUploadLimits.self, from: limitsData)
+                uploadLimits = try JSONDecoder().decode(UploadLimits.self, from: limitsData)
             } catch {
                 didFail = true
             }
@@ -482,7 +420,7 @@ final class TVAuthManager {
         // `ServiceError` already phrases its own cases for this screen — most
         // usefully the 429 rate-limit text, which the generic fallback below
         // would otherwise flatten into a connection problem.
-        if let serviceError = error as? TVQRSignIn.ServiceError,
+        if let serviceError = error as? QRSignIn.ServiceError,
            let description = serviceError.errorDescription
         {
             return description


### PR DESCRIPTION
## Summary by Sourcery

Add a native macOS SwiftUI app target with authentication, playback, search, playlists, favourites and account profile support, while sharing account/profile models and QR sign-in logic across platforms and updating keychain handling for macOS.

New Features:
- Introduce a macOS SwiftUI app with navigation split view, player bar, playback controls, search, library, favourites and playlists screens.
- Add macOS-specific authentication manager supporting username/password, Discord OAuth and QR-based device pairing.
- Implement macOS audio playback manager with AVPlayer, MediaPlayer now-playing integration and remote command handling.
- Add macOS image cache and remote image utilities for artwork rendering.
- Add shared account profile, badge and upload limit models reusable across iOS, tvOS and macOS targets.
- Introduce macOS-specific profile header, upload limits, badges UI and QR sign-in panel components.

Enhancements:
- Refactor tvOS auth and account views to reuse shared profile, badge and upload limit models and QR sign-in service.
- Update keychain credential store to prefer the macOS data-protection keychain when entitlements allow, with a runtime probe and fallback.
- Extend song model to disable Neuro fallback artwork and credit on macOS similarly to watchOS/tvOS.
- Rename and move QR sign-in service into shared code for reuse by macOS and tvOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native macOS app with Home, Search, Favorites, Library, playlists, and account screens.
  * Added music playback controls, queue management, seeking, volume, repeat modes, artwork, and system media controls.
  * Added credential, Discord, and QR-code sign-in options with session restoration.
  * Added profile details, badges, upload limits, playlist browsing, refresh, and error handling.
  * Added artwork caching and improved shared account data support.

* **Localization**
  * Added labels for navigation, playback, search, and sign-in experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->