### PR TITLE
Give haptics one semantic scale and a strength setting

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -489,7 +489,16 @@ private struct PopupModifier: ViewModifier {
                                 }
                             #endif
                         }
+                        // The mini player's own tap and its swipe-to-dismiss are
+                        // handled inside LNPopupController, so this binding is
+                        // the only place either surfaces to us.  Guarded on an
+                        // actual change: the suppression path above calls
+                        // `collapse()` on an already-collapsed popup.
+                        let wasExpanded = presentationState.isExpanded
                         presentationState.setExpanded(isOpen)
+                        if isOpen != wasExpanded {
+                            (isOpen ? AppHaptic.commit : AppHaptic.dismiss).play()
+                        }
                     }
                 )
             ) {
@@ -588,7 +597,7 @@ private struct PopupBarTrailingItems: View, Equatable {
                 .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.86, dim: 0.65, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.86, dim: 0.65, haptic: .commit))
             .accessibilityLabel(playPauseAccessibilityLabel)
             .accessibilityHint(
                 isRadioMode ? "Controls the live radio stream." : "Controls the current song."
@@ -601,7 +610,7 @@ private struct PopupBarTrailingItems: View, Equatable {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(PressableButtonStyle(scale: 0.86, dim: 0.65, haptic: .light))
+                .buttonStyle(PressableButtonStyle(scale: 0.86, dim: 0.65, haptic: .selection))
                 .accessibilityLabel("Next track")
                 .accessibilityHint("Skips to the next song.")
             }

--- a/Twinskaraoke/App/TwinskaraokeApp.swift
+++ b/Twinskaraoke/App/TwinskaraokeApp.swift
@@ -31,6 +31,7 @@ struct TwinskaraokeApp: App {
                 .preferredColorScheme(resolvedColorScheme)
                 .environment(\.locale, Locale(identifier: resolvedLanguage.localeIdentifier))
                 .injectReduceMotion()
+                .injectHaptics()
                 .tint(.appAccent)
                 .shimejiSession()
                 .onAppear {

--- a/Twinskaraoke/Components/Account/BadgeViews.swift
+++ b/Twinskaraoke/Components/Account/BadgeViews.swift
@@ -101,7 +101,7 @@ struct BadgeDetailSheet: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             Button {
-                AppHaptic.light.play()
+                AppHaptic.dismiss.play()
                 dismiss()
             } label: {
                 Image(systemName: "xmark")

--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -118,7 +118,6 @@ struct WideSongListPanel: View {
                     Spacer()
                 }
             }
-            .navigationTapHaptic()
             .buttonStyle(.plain)
             LazyVStack(spacing: 0) {
                 ForEach(songs) { song in

--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -118,6 +118,7 @@ struct WideSongListPanel: View {
                     Spacer()
                 }
             }
+            .navigationTapHaptic()
             .buttonStyle(.plain)
             LazyVStack(spacing: 0) {
                 ForEach(songs) { song in

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -65,7 +65,7 @@ struct AddToPlaylistSheet: View {
             .safeAreaInset(edge: .bottom) {
                 if !manager.playlists.isEmpty {
                     Button {
-                        AppHaptic.selection.play()
+                        AppHaptic.commit.play()
                         showCreatePlaylist = true
                     } label: {
                         Label("New Playlist", systemImage: "plus")
@@ -75,7 +75,7 @@ struct AddToPlaylistSheet: View {
                             .padding(.vertical, 14)
                             .background(Color.appControlActiveFill, in: Capsule())
                     }
-                    .buttonStyle(PressableButtonStyle(scale: 0.97, dim: 0.78, haptic: .medium))
+                    .buttonStyle(PressableButtonStyle(scale: 0.97, dim: 0.78, haptic: nil))
                     .padding(.horizontal, 20)
                     .padding(.top, 10)
                     .padding(.bottom, 10)
@@ -119,7 +119,7 @@ struct AddToPlaylistSheet: View {
                 message: "Create a playlist first to save this song."
             )
             Button {
-                AppHaptic.selection.play()
+                AppHaptic.commit.play()
                 showCreatePlaylist = true
             } label: {
                 Label("New Playlist", systemImage: "plus")
@@ -129,7 +129,7 @@ struct AddToPlaylistSheet: View {
                     .padding(.vertical, 12)
                     .background(Color.appControlActiveFill, in: Capsule())
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.95, dim: 0.78, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.95, dim: 0.78, haptic: nil))
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 32)

--- a/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
+++ b/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
@@ -141,6 +141,12 @@ struct AppleMusicProgressBar: View {
                 didHitEdge = true
                 AppHaptic.boundary.play()
             }
+            // Seed the notch index even though no detent plays here. Otherwise a
+            // drag that starts at an edge — or travels out to one and back —
+            // leaves this nil, and the `lastDetentIndex != nil` guard below eats
+            // the first interior notch. The guard is meant to fire once per
+            // gesture, not once per edge visit.
+            lastDetentIndex = Int(next * Double(Self.detentCount))
             return
         }
         didHitEdge = false

--- a/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
+++ b/Twinskaraoke/Components/Player/AppleMusicProgressBar.swift
@@ -20,6 +20,13 @@ struct AppleMusicProgressBar: View {
     @ScaledMetric(relativeTo: .caption) private var scaledBubbleHeight: CGFloat = 22
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var didBeginScrubbing = false
+    @State private var lastDetentIndex: Int?
+    @State private var didHitEdge = false
+
+    /// Notches across the full bar.  40 puts them ~2.5% apart, which on a
+    /// typical song is a few seconds per tick — dense enough to feel like
+    /// texture under the thumb, sparse enough that each tick stays distinct.
+    private static let detentCount = 40
 
     private var clampedProgress: Double {
         min(max(progress, 0), 1)
@@ -88,16 +95,21 @@ struct AppleMusicProgressBar: View {
                         }
                         if !didBeginScrubbing {
                             didBeginScrubbing = true
-                            AppHaptic.selection.play()
+                            AppHaptic.detent.prepare()
+                            AppHaptic.grab.play()
                         }
-                        progress = max(0, min(1, value.location.x / width))
+                        let next = max(0, min(1, value.location.x / width))
+                        playScrubFeedback(at: next)
+                        progress = next
                     }
                     .onEnded { _ in
                         let finalProgress = clampedProgress
                         onSeekEnd(finalProgress)
                         isScrubbing = false
                         didBeginScrubbing = false
-                        AppHaptic.light.play()
+                        lastDetentIndex = nil
+                        didHitEdge = false
+                        AppHaptic.commit.play()
                     }
             )
             .animation(scrubAnimation, value: isScrubbing)
@@ -120,11 +132,34 @@ struct AppleMusicProgressBar: View {
         }
     }
 
+    /// Ticks once per notch crossed, and thumps once when travel stops against
+    /// either end.  The edge flag latches so holding a finger past the end
+    /// doesn't repeat the thump every frame.
+    private func playScrubFeedback(at next: Double) {
+        if next <= 0 || next >= 1 {
+            if !didHitEdge {
+                didHitEdge = true
+                AppHaptic.boundary.play()
+            }
+            return
+        }
+        didHitEdge = false
+
+        let index = Int(next * Double(Self.detentCount))
+        guard index != lastDetentIndex else { return }
+        // Skip the very first comparison so picking the thumb up doesn't tick
+        // on top of the `.grab` that just played.
+        if lastDetentIndex != nil {
+            AppHaptic.detent.play()
+        }
+        lastDetentIndex = index
+    }
+
     private func adjustProgress(by delta: Double) {
         let nextProgress = min(max(progress + delta, 0), 1)
         progress = nextProgress
         onSeekEnd(nextProgress)
-        AppHaptic.selection.play()
+        AppHaptic.detent.play()
     }
 
     private var scrubAnimation: Animation? {

--- a/Twinskaraoke/Components/Player/KaraokeRightDock.swift
+++ b/Twinskaraoke/Components/Player/KaraokeRightDock.swift
@@ -75,7 +75,7 @@ struct KaraokeRightDock: View {
                 showKaraokeControls = false
             } else {
                 guard canActivateKaraoke else { return }
-                AppHaptic.medium.play()
+                AppHaptic.commit.play()
                 audioManager.karaokeMode = true
                 showKaraokeControls = true
             }

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -444,7 +444,12 @@ struct AccountToolbarButton: View {
                 ToolbarIconLabel(systemImage: "person.fill")
             }
         }
-        .buttonStyle(PressableButtonStyle(scale: 0.92, dim: 0.78, haptic: .selection))
+        // The style's own haptic is unreliable here: this lives in a
+        // `ToolbarItem`, and SwiftUI substitutes its own button style inside
+        // toolbars, discarding the custom style's feedback with it.  The
+        // explicit gesture is what actually fires.
+        .buttonStyle(PressableButtonStyle(scale: 0.92, dim: 0.78, haptic: nil))
+        .navigationTapHaptic()
         .accessibilityIdentifier("AccountToolbarButton")
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Opens account and settings.")
@@ -633,6 +638,7 @@ struct AMSectionHeader<Destination: View>: View {
                 NavigationLink(destination: destination) {
                     headerRow(showChevron: true)
                 }
+                .navigationTapHaptic()
                 .buttonStyle(.plain)
             } else {
                 headerRow(showChevron: false)

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -444,12 +444,13 @@ struct AccountToolbarButton: View {
                 ToolbarIconLabel(systemImage: "person.fill")
             }
         }
-        // The style's own haptic is unreliable here: this lives in a
-        // `ToolbarItem`, and SwiftUI substitutes its own button style inside
-        // toolbars, discarding the custom style's feedback with it.  The
-        // explicit gesture is what actually fires.
-        .buttonStyle(PressableButtonStyle(scale: 0.92, dim: 0.78, haptic: nil))
-        .navigationTapHaptic()
+        // Note this may not fire: SwiftUI substitutes its own button style
+        // inside a `ToolbarItem` and discards the custom style's feedback with
+        // it. Declared anyway because it costs nothing and works wherever the
+        // style *is* honoured — a tap gesture here would be worse, since one
+        // attached to a NavigationLink can win arbitration and eat the
+        // navigation entirely.
+        .buttonStyle(PressableButtonStyle(scale: 0.92, dim: 0.78, haptic: .selection))
         .accessibilityIdentifier("AccountToolbarButton")
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Opens account and settings.")
@@ -638,7 +639,6 @@ struct AMSectionHeader<Destination: View>: View {
                 NavigationLink(destination: destination) {
                     headerRow(showChevron: true)
                 }
-                .navigationTapHaptic()
                 .buttonStyle(.plain)
             } else {
                 headerRow(showChevron: false)

--- a/Twinskaraoke/Components/Shared/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/Shared/ScrollOptimization.swift
@@ -17,6 +17,15 @@ extension View {
         }
     }
 
+    /// Thumps once when the scroll view arrives at its bottom edge.
+    ///
+    /// Attach to long content lists, not to short ones: on content that barely
+    /// overflows, the end is reached constantly and the feedback stops meaning
+    /// anything.  The `guard` below skips non-scrolling content entirely.
+    func scrollEdgeHaptic(threshold: CGFloat = 2, rearmDistance: CGFloat = 48) -> some View {
+        modifier(ScrollEdgeHapticModifier(threshold: threshold, rearmDistance: rearmDistance))
+    }
+
     func scrollParallaxHero(
         baseSize: CGFloat,
         restingOffset: CGFloat = 0,
@@ -39,6 +48,58 @@ extension View {
                 .scaleEffect(scale)
                 .offset(y: yOffset)
                 .opacity(opacity)
+        }
+    }
+}
+
+/// Thumps once on arrival at the bottom, then refuses to thump again until the
+/// user has scrolled a real distance back up.
+///
+/// The hysteresis is the whole point.  A single `contentOffset >= travel`
+/// comparison looks correct and misbehaves badly: a rubber-band bounce
+/// oscillates across that line for the length of the bounce, so the thump
+/// re-fires every frame of it instead of once on arrival.
+private struct ScrollEdgeHapticModifier: ViewModifier {
+    let threshold: CGFloat
+    let rearmDistance: CGFloat
+    @State private var isArmed = true
+
+    /// Coarse zones rather than a raw distance.  `onScrollGeometryChange` only
+    /// runs its action when the transformed value *changes*, so returning a
+    /// continuously-varying `CGFloat` makes it fire every frame — SwiftUI then
+    /// logs "tried to update multiple times per frame".  Three zones collapse a
+    /// whole drag into two or three action calls.
+    private enum Zone: Equatable {
+        case atEnd
+        case approaching
+        case away
+        case notScrollable
+    }
+
+    func body(content: Content) -> some View {
+        content.onScrollGeometryChange(for: Zone.self) { geometry in
+            let travel = geometry.contentSize.height
+                + geometry.contentInsets.top
+                + geometry.contentInsets.bottom
+                - geometry.containerSize.height
+            guard travel > 0 else { return .notScrollable }
+            // Remaining distance to the bottom; negative while overscrolled.
+            let remaining = travel - geometry.contentOffset.y
+            if remaining <= threshold { return .atEnd }
+            return remaining > rearmDistance ? .away : .approaching
+        } action: { _, zone in
+            switch zone {
+            case .atEnd:
+                // Re-arming requires reaching `.away`, so a rubber-band settle
+                // that dips back into `.approaching` cannot re-trigger.
+                guard isArmed else { return }
+                isArmed = false
+                AppHaptic.boundary.play()
+            case .away:
+                isArmed = true
+            case .approaching, .notScrollable:
+                break
+            }
         }
     }
 }

--- a/Twinskaraoke/Components/Shared/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/Shared/ScrollOptimization.swift
@@ -83,8 +83,14 @@ private struct ScrollEdgeHapticModifier: ViewModifier {
                 + geometry.contentInsets.bottom
                 - geometry.containerSize.height
             guard travel > 0 else { return .notScrollable }
+            // `contentOffset` is not inset-normalised — at rest against the top it
+            // reads `-contentInsets.top`, not zero. Since `travel` includes the
+            // top inset, comparing it against the raw offset leaves `remaining`
+            // bottoming out at `contentInsets.top` instead of 0, so `.atEnd` was
+            // unreachable on any inset content and the thump never fired.
+            let offset = geometry.contentOffset.y + geometry.contentInsets.top
             // Remaining distance to the bottom; negative while overscrolled.
-            let remaining = travel - geometry.contentOffset.y
+            let remaining = travel - offset
             if remaining <= threshold { return .atEnd }
             return remaining > rearmDistance ? .away : .approaching
         } action: { _, zone in

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -269,7 +269,7 @@ struct MusicGridCard: View {
             .frame(width: width, alignment: .leading)
             .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
         }
-        .buttonStyle(PressableButtonStyle(scale: size == .regular ? 0.97 : 0.96, dim: 0.78, haptic: .selection))
+        .buttonStyle(PressableButtonStyle(scale: size == .regular ? 0.97 : 0.96, dim: 0.78, haptic: nil))
         .contextMenu {
             SongActionsMenuItems(song: song) {
                 showAddToPlaylist = true
@@ -522,7 +522,7 @@ private struct SongRowAccessibilityModifier: ViewModifier {
     private func performDownloadAction() {
         let downloads = DownloadManager.shared
         if downloadState.status.isDownloaded {
-            AppHaptic.warning.play()
+            AppHaptic.dismiss.play()
             downloads.remove(songID: song.id)
         } else if downloadState.status.isDownloading {
             AppHaptic.selection.play()

--- a/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
+++ b/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
@@ -83,6 +83,10 @@ struct ZoomNavigationLink<Destination: View, Label: View>: View {
             label()
         }
         .zoomTransitionSource(id: id, in: namespace, isEnabled: !reduceMotion)
+        // A tap here is a navigation, and the zoom transition gives it no action
+        // closure to hang feedback on.  Safe next to the drag-driven dismissal
+        // documented above: a TapGesture needs a press with no travel.
+        .navigationTapHaptic()
     }
 }
 

--- a/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
+++ b/Twinskaraoke/Components/Shared/ZoomNavigationLink.swift
@@ -83,10 +83,6 @@ struct ZoomNavigationLink<Destination: View, Label: View>: View {
             label()
         }
         .zoomTransitionSource(id: id, in: namespace, isEnabled: !reduceMotion)
-        // A tap here is a navigation, and the zoom transition gives it no action
-        // closure to hang feedback on.  Safe next to the drag-driven dismissal
-        // documented above: a TapGesture needs a press with no travel.
-        .navigationTapHaptic()
     }
 }
 

--- a/Twinskaraoke/Features/Account/AboutView.swift
+++ b/Twinskaraoke/Features/Account/AboutView.swift
@@ -81,7 +81,6 @@ struct AboutView: View {
                         subtitle: "Catalog, radio, galleries, games, and community tools"
                     )
                 }
-                .navigationTapHaptic()
                 NavigationLink {
                     CreditsView()
                 } label: {
@@ -92,7 +91,6 @@ struct AboutView: View {
                         subtitle: "Artists, maintainers, testers, and contributors"
                     )
                 }
-                .navigationTapHaptic()
                 NavigationLink {
                     LanguageSupportView()
                 } label: {
@@ -103,7 +101,6 @@ struct AboutView: View {
                         subtitle: "Available app languages and regional behavior"
                     )
                 }
-                .navigationTapHaptic()
                 NavigationLink {
                     iOSAppDevelopmentView()
                 } label: {
@@ -114,7 +111,6 @@ struct AboutView: View {
                         subtitle: "Source code, stack, and contribution notes"
                     )
                 }
-                .navigationTapHaptic()
                 NavigationLink {
                     ContactSupportView()
                 } label: {
@@ -125,7 +121,6 @@ struct AboutView: View {
                         subtitle: "Credit corrections and take-down requests"
                     )
                 }
-                .navigationTapHaptic()
             }
             Section("Resources") {
                 Link(destination: URL(string: "https://radio.twinskaraoke.com")!) {
@@ -160,7 +155,6 @@ struct AboutView: View {
                         subtitle: "Data storage, network services, and user choices"
                     )
                 }
-                .navigationTapHaptic()
                 NavigationLink {
                     TermsOfServiceView()
                 } label: {
@@ -171,7 +165,6 @@ struct AboutView: View {
                         subtitle: "Community-use rules and legal disclaimers"
                     )
                 }
-                .navigationTapHaptic()
                 NavigationLink {
                     AcknowledgementsView()
                 } label: {
@@ -182,7 +175,6 @@ struct AboutView: View {
                         subtitle: "Third-party package acknowledgements"
                     )
                 }
-                .navigationTapHaptic()
             }
             Section {
                 Text("© 2026 Neuro & Evil Karaoke Web Player\nFan-made by Soul. Unofficial.")
@@ -354,7 +346,6 @@ private struct LanguageSupportView: View {
                         subtitle: "Change language, appearance, playback, and storage preferences"
                     )
                 }
-                .navigationTapHaptic()
             }
         }
         .navigationTitle("Language Support")

--- a/Twinskaraoke/Features/Account/AboutView.swift
+++ b/Twinskaraoke/Features/Account/AboutView.swift
@@ -81,6 +81,7 @@ struct AboutView: View {
                         subtitle: "Catalog, radio, galleries, games, and community tools"
                     )
                 }
+                .navigationTapHaptic()
                 NavigationLink {
                     CreditsView()
                 } label: {
@@ -91,6 +92,7 @@ struct AboutView: View {
                         subtitle: "Artists, maintainers, testers, and contributors"
                     )
                 }
+                .navigationTapHaptic()
                 NavigationLink {
                     LanguageSupportView()
                 } label: {
@@ -101,6 +103,7 @@ struct AboutView: View {
                         subtitle: "Available app languages and regional behavior"
                     )
                 }
+                .navigationTapHaptic()
                 NavigationLink {
                     iOSAppDevelopmentView()
                 } label: {
@@ -111,6 +114,7 @@ struct AboutView: View {
                         subtitle: "Source code, stack, and contribution notes"
                     )
                 }
+                .navigationTapHaptic()
                 NavigationLink {
                     ContactSupportView()
                 } label: {
@@ -121,6 +125,7 @@ struct AboutView: View {
                         subtitle: "Credit corrections and take-down requests"
                     )
                 }
+                .navigationTapHaptic()
             }
             Section("Resources") {
                 Link(destination: URL(string: "https://radio.twinskaraoke.com")!) {
@@ -155,6 +160,7 @@ struct AboutView: View {
                         subtitle: "Data storage, network services, and user choices"
                     )
                 }
+                .navigationTapHaptic()
                 NavigationLink {
                     TermsOfServiceView()
                 } label: {
@@ -165,6 +171,7 @@ struct AboutView: View {
                         subtitle: "Community-use rules and legal disclaimers"
                     )
                 }
+                .navigationTapHaptic()
                 NavigationLink {
                     AcknowledgementsView()
                 } label: {
@@ -175,6 +182,7 @@ struct AboutView: View {
                         subtitle: "Third-party package acknowledgements"
                     )
                 }
+                .navigationTapHaptic()
             }
             Section {
                 Text("© 2026 Neuro & Evil Karaoke Web Player\nFan-made by Soul. Unofficial.")
@@ -346,6 +354,7 @@ private struct LanguageSupportView: View {
                         subtitle: "Change language, appearance, playback, and storage preferences"
                     )
                 }
+                .navigationTapHaptic()
             }
         }
         .navigationTitle("Language Support")

--- a/Twinskaraoke/Features/Account/AccountView.swift
+++ b/Twinskaraoke/Features/Account/AccountView.swift
@@ -100,7 +100,6 @@ struct AccountView: View {
                         xpToNextLevel: profile?.xpToNextLevel
                     )
                 }
-                .navigationTapHaptic()
                 if !unlockedBadges.isEmpty {
                     UnlockedBadgesRow(
                         badges: unlockedBadges,
@@ -142,13 +141,11 @@ struct AccountView: View {
             } label: {
                 Label("Settings", systemImage: "gearshape")
             }
-            .navigationTapHaptic()
             NavigationLink {
                 NotificationsView()
             } label: {
                 Label("Notifications", systemImage: "bell")
             }
-            .navigationTapHaptic()
             NavigationLink {
                 AboutView()
             } label: {

--- a/Twinskaraoke/Features/Account/AccountView.swift
+++ b/Twinskaraoke/Features/Account/AccountView.swift
@@ -100,6 +100,7 @@ struct AccountView: View {
                         xpToNextLevel: profile?.xpToNextLevel
                     )
                 }
+                .navigationTapHaptic()
                 if !unlockedBadges.isEmpty {
                     UnlockedBadgesRow(
                         badges: unlockedBadges,
@@ -141,11 +142,13 @@ struct AccountView: View {
             } label: {
                 Label("Settings", systemImage: "gearshape")
             }
+            .navigationTapHaptic()
             NavigationLink {
                 NotificationsView()
             } label: {
                 Label("Notifications", systemImage: "bell")
             }
+            .navigationTapHaptic()
             NavigationLink {
                 AboutView()
             } label: {
@@ -157,7 +160,7 @@ struct AccountView: View {
     private var signOutSection: some View {
         Section {
             Button(role: .destructive) {
-                AppHaptic.warning.play()
+                AppHaptic.selection.play()
                 showSignOutConfirm = true
             } label: {
                 HStack {
@@ -171,7 +174,7 @@ struct AccountView: View {
                 Button("Cancel", role: .cancel) {}
                     .tint(Color(uiColor: .systemBlue))
                 Button("Sign Out", role: .destructive) {
-                    AppHaptic.warning.play()
+                    AppHaptic.dismiss.play()
                     auth.logout()
                 }
             } message: {

--- a/Twinskaraoke/Features/Account/LoginSheet.swift
+++ b/Twinskaraoke/Features/Account/LoginSheet.swift
@@ -243,7 +243,7 @@ struct LoginSheet: View {
     private var discordButton: some View {
         Button {
             guard !auth.isLoading else { return }
-            AppHaptic.medium.play()
+            AppHaptic.commit.play()
             Task { await auth.loginWithDiscord() }
         } label: {
             HStack(spacing: 10) {
@@ -279,7 +279,7 @@ struct LoginSheet: View {
             focus = trimmedUsername.isEmpty ? .username : .password
             return
         }
-        AppHaptic.medium.play()
+        AppHaptic.commit.play()
         focus = nil
         Task { await auth.login(username: trimmedUsername, password: password) }
     }

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -38,7 +38,7 @@ struct QRApproveView: View {
                 }
                 ToolbarItem(placement: .cancellationAction) {
                     Button {
-                        AppHaptic.light.play()
+                        AppHaptic.dismiss.play()
                         dismiss()
                     } label: {
                         Image(systemName: "xmark")
@@ -106,7 +106,7 @@ struct QRApproveView: View {
                 message: message,
                 retry: retryCameraCheck,
                 dismiss: {
-                    AppHaptic.light.play()
+                    AppHaptic.dismiss.play()
                     dismiss()
                 }
             )
@@ -189,7 +189,7 @@ struct QRApproveView: View {
 
             VStack(spacing: 10) {
                 Button {
-                    AppHaptic.medium.play()
+                    AppHaptic.commit.play()
                     Task { await approve(sessionId: sessionId) }
                 } label: {
                     QRActionLabel(title: "Approve", systemImage: "checkmark.circle.fill", isPrimary: true)
@@ -197,7 +197,7 @@ struct QRApproveView: View {
                 .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.78))
 
                 Button {
-                    AppHaptic.light.play()
+                    AppHaptic.dismiss.play()
                     withOptionalAnimation(phaseAnimation) {
                         phase = .scanning
                     }
@@ -249,7 +249,7 @@ struct QRApproveView: View {
                         phase = .scanning
                     }
                 } else {
-                    AppHaptic.light.play()
+                    AppHaptic.dismiss.play()
                     dismiss()
                 }
             } label: {

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -12,6 +12,8 @@ struct SettingsView: View {
     @AppStorage("nk.appearance") private var appearanceMode: String = AppearanceMode.dark.rawValue
     @AppStorage(AppLanguage.storageKey) private var languageMode: String = AppLanguage.system.rawValue
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
+    @AppStorage(AppHaptics.storageKey) private var hapticsEnabled: Bool = true
+    @AppStorage(AppHaptics.strengthStorageKey) private var hapticStrength: String = AppHapticStrength.default.rawValue
     @AppStorage("nk.experimentsEnabled") private var experimentsEnabled: Bool = false
     @AppStorage("nk.experimentalThemesEnabled") private var experimentalThemesEnabled: Bool = false
     @AppStorage("nk.experimentalShimejiEnabled") private var shimejiEnabled: Bool = false
@@ -110,6 +112,7 @@ struct SettingsView: View {
             }
             equalizerSection
             lyricsSection
+            hapticsSection
             appearanceSection
             storageSection
             developerSection
@@ -123,10 +126,13 @@ struct SettingsView: View {
     private var librarySection: some View {
         Section {
             Toggle("Add Playlist Songs", isOn: $addPlaylistSongsToLibrary)
+            .toggleHaptic(addPlaylistSongsToLibrary)
                 .tint(.appAccent)
             Toggle("Add Favorite Songs", isOn: $addFavoriteSongsToLibrary)
+            .toggleHaptic(addFavoriteSongsToLibrary)
                 .tint(.appAccent)
             Toggle("Sync Library", isOn: $syncLibrary)
+            .toggleHaptic(syncLibrary)
                 .tint(.appAccent)
         } header: {
             Text("Library")
@@ -152,8 +158,10 @@ struct SettingsView: View {
     private var audioSection: some View {
         Section {
             Toggle("Auto Mix", isOn: $audioManager.autoMixEnabled)
+            .toggleHaptic(audioManager.autoMixEnabled)
                 .tint(.appAccent)
             Toggle("Crossfade", isOn: $audioManager.crossfadeEnabled)
+            .toggleHaptic(audioManager.crossfadeEnabled)
                 .tint(.appAccent)
             if audioManager.crossfadeEnabled {
                 CrossfadeDurationRow(
@@ -170,12 +178,14 @@ struct SettingsView: View {
                     set: { _ in audioManager.toggleAutoplay() }
                 )
             )
+            .toggleHaptic(audioManager.autoplayEnabled)
             .tint(.appAccent)
             Picker("Audio Quality", selection: $streamingQuality) {
                 Text("High Efficiency").tag("low")
                 Text("High Quality").tag("medium")
                 Text("Lossless").tag("high")
             }
+            .selectionHaptic(streamingQuality)
         } header: {
             Text("Audio")
         } footer: {
@@ -186,6 +196,7 @@ struct SettingsView: View {
     private var downloadsSection: some View {
         Section {
             Toggle("Auto-Download Played Songs", isOn: $downloadOnPlay)
+            .toggleHaptic(downloadOnPlay)
                 .tint(.appAccent)
         } header: {
             Text("Downloads")
@@ -197,12 +208,63 @@ struct SettingsView: View {
     private var lyricsSection: some View {
         Section {
             Toggle("Respect Reduce Motion", isOn: $respectReducedMotion)
+            .toggleHaptic(respectReducedMotion)
                 .tint(.appAccent)
         } header: {
             Text("Lyrics")
         } footer: {
             Text("Animated lyrics and transitions follow your motion preference.")
         }
+    }
+
+    private var hapticsSection: some View {
+        Section {
+            Toggle("Haptic Feedback", isOn: hapticsToggleBinding)
+                .tint(.appAccent)
+            if hapticsEnabled {
+                Picker("Strength", selection: hapticStrengthBinding) {
+                    ForEach(AppHapticStrength.allCases) { strength in
+                        Text(strength.label).tag(strength)
+                    }
+                }
+            }
+        } header: {
+            Text("Haptics")
+        } footer: {
+            Text(hapticsEnabled
+                ? "Taps, swipes and controls answer back with a vibration. Strength sets how hard they land — each control keeps its own character at every level."
+                : "Taps, swipes and controls answer back with a vibration.")
+        }
+    }
+
+    /// Plays the chosen level as you pick it, so the setting is judged by feel
+    /// rather than by the word next to it.
+    private var hapticStrengthBinding: Binding<AppHapticStrength> {
+        Binding(
+            get: { AppHapticStrength(rawValue: hapticStrength) ?? .default },
+            set: { newValue in
+                hapticStrength = newValue.rawValue
+                AppHaptic.commit.play()
+            }
+        )
+    }
+
+    /// Fires the confirmation *before* writing the preference when switching
+    /// off, so the toggle's own haptic still plays — the user's last impression
+    /// of the feature is the feature working, not silence.
+    private var hapticsToggleBinding: Binding<Bool> {
+        Binding(
+            get: { hapticsEnabled },
+            set: { newValue in
+                if newValue {
+                    hapticsEnabled = true
+                    AppHaptic.success.play()
+                } else {
+                    AppHaptic.dismiss.play()
+                    hapticsEnabled = false
+                }
+            }
+        )
     }
 
     private var visibleAppearanceModes: [AppearanceMode] {
@@ -218,11 +280,13 @@ struct SettingsView: View {
                     Text(mode.label).tag(mode.rawValue)
                 }
             }
+            .selectionHaptic(appearanceMode)
             Picker("Language", selection: $languageMode) {
                 ForEach(AppLanguage.allCases) { language in
                     Text(language.displayName).tag(language.rawValue)
                 }
             }
+            .selectionHaptic(languageMode)
         }
     }
 
@@ -233,7 +297,7 @@ struct SettingsView: View {
                 if newValue {
                     showExperimentsAlert = true
                 } else {
-                    AppHaptic.light.play()
+                    AppHaptic.dismiss.play()
                     experimentsEnabled = false
                     experimentalThemesEnabled = false
                     shimejiEnabled = false
@@ -248,7 +312,7 @@ struct SettingsView: View {
             get: { experimentalThemesEnabled },
             set: { newValue in
                 experimentalThemesEnabled = newValue
-                newValue ? AppHaptic.success.play() : AppHaptic.light.play()
+                newValue ? AppHaptic.success.play() : AppHaptic.dismiss.play()
                 if !newValue {
                     resetThemeIfHiddenByExperiments()
                 }
@@ -279,6 +343,7 @@ struct SettingsView: View {
                     } label: {
                         Text("Shimeji Characters")
                     }
+                    .navigationTapHaptic()
                 }
             }
         } header: {
@@ -297,7 +362,7 @@ struct SettingsView: View {
             get: { shimejiEnabled },
             set: { newValue in
                 shimejiEnabled = newValue
-                newValue ? AppHaptic.success.play() : AppHaptic.light.play()
+                newValue ? AppHaptic.success.play() : AppHaptic.dismiss.play()
                 if newValue, case .notDownloaded = ShimejiResourceManager.shared.state {
                     ShimejiResourceManager.shared.download()
                 }
@@ -314,6 +379,7 @@ struct SettingsView: View {
                 } label: {
                     Text("Developer")
                 }
+                .navigationTapHaptic()
             }
         }
     }
@@ -344,6 +410,7 @@ struct SettingsView: View {
     private var equalizerSection: some View {
         Section {
             Toggle("Equalizer", isOn: $audioManager.eqEnabled)
+            .toggleHaptic(audioManager.eqEnabled)
                 .tint(.appAccent)
             if audioManager.eqEnabled {
                 Picker("Preset", selection: $audioManager.eqPreset) {
@@ -351,6 +418,7 @@ struct SettingsView: View {
                         Text(preset.rawValue).tag(preset)
                     }
                 }
+                .selectionHaptic(audioManager.eqPreset)
                 EqualizerBands(gainsDB: $audioManager.eqGainsDB)
                     .padding(.vertical, 8)
                 Button("Reset Equalizer") {
@@ -368,6 +436,7 @@ struct SettingsView: View {
     private var aiAudioSection: some View {
         Section {
             Toggle("AI Audio Processing", isOn: $audioManager.aiEnabled)
+            .toggleHaptic(audioManager.aiEnabled)
                 .tint(.appAccent)
 
             if audioManager.aiEnabled {
@@ -411,6 +480,7 @@ struct SettingsView: View {
                     set: { audioManager.karaokeMode = $0 }
                 )
             )
+            .toggleHaptic(audioManager.karaokeMode)
             .tint(.appAccent)
             .disabled(audioManager.isBackgroundKaraokeLocked)
             if audioManager.karaokeMode {
@@ -427,6 +497,7 @@ struct SettingsView: View {
                 )
             }
             Toggle("Bass Enhance", isOn: $audioManager.bassEnhanceMode)
+            .toggleHaptic(audioManager.bassEnhanceMode)
                 .tint(.appAccent)
                 .disabled(audioManager.isBackgroundKaraokeLocked)
             if audioManager.bassEnhanceMode {
@@ -443,6 +514,7 @@ struct SettingsView: View {
                 )
             }
             Toggle("Vocal Enhance", isOn: $audioManager.vocalEnhanceMode)
+            .toggleHaptic(audioManager.vocalEnhanceMode)
                 .tint(.appAccent)
                 .disabled(audioManager.isBackgroundKaraokeLocked)
             if audioManager.vocalEnhanceMode {
@@ -459,6 +531,7 @@ struct SettingsView: View {
                 )
             }
             Toggle("Instrumental Enhance", isOn: $audioManager.instrumentalEnhanceMode)
+            .toggleHaptic(audioManager.instrumentalEnhanceMode)
                 .tint(.appAccent)
                 .disabled(audioManager.isBackgroundKaraokeLocked)
             if audioManager.instrumentalEnhanceMode {
@@ -552,7 +625,7 @@ struct SettingsView: View {
     }
 
     private func request(_ action: SettingsDestructiveAction) {
-        AppHaptic.warning.play()
+        AppHaptic.selection.play()
         pendingAction = action
     }
 
@@ -823,7 +896,7 @@ private struct StrengthSlider: View {
         let feedbackStep = Int((value * 20).rounded())
         guard feedbackStep != lastFeedbackStep else { return }
         lastFeedbackStep = feedbackStep
-        AppHaptic.selection.play()
+        AppHaptic.detent.play()
     }
 
     private var sliderAnimation: Animation? {
@@ -1013,7 +1086,7 @@ private struct EqualizerBand: View {
         let feedbackStep = Int(value.rounded())
         guard feedbackStep != lastFeedbackStep else { return }
         lastFeedbackStep = feedbackStep
-        AppHaptic.selection.play()
+        AppHaptic.detent.play()
     }
 
     private var bandAnimation: Animation? {
@@ -1172,7 +1245,7 @@ private struct NotificationPreferenceToggle: View {
         .accessibilityLabel(title)
         .accessibilityValue(isOn ? "On" : "Off")
         .onChange(of: isOn) { _, enabled in
-            enabled ? AppHaptic.selection.play() : AppHaptic.light.play()
+            enabled ? AppHaptic.selection.play() : AppHaptic.dismiss.play()
         }
     }
 }

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -343,7 +343,6 @@ struct SettingsView: View {
                     } label: {
                         Text("Shimeji Characters")
                     }
-                    .navigationTapHaptic()
                 }
             }
         } header: {
@@ -379,7 +378,6 @@ struct SettingsView: View {
                 } label: {
                     Text("Developer")
                 }
-                .navigationTapHaptic()
             }
         }
     }

--- a/Twinskaraoke/Features/Account/ShimejiSettingsView.swift
+++ b/Twinskaraoke/Features/Account/ShimejiSettingsView.swift
@@ -76,7 +76,7 @@ struct ShimejiSettingsView: View {
         if resources.manifest != nil {
             Section {
                 Button("Remove Downloaded Pack", role: .destructive) {
-                    AppHaptic.warning.play()
+                    AppHaptic.dismiss.play()
                     resources.deleteDownloadedPack()
                 }
             }

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -186,7 +186,7 @@ struct BrowseSongCollectionView: View {
         HStack(spacing: AM.Spacing.m) {
             Button {
                 if let first = songs.first {
-                    AppHaptic.medium.play()
+                    AppHaptic.commit.play()
                     AudioPlayerManager.shared.playInOrder(song: first, context: songs)
                 }
             } label: {

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -30,6 +30,7 @@ struct HomeView: View {
                     .padding(.bottom, AM.Spacing.l)
                 }
                 .smoothScrolling()
+                .scrollEdgeHaptic()
                 .tabBarScrollInset()
                 .musicScreenBackground()
             }
@@ -40,7 +41,11 @@ struct HomeView: View {
                     AccountToolbarButton()
                 }
             }
-            .refreshable { await viewModel.refreshHomeData() }
+            .refreshable {
+                AppHaptic.selection.play()
+                await viewModel.refreshHomeData()
+                AppHaptic.success.play()
+            }
             .task { viewModel.fetchHomeData() }
             .onChange(of: artworkPrefetchSignature) { _, _ in
                 prefetchVisibleArtworkIfNeeded()

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtDetailView.swift
@@ -93,7 +93,7 @@ struct ArtDetailView: View {
     }
 
     private func openFullScreen() {
-        AppHaptic.medium.play()
+        AppHaptic.commit.play()
         showFullScreen = true
     }
 

--- a/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
@@ -51,7 +51,7 @@ struct ZoomableImageViewer: View {
                 VStack {
                     HStack {
                         GlassXButton(action: {
-                            AppHaptic.light.play()
+                            AppHaptic.dismiss.play()
                             dismiss()
                         })
                         Spacer()
@@ -118,7 +118,7 @@ struct ZoomableImageViewer: View {
     }
 
     private func toggleZoom() {
-        AppHaptic.medium.play()
+        AppHaptic.commit.play()
         let update = {
             if scale > 1 {
                 scale = 1

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -52,7 +52,6 @@ struct ArtistsView: View {
                         NavigationLink(destination: ArtistDetailView(artist: artist)) {
                             ArtistRow(artist: artist)
                         }
-                        .navigationTapHaptic()
                         .onAppear { viewModel.loadMoreIfNeeded(current: artist) }
                         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                         .listRowBackground(Color.clear)

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -52,6 +52,7 @@ struct ArtistsView: View {
                         NavigationLink(destination: ArtistDetailView(artist: artist)) {
                             ArtistRow(artist: artist)
                         }
+                        .navigationTapHaptic()
                         .onAppear { viewModel.loadMoreIfNeeded(current: artist) }
                         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                         .listRowBackground(Color.clear)
@@ -288,7 +289,7 @@ struct ArtistDetailView: View {
                     text: "Play"
                 )
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
             Button {
                 AudioPlayerManager.shared.playShuffled(from: songs)
             } label: {
@@ -297,7 +298,7 @@ struct ArtistDetailView: View {
                     text: "Shuffle"
                 )
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
         }
         .padding(.horizontal)
     }
@@ -499,7 +500,7 @@ private struct ArtistActionsMenu: View {
                 Label("Downloading \(downloadingCount)...", systemImage: "arrow.down.circle")
             } else if allDownloaded {
                 Button(role: .destructive) {
-                    AppHaptic.warning.play()
+                    AppHaptic.dismiss.play()
                     DownloadManager.shared.remove(songIDs: songs.map(\.id))
                 } label: {
                     Label("Remove Downloads", systemImage: "trash")

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -86,7 +86,7 @@ struct CreatePlaylistSheet: View {
                     } label: {
                         CreatePlaylistSaveLabel(isSaving: isSaving)
                     }
-                    .buttonStyle(PressableButtonStyle(scale: 0.97, dim: 0.8, haptic: canSave ? .medium : nil))
+                    .buttonStyle(PressableButtonStyle(scale: 0.97, dim: 0.8, haptic: canSave ? .commit : nil))
                     .disabled(!canSave)
                     .accessibilityLabel("Create playlist")
                 }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -75,6 +75,7 @@ struct DownloadedSongsView: View {
                 }
             }
             .smoothScrolling()
+            .scrollEdgeHaptic()
             .bottomChromeScrollTracking()
             .collapsedNavigationTitle($showsCollapsedTitle)
         }
@@ -188,14 +189,14 @@ struct DownloadedSongsView: View {
             } label: {
                 LibraryActionButtonLabel(symbol: "play.fill", text: "Play")
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
             .accessibilityLabel("Play downloaded songs")
             Button {
                 shuffle()
             } label: {
                 LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
             .accessibilityLabel("Shuffle downloaded songs")
         }
     }
@@ -292,13 +293,13 @@ struct DownloadedSongsView: View {
     }
 
     private func removeDownload(_ song: Song) {
-        AppHaptic.warning.play()
+        AppHaptic.dismiss.play()
         downloads.remove(songID: song.id)
         refresh()
     }
 
     private func requestRemoveAllDownloads() {
-        AppHaptic.warning.play()
+        AppHaptic.selection.play()
         showRemoveAllConfirmation = true
     }
 
@@ -470,7 +471,6 @@ private struct DownloadedSongsMenu: View {
             Divider()
 
             Button(role: .destructive) {
-                AppHaptic.warning.play()
                 removeAll()
             } label: {
                 Label("Remove Downloads", systemImage: "trash")

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -99,6 +99,7 @@ struct LibraryView: View {
                 }
             }
             .refreshable {
+                AppHaptic.selection.play()
                 refreshLibrary()
             }
             .navigationDestination(for: Playlist.self) { playlist in
@@ -516,13 +517,13 @@ struct LibrarySongsView: View {
             } label: {
                 LibraryActionButtonLabel(symbol: "play.fill", text: "Play")
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
             Button {
                 AudioPlayerManager.shared.playShuffled(from: songs)
             } label: {
                 LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
         }
     }
 

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -98,8 +98,8 @@ struct LibraryView: View {
                     AccountToolbarButton()
                 }
             }
+            // `refreshLibrary()` plays the trigger tick itself.
             .refreshable {
-                AppHaptic.selection.play()
                 refreshLibrary()
             }
             .navigationDestination(for: Playlist.self) { playlist in

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -127,7 +127,7 @@ struct PlaylistDetailView: View {
         let revealed = min(effective, extent)
         if revealed >= extent {
             isSearchLatched = true
-            AppHaptic.medium.play()
+            AppHaptic.boundary.play()
             withOptionalAnimation(reduceMotion ? nil : AppMotion.snap) {
                 searchRevealHeight = extent
             }
@@ -240,6 +240,7 @@ struct PlaylistDetailView: View {
                 )
         }
         .smoothScrolling()
+        .scrollEdgeHaptic()
         .scrollDismissesKeyboard(.interactively)
         .bottomChromeScrollTracking()
         // Resting offset expressed as a raw point, which is what finally worked.

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -65,6 +65,7 @@ struct RandomSongsView: View {
         .refreshable {
             AppHaptic.selection.play()
             await viewModel.reload()
+            AppHaptic.success.play()
         }
         .task {
             await viewModel.loadIfNeeded()

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -65,6 +65,7 @@ struct UploadedSongsView: View {
         .refreshable {
             AppHaptic.selection.play()
             await viewModel.refresh()
+            AppHaptic.success.play()
         }
         .task {
             viewModel.loadIfNeeded()
@@ -124,7 +125,7 @@ struct UploadedSongsView: View {
             } label: {
                 LibraryActionButtonLabel(symbol: "play.fill", text: "Play")
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
             .accessibilityLabel("Play uploaded songs")
 
             Button {
@@ -132,7 +133,7 @@ struct UploadedSongsView: View {
             } label: {
                 LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.75, haptic: .commit))
             .accessibilityLabel("Shuffle uploaded songs")
         }
     }

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -535,7 +535,7 @@ struct VideoPlayerScreen: View {
         )
         nextPlayer.play()
         player = nextPlayer
-        AppHaptic.light.play()
+        AppHaptic.commit.play()
     }
 }
 

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -807,7 +807,7 @@ struct FullScreenPlayerView: View {
 
     private var dismissBar: some View {
         Button {
-            AppHaptic.light.play()
+            AppHaptic.dismiss.play()
             popupPresentation.collapse()
         } label: {
             Capsule()
@@ -815,7 +815,7 @@ struct FullScreenPlayerView: View {
                 .frame(width: 40, height: 5)
                 .frame(width: 44, height: 44)
         }
-        .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.7, haptic: .light))
+        .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.7, haptic: nil))
         .accessibilityLabel("Dismiss player")
         .accessibilityHint("Collapses the full-screen player.")
     }
@@ -1035,7 +1035,7 @@ struct FullScreenPlayerView: View {
                     .frame(maxWidth: .infinity)
                     .frame(height: rowHeight)
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .light))
+            .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .selection))
             .accessibilityLabel("Previous track")
             .accessibilityHint("Skips to the previous song.")
             Button {
@@ -1054,7 +1054,7 @@ struct FullScreenPlayerView: View {
                 .frame(maxWidth: .infinity)
                 .frame(height: rowHeight)
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .medium))
+            .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .commit))
             .accessibilityLabel(audioManager.isPlaying ? "Pause" : "Play")
             .accessibilityValue(audioManager.currentSong?.title ?? "Current song")
             Button {
@@ -1066,7 +1066,7 @@ struct FullScreenPlayerView: View {
                     .frame(maxWidth: .infinity)
                     .frame(height: rowHeight)
             }
-            .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .light))
+            .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .selection))
             .accessibilityLabel("Next track")
             .accessibilityHint("Skips to the next song.")
         }
@@ -1124,7 +1124,7 @@ struct FullScreenPlayerView: View {
                 AppHaptic.selection.play()
                 showTranslatedLyrics.toggle()
             } else {
-                AppHaptic.light.play()
+                AppHaptic.boundary.play()
                 lyricsViewModel.requestTranslation()
             }
         } label: {

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -117,7 +117,7 @@ struct QueueView: View {
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                 Button {
-                                    AppHaptic.selection.play()
+                                    AppHaptic.commit.play()
                                     audioManager.playNext(song: entry.song)
                                 } label: {
                                     Label("Play Next", systemImage: "text.insert")
@@ -127,7 +127,7 @@ struct QueueView: View {
                             .transition(rowTransition)
                         }
                         .onMove { source, destination in
-                            AppHaptic.selection.play()
+                            AppHaptic.commit.play()
                             withOptionalAnimation(queueMutationAnimation) {
                                 audioManager.moveInUpNext(from: source, to: destination)
                             }
@@ -175,7 +175,7 @@ struct QueueView: View {
             Spacer()
             if upNextCount > 0 {
                 Button(role: .destructive) {
-                    AppHaptic.warning.play()
+                    AppHaptic.dismiss.play()
                     withOptionalAnimation(queueMutationAnimation) {
                         audioManager.removeFromUpNext(at: IndexSet(integersIn: 0 ..< upNextCount))
                     }
@@ -194,7 +194,7 @@ struct QueueView: View {
                 .transition(clearButtonTransition)
             }
             GlassXButton(action: {
-                AppHaptic.light.play()
+                AppHaptic.dismiss.play()
                 dismiss()
             })
             .accessibilityHint("Dismisses Playing Next.")
@@ -207,7 +207,7 @@ struct QueueView: View {
 
     private func currentSongRow(_ current: Song) -> some View {
         Button {
-            AppHaptic.light.play()
+            AppHaptic.selection.play()
             dismiss()
         } label: {
             HStack(spacing: 12) {
@@ -256,7 +256,7 @@ struct QueueView: View {
         .accessibilityHint("Double tap to return to the player. More actions are available.")
         .accessibilityAddTraits(.isButton)
         .accessibilityAction(named: "Return to Player") {
-            AppHaptic.light.play()
+            AppHaptic.selection.play()
             dismiss()
         }
         .accessibilityAction(named: "Add to Playlist") {
@@ -278,14 +278,14 @@ struct QueueView: View {
     }
 
     private func removeUpNextSongs(at indices: IndexSet) {
-        AppHaptic.warning.play()
+        AppHaptic.dismiss.play()
         withOptionalAnimation(queueMutationAnimation) {
             audioManager.removeFromUpNext(at: indices)
         }
     }
 
     private func playQueuedSong(_ song: Song) {
-        AppHaptic.medium.play()
+        AppHaptic.commit.play()
         audioManager.play(song: song, context: audioManager.queue)
     }
 

--- a/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
+++ b/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
@@ -120,7 +120,7 @@ struct RadioPlayerLayout: View {
             .frame(width: 88, height: 88)
             .contentShape(Rectangle())
         }
-        .buttonStyle(PressableButtonStyle(scale: 0.9, dim: 0.6, haptic: .medium))
+        .buttonStyle(PressableButtonStyle(scale: 0.9, dim: 0.6, haptic: .commit))
         .accessibilityLabel(audioManager.isPlaying ? "Stop live radio" : "Play live radio")
         .accessibilityValue(song.title)
         .accessibilityHint("Controls the live radio stream.")
@@ -129,7 +129,7 @@ struct RadioPlayerLayout: View {
     @ViewBuilder
     private var radioActions: some View {
         Button {
-            AppHaptic.medium.play()
+            AppHaptic.commit.play()
             audioManager.togglePlayPause()
         } label: {
             Label(

--- a/Twinskaraoke/Features/Player/SystemVolumeBridge.swift
+++ b/Twinskaraoke/Features/Player/SystemVolumeBridge.swift
@@ -15,6 +15,20 @@
     struct SystemVolumeBridge: UIViewRepresentable {
         @Binding var volume: Double
         @Binding var isUserScrubbing: Bool
+
+        /// Holds the throttle clock across the struct's many re-creations —
+        /// SwiftUI rebuilds the representable on every update, so this cannot
+        /// live in the struct itself.
+        final class Coordinator {
+            var lastPushTime: TimeInterval = 0
+        }
+
+        func makeCoordinator() -> Coordinator { Coordinator() }
+
+        /// 20Hz is indistinguishable to a hand moving a volume slider, so pushing
+        /// any faster is pure waste.
+        private static let pushInterval: TimeInterval = 1.0 / 20.0
+
         func makeUIView(context _: Context) -> MPVolumeView {
             let view = MPVolumeView(frame: .zero)
             view.alpha = 0.0001
@@ -22,8 +36,16 @@
             return view
         }
 
-        func updateUIView(_ uiView: MPVolumeView, context _: Context) {
+        func updateUIView(_ uiView: MPVolumeView, context: Context) {
             guard isUserScrubbing else { return }
+            // SwiftUI calls this at display rate (up to 120Hz) while a drag is
+            // live, and every `sendActions` below crosses into the system volume
+            // server.  The value guard alone does not help: during a drag
+            // the target moves every frame, so it passes every time.
+            let now = ProcessInfo.processInfo.systemUptime
+            guard now - context.coordinator.lastPushTime >= Self.pushInterval else { return }
+            context.coordinator.lastPushTime = now
+
             DispatchQueue.main.async {
                 guard let slider = uiView.subviews.compactMap({ $0 as? UISlider }).first else { return }
                 let target = Float(max(0, min(1, volume)))

--- a/Twinskaraoke/Features/Player/SystemVolumeBridge.swift
+++ b/Twinskaraoke/Features/Player/SystemVolumeBridge.swift
@@ -21,6 +21,7 @@
         /// live in the struct itself.
         final class Coordinator {
             var lastPushTime: TimeInterval = 0
+            var wasScrubbing = false
         }
 
         func makeCoordinator() -> Coordinator { Coordinator() }
@@ -37,14 +38,24 @@
         }
 
         func updateUIView(_ uiView: MPVolumeView, context: Context) {
-            guard isUserScrubbing else { return }
+            let coordinator = context.coordinator
+            // The frame the drag ends on must always be pushed. Throttling alone
+            // would discard whatever travel happened since the last accepted
+            // push, leaving the system volume short of where the finger let go —
+            // worst on a fast flick to 0 or 1.
+            let didFinishScrubbing = coordinator.wasScrubbing && !isUserScrubbing
+            coordinator.wasScrubbing = isUserScrubbing
+            guard isUserScrubbing || didFinishScrubbing else { return }
+
             // SwiftUI calls this at display rate (up to 120Hz) while a drag is
             // live, and every `sendActions` below crosses into the system volume
             // server.  The value guard alone does not help: during a drag
             // the target moves every frame, so it passes every time.
             let now = ProcessInfo.processInfo.systemUptime
-            guard now - context.coordinator.lastPushTime >= Self.pushInterval else { return }
-            context.coordinator.lastPushTime = now
+            if !didFinishScrubbing {
+                guard now - coordinator.lastPushTime >= Self.pushInterval else { return }
+            }
+            coordinator.lastPushTime = now
 
             DispatchQueue.main.async {
                 guard let slider = uiView.subviews.compactMap({ $0 as? UISlider }).first else { return }

--- a/Twinskaraoke/Features/Radio/RadioQueueHero.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueHero.swift
@@ -46,7 +46,7 @@ struct RadioQueueHero: View {
             Spacer(minLength: 4)
 
             Button {
-                AppHaptic.medium.play()
+                AppHaptic.commit.play()
                 onPlayPause()
             } label: {
                 Label(isPlaying ? "Pause live station" : "Play live station", systemImage: isPlaying ? "pause.fill" : "play.fill")

--- a/Twinskaraoke/Features/Radio/RadioQueueView.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueView.swift
@@ -90,7 +90,13 @@ struct RadioQueueView: View {
                 .refreshable {
                     AppHaptic.selection.play()
                     await radio.refresh()
-                    AppHaptic.success.play()
+                    // Branch on the outcome rather than always claiming success,
+                    // matching `RadioView.retryRadioRefresh()`.
+                    if radio.refreshErrorMessage != nil {
+                        AppHaptic.error.play()
+                    } else {
+                        AppHaptic.success.play()
+                    }
                 }
             }
         }

--- a/Twinskaraoke/Features/Radio/RadioQueueView.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueView.swift
@@ -87,7 +87,11 @@ struct RadioQueueView: View {
                     .animation(scheduleAnimation(response: 0.28), value: currentSong?.displayTitle)
                 }
                 .smoothScrolling()
-                .refreshable { await radio.refresh() }
+                .refreshable {
+                    AppHaptic.selection.play()
+                    await radio.refresh()
+                    AppHaptic.success.play()
+                }
             }
         }
     }
@@ -106,7 +110,7 @@ struct RadioQueueView: View {
             }
             Spacer()
             GlassXButton(action: {
-                AppHaptic.light.play()
+                AppHaptic.dismiss.play()
                 dismiss()
             })
             .accessibilityHint("Dismisses the radio queue.")
@@ -119,7 +123,7 @@ struct RadioQueueView: View {
     private var stationControls: some View {
         HStack(spacing: 12) {
             Button {
-                AppHaptic.medium.play()
+                AppHaptic.commit.play()
                 playOrPauseLiveStation()
             } label: {
                 LibraryActionButtonLabel(
@@ -174,7 +178,7 @@ struct RadioQueueView: View {
         .contentShape(Rectangle())
         .contextMenu {
             Button {
-                AppHaptic.medium.play()
+                AppHaptic.commit.play()
                 radio.playLiveStream()
             } label: {
                 Label("Play Live Station", systemImage: "dot.radiowaves.left.and.right")
@@ -194,7 +198,7 @@ struct RadioQueueView: View {
         .accessibilityValue("\(song.displayTitle), \(song.displayArtist)")
         .accessibilityHint("Shows actions for the live radio station.")
         .accessibilityAction(named: "Play Live Station") {
-            AppHaptic.medium.play()
+            AppHaptic.commit.play()
             radio.playLiveStream()
         }
         .transition(rowTransition)

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -125,6 +125,8 @@ struct RadioView: View {
         await radio.refresh()
         if radio.refreshErrorMessage != nil {
             AppHaptic.error.play()
+        } else {
+            AppHaptic.success.play()
         }
     }
 
@@ -220,7 +222,7 @@ struct RadioView: View {
     @ViewBuilder
     private var radioActions: some View {
         Button {
-            AppHaptic.medium.play()
+            AppHaptic.commit.play()
             radio.playLiveStream()
         } label: {
             Label("Play Live Station", systemImage: "dot.radiowaves.left.and.right")
@@ -391,7 +393,7 @@ struct RadioView: View {
 
     private func radioPlayButton(isLivePlaying: Bool, accessibilityValue: String) -> some View {
         Button {
-            AppHaptic.medium.play()
+            AppHaptic.commit.play()
             playOrPauseLiveStation()
         } label: {
             ZStack {

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2910,7 +2910,14 @@ final class AudioPlayerManager {
                     self.updateNowPlayingInfo(reloadArtwork: false)
                     return .success
                 }
-                return self.resumeCurrentPlayback(source: "remote.play") ? .success : .commandFailed
+                let resumed = self.resumeCurrentPlayback(source: "remote.play")
+                // In-app play/pause buttons carry their own `.commit`; the
+                // remote surfaces had none. iOS suppresses haptics while
+                // backgrounded, so in practice this is felt when the app is
+                // foreground and the command comes from headphones or
+                // Control Center.
+                if resumed { AppHaptic.commit.play() }
+                return resumed ? .success : .commandFailed
             }
         }
         cc.pauseCommand.addTarget { [weak self] _ in
@@ -2924,16 +2931,22 @@ final class AudioPlayerManager {
                     // fallback made lock-screen/control state diverge in device
                     // testing, so this intentionally preserves the working
                     // system-integration behavior over strict command semantics.
-                    return self.resumeCurrentPlayback(source: "remote.pauseAsPlay") ? .success : .commandFailed
+                    let resumed = self.resumeCurrentPlayback(source: "remote.pauseAsPlay")
+                    if resumed { AppHaptic.commit.play() }
+                    return resumed ? .success : .commandFailed
                 }
-                return self.pauseCurrentPlayback(source: "remote.pause") ? .success : .commandFailed
+                let paused = self.pauseCurrentPlayback(source: "remote.pause")
+                if paused { AppHaptic.commit.play() }
+                return paused ? .success : .commandFailed
             }
         }
         cc.togglePlayPauseCommand.addTarget { [weak self] _ in
             guard let self else { return .commandFailed }
             return performOnMain {
                 DebugLogger.log("Remote toggle command received", category: .playback)
-                return self.togglePlayPause(source: "remote.toggle") ? .success : .commandFailed
+                let toggled = self.togglePlayPause(source: "remote.toggle")
+                if toggled { AppHaptic.commit.play() }
+                return toggled ? .success : .commandFailed
             }
         }
         cc.nextTrackCommand.addTarget { [weak self] _ in

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -131,6 +131,7 @@ final class DownloadManager {
     private var isLoggingDownloadQueue = false
     private var completedInCurrentQueue = 0
     private var failedInCurrentQueue = 0
+    private var cancelledInCurrentQueue = 0
     private var pendingWiFiRepairs: [String: Song] = [:]
     private var validDownloadCache: [String: ValidDownloadCacheEntry] = [:]
     private var downloadedMetadata: [String: Song] = [:]
@@ -467,6 +468,7 @@ final class DownloadManager {
             isLoggingDownloadQueue = true
             completedInCurrentQueue = 0
             failedInCurrentQueue = 0
+            cancelledInCurrentQueue = 0
             DebugLogger.log("Download queue started", category: .network)
         }
         updatePublishedState { $0.inProgress = nextInProgress }
@@ -793,6 +795,10 @@ final class DownloadManager {
 
     func cancel(songID: String) {
         cancelWork(songID: songID)
+        // Counts as an incomplete batch: without this a queue where the user
+        // cancelled one song still satisfies `failedInCurrentQueue == 0` and
+        // celebrates as though everything landed.
+        cancelledInCurrentQueue += 1
         updatePublishedState { $0.inProgress.remove(songID) }
         startQueuedDownloadsIfPossible()
         logDownloadQueueCompletionIfNeeded()
@@ -937,6 +943,7 @@ final class DownloadManager {
         isLoggingDownloadQueue = false
         completedInCurrentQueue = 0
         failedInCurrentQueue = 0
+        cancelledInCurrentQueue = 0
         pendingWiFiRepairs.removeAll()
         validDownloadCache.removeAll()
         downloadedMetadata.removeAll()
@@ -987,12 +994,13 @@ final class DownloadManager {
         // A whole batch landing is worth a custom texture; a single song is
         // not — every download entry point is an explicit user action, so the
         // only thing separating "earned" from "noise" here is the batch size.
-        if completedInCurrentQueue > 1, failedInCurrentQueue == 0 {
+        if completedInCurrentQueue > 1, failedInCurrentQueue == 0, cancelledInCurrentQueue == 0 {
             AppHaptic.celebrate.play()
         }
         isLoggingDownloadQueue = false
         completedInCurrentQueue = 0
         failedInCurrentQueue = 0
+        cancelledInCurrentQueue = 0
     }
 
     /// The scan runs concurrently with live downloads. It only removes

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -984,6 +984,12 @@ final class DownloadManager {
             "Download queue complete: completed=\(completedInCurrentQueue), failed=\(failedInCurrentQueue)",
             category: .network
         )
+        // A whole batch landing is worth a custom texture; a single song is
+        // not — every download entry point is an explicit user action, so the
+        // only thing separating "earned" from "noise" here is the batch size.
+        if completedInCurrentQueue > 1, failedInCurrentQueue == 0 {
+            AppHaptic.celebrate.play()
+        }
         isLoggingDownloadQueue = false
         completedInCurrentQueue = 0
         failedInCurrentQueue = 0

--- a/TwinskaraokeShared/Components/AppHaptic.swift
+++ b/TwinskaraokeShared/Components/AppHaptic.swift
@@ -1,0 +1,699 @@
+import SwiftUI
+
+#if os(iOS)
+  import AVFoundation
+  import CoreHaptics
+  import UIKit
+#endif
+
+// MARK: - Haptics preference
+
+/// Whether haptics should fire, combining the user's in-app preference with
+/// the hardware's ability to play them.  Mirrors `AppMotion.reduceMotion`.
+enum AppHaptics {
+  static let storageKey = "nk.hapticsEnabled"
+  static let strengthStorageKey = "nk.hapticStrength"
+
+  /// Read straight from `UserDefaults` rather than `@AppStorage` because
+  /// `AppHaptic.play()` is called from plain model code and gesture callbacks,
+  /// not only from `View` bodies.  Absent key means "on" — `bool(forKey:)`
+  /// would report `false` for a preference the user has never touched.
+  static var isEnabled: Bool {
+    guard UserDefaults.standard.object(forKey: storageKey) != nil else { return true }
+    return UserDefaults.standard.bool(forKey: storageKey)
+  }
+
+  static var strength: AppHapticStrength {
+    guard let raw = UserDefaults.standard.string(forKey: strengthStorageKey),
+          let strength = AppHapticStrength(rawValue: raw)
+    else { return .default }
+    return strength
+  }
+}
+
+/// A global weight applied on top of every role.  The role decides the
+/// *character* of a haptic (sharp tick, soft swell, solid thud); this decides
+/// how hard it lands.  Roles keep their relative ordering at every level, so
+/// raising the baseline never collapses two roles into the same sensation.
+enum AppHapticStrength: String, CaseIterable, Identifiable, Sendable {
+  case light
+  case medium
+  case strong
+  case heavy
+
+  /// `medium` sits where `strong` used to before the scale was rebalanced: full
+  /// intensity on every role and real impacts for taps, which is already firmer
+  /// than most iOS apps ship. `strong` and `heavy` now genuinely earn their
+  /// names via CoreHaptics, so they are opt-in rather than the starting point.
+  static let `default`: AppHapticStrength = .medium
+
+  var id: String { rawValue }
+
+  var label: String {
+    switch self {
+    case .light: "Light"
+    case .medium: "Medium"
+    case .strong: "Strong"
+    case .heavy: "Heavy"
+    }
+  }
+
+  /// Scales role intensity on the UIKit path.  Capped at 1.0 by the generators,
+  /// which is precisely why the top two levels leave that path entirely.
+  var intensityScale: CGFloat {
+    switch self {
+    case .light: 0.78
+    case .medium: 1.0
+    case .strong, .heavy: 1.0
+    }
+  }
+
+  /// `UIImpactFeedbackGenerator` tops out at `.heavy` @ 1.0, and several roles
+  /// already sit there — so the top two levels render through CoreHaptics
+  /// instead, where intensity, sharpness and duration are continuous.  That is
+  /// the only way to go past the canned ceiling *and* keep roles separable;
+  /// stacking more roles onto five discrete rungs just collides them.
+  var usesCoreHapticsImpacts: Bool { self == .strong || self == .heavy }
+
+  /// Length multiplier for the continuous layer stacked under each transient.
+  /// A transient alone is a click; adding sustain under it is what reads as
+  /// weight, and it is where `heavy` gets its extra punch once intensity is
+  /// already pinned at maximum.
+  var bodyScale: Double {
+    switch self {
+    case .light, .medium: 0
+    case .strong: 1.0
+    case .heavy: 1.75
+    }
+  }
+
+  /// Only the gentlest level keeps the plain selection tick.  It has no
+  /// intensity control, so it is the one texture that cannot be cranked.
+  var usesImpactForSelection: Bool { self != .light }
+
+  /// How far up the canned-generator ladder to climb.  This is the *fallback*
+  /// path for the top two levels — hardware without CoreHaptics, or an engine
+  /// that failed to start — so it still has to get heavier with the baseline.
+  /// `heavy` deliberately stops at the same boost as `strong`.  Five rungs
+  /// cannot hold six roles apart once they are pushed harder than this — they
+  /// pile against the top and collide.  Heavy earns its extra weight from
+  /// `bodyScale` on the CoreHaptics path, so the canned fallback simply tops
+  /// out rather than smearing roles together.
+  var rungBoost: Int {
+    switch self {
+    case .light, .medium: 0
+    case .strong, .heavy: 1
+    }
+  }
+}
+
+// MARK: - Haptics EnvironmentKey
+
+struct AppHapticsEnabledKey: EnvironmentKey {
+  static let defaultValue: Bool = true
+}
+
+extension EnvironmentValues {
+  /// Whether haptics are switched on for this view tree.  Read this when a
+  /// view needs to *branch* on the preference (e.g. to skip arming a
+  /// generator); firing through `AppHaptic` already honours it.
+  var appHapticsEnabled: Bool {
+    get { self[AppHapticsEnabledKey.self] }
+    set { self[AppHapticsEnabledKey.self] = newValue }
+  }
+}
+
+extension View {
+  /// Injects the haptics preference into the environment and keeps the haptic
+  /// engine's lifecycle tied to the scene.  Apply once at the root, next to
+  /// `injectReduceMotion()`.
+  func injectHaptics() -> some View {
+    HapticsInjector(content: self)
+  }
+
+  /// Plays a tick for a tap that navigates.
+  ///
+  /// `NavigationLink` exposes no action closure to hang a haptic on, and a
+  /// custom `ButtonStyle` is *not* a reliable substitute: SwiftUI swaps in its
+  /// own style inside toolbars and some list contexts, which silently discards
+  /// the style's haptic along with it.  A simultaneous `TapGesture` runs
+  /// alongside the link's own recognizer without consuming the tap, so
+  /// navigation still happens.
+  ///
+  /// `TapGesture` only recognises a press with no travel, so this does not
+  /// compete with scrolling or with drag-driven transitions.
+  func navigationTapHaptic(_ haptic: AppHaptic = .selection) -> some View {
+    simultaneousGesture(TapGesture().onEnded { haptic.play() })
+  }
+
+  /// Plays a flip whenever a bound `Bool` changes — for `Toggle`s built on a
+  /// plain binding, which SwiftUI gives no action hook of their own.
+  ///
+  /// Switching something on is a commit; switching it off is the gentler
+  /// counterpart, matching how the rest of the app treats forward versus back.
+  /// Do **not** add this to a `Toggle` whose binding already plays a haptic in
+  /// its setter, or the flip fires twice.
+  func toggleHaptic(_ value: Bool) -> some View {
+    onChange(of: value) { _, isOn in
+      (isOn ? AppHaptic.commit : AppHaptic.dismiss).play()
+    }
+  }
+
+  /// Plays a tick whenever a picker's selection changes.  `Picker` has no
+  /// action closure, and its rows are system-drawn, so the bound value is the
+  /// only place a change surfaces.
+  func selectionHaptic<T: Equatable>(_ value: T) -> some View {
+    onChange(of: value) { _, _ in AppHaptic.selection.play() }
+  }
+}
+
+// Generic over Content for the same reason `ReduceMotionInjector` is: this
+// wraps the root of the view tree, and an AnyView there erases the static type
+// SwiftUI relies on to diff the whole app structurally.
+private struct HapticsInjector<Content: View>: View {
+  let content: Content
+  @AppStorage(AppHaptics.storageKey) private var hapticsEnabled: Bool = true
+  @Environment(\.scenePhase) private var scenePhase
+
+  var body: some View {
+    content
+      .environment(\.appHapticsEnabled, hapticsEnabled)
+      .onChange(of: scenePhase) { _, phase in
+        #if os(iOS)
+          switch phase {
+          case .active:
+            HapticEngine.shared.wake()
+          case .background:
+            HapticEngine.shared.sleep()
+          default:
+            break
+          }
+        #endif
+      }
+  }
+}
+
+// MARK: - AppHaptic
+
+/// One shared feel family so every interaction feels tuned by the same hand.
+/// Pick by **role**, not by texture-per-callsite — the texture behind a role
+/// can be retuned here once and every call site inherits it.
+enum AppHaptic {
+  /// Discrete selection moved: row tap, tab change, segment switch, filter
+  /// applied, picker step.  The most common case by far.
+  case selection
+
+  /// A continuous drag crossed a notch: scrub detents, reorder steps, zoom
+  /// stops.  Rate-limited, so a fast drag *ticks* instead of buzzing.
+  case detent
+
+  /// A control was physically picked up: drag begins, long-press arms, a
+  /// sheet grabs its handle.  Soft, so it reads as contact rather than a click.
+  case grab
+
+  /// A control committed to its action: primary button, play/pause, send.
+  case commit
+
+  /// The gentle counterpart to `commit` — a surface closed, an action
+  /// cancelled, a setting switched off.  Backing out should never feel as
+  /// weighty as going forward.
+  case dismiss
+
+  /// Travel stopped against a limit: scrub end-stop, list edge, cap reached.
+  /// Rigid, so it reads as hitting something solid.
+  case boundary
+
+  /// The work finished and the result is good.
+  case success
+
+  /// The work finished but something needs attention.
+  case warning
+
+  /// The work failed.
+  case error
+
+  /// A rare, earned moment — a custom CoreHaptics texture rather than a canned
+  /// system thump.  Reserve it; overuse is what makes haptics feel cheap.
+  case celebrate
+
+  func play() {
+    #if os(iOS)
+      guard AppHaptics.isEnabled else { return }
+      HapticEngine.shared.play(self)
+    #endif
+  }
+
+  /// Warms the generator this role uses so the *next* `play()` fires without
+  /// the ~100ms spin-up latency.  Call at the start of a gesture — on
+  /// `onLongPressGesture`'s `onPressingChanged`, or the first tick of a drag.
+  /// Free to call repeatedly; the system coalesces it.
+  func prepare() {
+    #if os(iOS)
+      guard AppHaptics.isEnabled else { return }
+      HapticEngine.shared.prepare(self)
+    #endif
+  }
+}
+
+#if os(iOS)
+
+  // MARK: - HapticEngine
+
+  /// Owns the feedback generators and the CoreHaptics engine.
+  ///
+  /// The generators are cached rather than allocated per call: a
+  /// `UIFeedbackGenerator` only pays off if it is alive long enough to keep the
+  /// Taptic Engine warm, and `prepare()` immediately followed by a fire is
+  /// indistinguishable from not preparing at all.
+  final class HapticEngine {
+    static let shared = HapticEngine()
+
+    private let selectionGenerator = UISelectionFeedbackGenerator()
+    private let notificationGenerator = UINotificationFeedbackGenerator()
+    private let softGenerator = UIImpactFeedbackGenerator(style: .soft)
+    private let rigidGenerator = UIImpactFeedbackGenerator(style: .rigid)
+    private let lightGenerator = UIImpactFeedbackGenerator(style: .light)
+    private let mediumGenerator = UIImpactFeedbackGenerator(style: .medium)
+    private let heavyGenerator = UIImpactFeedbackGenerator(style: .heavy)
+
+    /// Detents arrive as fast as a drag delivers touches — far faster than the
+    /// Taptic Engine can render distinctly.  Below this spacing the ticks blur
+    /// into a buzz, which reads as noise rather than texture.
+    ///
+    /// The spacing widens with strength on purpose: a heavier tap rings for
+    /// longer, so ticks that stayed crisp at the light baseline would smear
+    /// into each other at the heavy one.
+    /// Spacing exists so ticks stay perceptually distinct — a heavier tap rings
+    /// longer and smears if crowded — **not** to satisfy the server's 32Hz
+    /// ceiling. Starving the rate to 12.5Hz was measured on device and did not
+    /// stop the rate-limit log; it only made the scrub coarser. See the
+    /// `prepare()` note in `playImpact` for what the log actually tracks.
+    private static func detentMinimumInterval(for strength: AppHapticStrength) -> TimeInterval {
+      switch strength {
+      case .light, .medium: 0.05
+      case .strong: 0.055
+      case .heavy: 0.07
+      }
+    }
+
+    /// The haptic server drops anything sent faster than 32Hz and logs
+    /// "Message send exceeds rate-limit threshold and will be dropped".
+    ///
+    /// This floor applies to *every* impact, not just detents, because the
+    /// server's budget is shared: two individually-reasonable sources can breach
+    /// it together. Dropping our own overflow is strictly better than letting the
+    /// server drop it — one skipped tick is imperceptible, whereas a flooded
+    /// server discards them in audible clumps and the scrub feels uneven.
+    ///
+    /// Notification roles and `celebrate` bypass this: they are rare, carry real
+    /// meaning, and must never be swallowed by a burst of ticks.
+    ///
+    /// 20Hz, matched to the detent spacing rather than left looser.
+    ///
+    /// Measured on device: with the generator kept warm, a peak scrub still
+    /// tripped the server, and the tightest observed spacing was 33ms — the old
+    /// 1/30s value here, not the 40ms detent interval. A `.boundary` (scrub
+    /// end-stop) or `.grab` was interleaving with detents and slipping through at
+    /// the looser floor while every role individually respected its own spacing.
+    ///
+    /// All roles share one clock, so **the loosest interval sets the real
+    /// ceiling** — a per-role interval is only ever a lower bound. Matching this
+    /// to the detent spacing closes that seam, and no hand-driven interaction is
+    /// faster than 20Hz, so discrete taps are unaffected.
+    private static let systemRateLimitInterval: TimeInterval = 1.0 / 20.0
+    private var lastImpactTime: TimeInterval = 0
+
+    /// Returns false when this impact would breach `interval` since the last one.
+    private func allowsImpact(minimumInterval interval: TimeInterval) -> Bool {
+      let now = ProcessInfo.processInfo.systemUptime
+      guard now - lastImpactTime >= interval else { return false }
+      lastImpactTime = now
+      return true
+    }
+
+    private var engine: CHHapticEngine?
+    private var enginePrepared = false
+
+    struct ImpactKey: Hashable {
+      let haptic: AppHaptic
+      let strength: AppHapticStrength
+    }
+
+    /// Rebuilt lazily; must be dropped whenever the engine resets, because a
+    /// player is bound to the engine instance that created it.
+    private var impactPlayers: [ImpactKey: CHHapticPatternPlayer] = [:]
+
+    private init() {}
+
+    // MARK: Playback
+
+    func play(_ haptic: AppHaptic) {
+      let strength = AppHaptics.strength
+      switch haptic {
+      case .detent:
+        playDetent(strength: strength)
+      case .success:
+        notificationGenerator.notificationOccurred(.success)
+      case .warning:
+        notificationGenerator.notificationOccurred(.warning)
+      case .error:
+        notificationGenerator.notificationOccurred(.error)
+      case .celebrate:
+        playCelebrate()
+      case .selection where !strength.usesImpactForSelection:
+        // The one texture with no intensity control, so it only survives at
+        // the gentlest baseline; above it a real impact takes over.  Still
+        // throttled: this path bypasses `playImpact`, and the server's 32Hz
+        // budget counts selection ticks the same as impacts.
+        guard allowsImpact(minimumInterval: Self.systemRateLimitInterval) else { return }
+        selectionGenerator.selectionChanged()
+      case .selection, .grab, .commit, .dismiss, .boundary:
+        playImpact(haptic, strength: strength)
+      }
+    }
+
+    /// CoreHaptics when the baseline calls for it, canned generators otherwise.
+    /// Any CoreHaptics failure falls through rather than dropping the haptic —
+    /// a weaker tap beats no tap.
+    private func playImpact(
+      _ haptic: AppHaptic,
+      strength: AppHapticStrength,
+      minimumInterval: TimeInterval? = nil
+    ) {
+      // Every impact funnels through here, which makes this the one place the
+      // shared 32Hz server budget can be enforced.  Roles that want to be
+      // sparser than the floor (detents) pass their own spacing.
+      let interval = max(minimumInterval ?? 0, Self.systemRateLimitInterval)
+      guard allowsImpact(minimumInterval: interval) else { return }
+      // `.detent` stays on the canned generator at *every* strength.
+      // `UIImpactFeedbackGenerator` is the API built for rapid repeated feedback
+      // and can be held armed between ticks (see the `prepare()` call below),
+      // whereas a CoreHaptics pattern player has to be started afresh for each
+      // one. `.rigid` at full intensity is already the sharpest canned texture,
+      // so the loss is small and the trade is worth it on a role that fires
+      // ~20x a second.
+      if haptic != .detent,
+         strength.usesCoreHapticsImpacts,
+         playCoreImpact(haptic, strength: strength) {
+        return
+      }
+      let (generator, intensity) = resolve(haptic, strength: strength)
+      generator.impactOccurred(intensity: intensity)
+      // Re-arm immediately so the generator's reporter does not idle out before
+      // the next tick.
+      //
+      // Measured on device: throttling *harder* made things worse — at 50ms gaps
+      // the server complained ~2.2x per impact, at 83ms gaps ~2.5x, and at 10Hz
+      // (25Hz effective, comfortably under the 32Hz ceiling) it still complained.
+      // Complaints therefore do not scale with our fire rate; they track the
+      // `Reporter disconnected or already stopped` churn, which grows as the gaps
+      // widen. Keeping the generator armed is what the header prescribes:
+      // "safe to call more than once before the generator receives an event, if
+      // events are still imminently possible".
+      generator.prepare()
+    }
+
+    /// Per-role CoreHaptics character: how hard, how sharp, and how much
+    /// sustain sits under the transient.  Sharpness is what keeps roles
+    /// distinguishable once intensity is pinned at 1.0 for most of them.
+    private func coreProfile(for haptic: AppHaptic) -> (intensity: Float, sharpness: Float, body: TimeInterval)? {
+      switch haptic {
+      case .selection: (0.85, 0.55, 0.012)
+      case .grab: (0.85, 0.20, 0.045)  // dull and swelling — a pickup, not a click
+      case .dismiss: (0.90, 0.45, 0.020)
+      case .commit: (1.00, 0.70, 0.045)
+      case .detent: (1.00, 1.00, 0)  // maximum sharpness, never any sustain
+      case .boundary: (1.00, 0.35, 0.075)  // long and dull — a solid wall
+      default: nil
+      }
+    }
+
+    private func playCoreImpact(_ haptic: AppHaptic, strength: AppHapticStrength) -> Bool {
+      guard let profile = coreProfile(for: haptic) else { return false }
+      startEngineIfNeeded()
+      guard supportsCoreHaptics, engine != nil else { return false }
+
+      let key = ImpactKey(haptic: haptic, strength: strength)
+      guard let player = impactPlayer(for: key, profile: profile, strength: strength) else {
+        return false
+      }
+      do {
+        try player.start(atTime: CHHapticTimeImmediate)
+        return true
+      } catch {
+        // The engine died under us; drop the cache so the next call rebuilds.
+        impactPlayers.removeAll()
+        return false
+      }
+    }
+
+    /// Players are cached because building one allocates and crosses into the
+    /// haptic server — far too costly to repeat on every tap, let alone on
+    /// every detent during a drag.
+    private func impactPlayer(
+      for key: ImpactKey,
+      profile: (intensity: Float, sharpness: Float, body: TimeInterval),
+      strength: AppHapticStrength
+    ) -> CHHapticPatternPlayer? {
+      if let cached = impactPlayers[key] { return cached }
+      guard let engine else { return nil }
+
+      var events = [
+        CHHapticEvent(
+          eventType: .hapticTransient,
+          parameters: [
+            CHHapticEventParameter(parameterID: .hapticIntensity, value: profile.intensity),
+            CHHapticEventParameter(parameterID: .hapticSharpness, value: profile.sharpness),
+          ],
+          relativeTime: 0
+        )
+      ]
+      let body = profile.body * strength.bodyScale
+      if body > 0 {
+        events.append(
+          CHHapticEvent(
+            eventType: .hapticContinuous,
+            parameters: [
+              CHHapticEventParameter(parameterID: .hapticIntensity, value: profile.intensity),
+              // Duller than the transient so the sustain reads as weight
+              // behind the hit rather than as a second, buzzier event.
+              CHHapticEventParameter(parameterID: .hapticSharpness, value: profile.sharpness * 0.5),
+            ],
+            relativeTime: 0,
+            duration: body
+          )
+        )
+      }
+
+      do {
+        let player = try engine.makePlayer(with: try CHHapticPattern(events: events, parameters: []))
+        impactPlayers[key] = player
+        return player
+      } catch {
+        return nil
+      }
+    }
+
+    /// The weight ladder, quietest to heaviest: soft → light → medium → rigid
+    /// → heavy.  Each role sits at its own rung so the roles stay distinguishable
+    /// from each other no matter where the baseline puts them.
+    private var ladder: [UIImpactFeedbackGenerator] {
+      [softGenerator, lightGenerator, mediumGenerator, rigidGenerator, heavyGenerator]
+    }
+
+    private func resolve(
+      _ haptic: AppHaptic,
+      strength: AppHapticStrength
+    ) -> (UIImpactFeedbackGenerator, CGFloat) {
+      // Rung = character (chosen for feel, not volume).  Trim separates roles
+      // that share a rung.  Cap stops a role climbing past where it stops
+      // making sense.
+      let baseRung: Int
+      let trim: CGFloat
+      let cap: Int
+      switch haptic {
+      case .grab:
+        baseRung = 0; trim = 1.0; cap = 4  // soft — a swell, not a click
+      case .selection:
+        baseRung = 1; trim = 0.85; cap = 4  // light, and the lightest thing here
+      case .dismiss:
+        baseRung = 1; trim = 1.0; cap = 4  // light, but weightier than a plain tap
+      case .commit:
+        // Capped below `heavy` so `boundary` keeps the top rung to itself:
+        // hitting a limit should be the weightiest thing in the app, and
+        // without this the two collide at the heaviest baseline.
+        baseRung = 2; trim = 1.0; cap = 3  // medium
+      case .detent:
+        // Capped at rigid on purpose.  Sharpness *is* a tick's identity, and a
+        // scrub firing ~15 heavy impacts a second would be unusable — so
+        // strength raises a detent's intensity but never its weight.
+        //
+        // The trim keeps it off `commit`, which lands on rigid too once
+        // `heavy` promotes it.  The two never share a context (a mid-drag notch
+        // versus a button press), so a small margin is enough to keep them
+        // from being literally the same event.
+        baseRung = 3; trim = 0.9; cap = 3
+      case .boundary:
+        baseRung = 4; trim = 1.0; cap = 4  // heavy — a limit must feel unlike a notch
+      default:
+        baseRung = 2; trim = 1.0; cap = 4
+      }
+
+      let promoted = baseRung + strength.rungBoost
+      let rung = min(cap, min(ladder.count - 1, promoted))
+      let intensity = min(1.0, max(0.1, strength.intensityScale * trim))
+      return (ladder[rung], intensity)
+    }
+
+    func prepare(_ haptic: AppHaptic) {
+      let strength = AppHaptics.strength
+      switch haptic {
+      case .success, .warning, .error:
+        notificationGenerator.prepare()
+      case .celebrate:
+        startEngineIfNeeded()
+      case .selection where !strength.usesImpactForSelection:
+        selectionGenerator.prepare()
+      case .selection, .detent, .grab, .commit, .dismiss, .boundary:
+        // Must go through `resolve` for the same reason `play` does: warming a
+        // generator the current strength will never fire buys nothing.
+        resolve(haptic, strength: strength).0.prepare()
+      }
+    }
+
+    private func playDetent(strength: AppHapticStrength) {
+      // A detent is felt by a finger that is already moving and pressed flat to
+      // the glass, which masks soft textures badly — hence maximum sharpness on
+      // the CoreHaptics path and the sharpest rung on the fallback.
+      playImpact(
+        .detent,
+        strength: strength,
+        minimumInterval: Self.detentMinimumInterval(for: strength)
+      )
+    }
+
+    // MARK: Scene lifecycle
+
+    /// The system tears the CoreHaptics engine down in the background; bring it
+    /// back on return so the first celebratory moment after a resume isn't the
+    /// one that silently no-ops.
+    func wake() {
+      // Start eagerly when the baseline renders impacts through CoreHaptics:
+      // otherwise the very first tap of a session pays engine start-up latency
+      // or silently falls back to the weaker canned generator.
+      guard enginePrepared || AppHaptics.strength.usesCoreHapticsImpacts else { return }
+      startEngineIfNeeded()
+    }
+
+    func sleep() {
+      // Players do not survive the engine stopping.
+      impactPlayers.removeAll()
+      engine?.stop()
+    }
+
+    // MARK: CoreHaptics
+
+    private var supportsCoreHaptics: Bool {
+      CHHapticEngine.capabilitiesForHardware().supportsHaptics
+    }
+
+    private func startEngineIfNeeded() {
+      guard supportsCoreHaptics else { return }
+      enginePrepared = true
+
+      if let engine {
+        try? engine.start()
+        return
+      }
+
+      do {
+        // Share the app's audio session rather than letting CoreHaptics make
+        // its own (which is what `CHHapticEngine()` does).  Per the header,
+        // engines sharing a session get "identical audio behavior with regard
+        // to interruptions" — in a music app a second, competing session is a
+        // real hazard around route changes and interruptions.
+        let engine = try CHHapticEngine(audioSession: AVAudioSession.sharedInstance())
+        // We never schedule audio events, so keep the engine off audio work
+        // entirely.  Must be set before `start()` — the header notes it only
+        // takes effect across a stop/restart.
+        engine.playsHapticsOnly = true
+        // Both handlers can fire while the app is foregrounded — a phone call
+        // or another app's audio session will reset us out from under the UI.
+        //
+        // `@Sendable` is load-bearing, not decoration: with
+        // SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor these closures would
+        // otherwise inherit @MainActor and trap at runtime when CoreHaptics
+        // invokes them off the main queue — the same trap SDWebImage's
+        // request modifiers and unguarded Combine sinks hit here before.
+        engine.stoppedHandler = { @Sendable [weak self] _ in
+          Task { @MainActor in
+            self?.impactPlayers.removeAll()
+            self?.engine = nil
+          }
+        }
+        engine.resetHandler = { @Sendable [weak self] in
+          Task { @MainActor in
+            // Players are bound to the engine that built them and do not
+            // survive a reset; Apple requires recreating them here.
+            self?.impactPlayers.removeAll()
+            try? self?.engine?.start()
+          }
+        }
+        try engine.start()
+        self.engine = engine
+      } catch {
+        // A missing engine costs feel, not function: impacts fall back to the
+        // canned generators and celebrations to a notification thump.
+        impactPlayers.removeAll()
+        engine = nil
+      }
+    }
+
+    /// A two-beat rise: a soft swell that lands on a crisp accent.  Short
+    /// enough to punctuate rather than interrupt.
+    private func playCelebrate() {
+      startEngineIfNeeded()
+
+      guard supportsCoreHaptics, let engine else {
+        notificationGenerator.notificationOccurred(.success)
+        return
+      }
+
+      let swell = CHHapticEvent(
+        eventType: .hapticContinuous,
+        parameters: [
+          CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.45),
+          CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.25),
+        ],
+        relativeTime: 0,
+        duration: 0.18
+      )
+      let accent = CHHapticEvent(
+        eventType: .hapticTransient,
+        parameters: [
+          CHHapticEventParameter(parameterID: .hapticIntensity, value: 1.0),
+          CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.8),
+        ],
+        relativeTime: 0.18
+      )
+      // Ramp the swell upward so the accent reads as its arrival, not a
+      // separate second tap.
+      let rise = CHHapticParameterCurve(
+        parameterID: .hapticIntensityControl,
+        controlPoints: [
+          .init(relativeTime: 0, value: 0.4),
+          .init(relativeTime: 0.18, value: 1.0),
+        ],
+        relativeTime: 0
+      )
+
+      do {
+        let pattern = try CHHapticPattern(events: [swell, accent], parameterCurves: [rise])
+        try engine.makePlayer(with: pattern).start(atTime: CHHapticTimeImmediate)
+      } catch {
+        notificationGenerator.notificationOccurred(.success)
+      }
+    }
+  }
+
+#endif

--- a/TwinskaraokeShared/Components/AppHaptic.swift
+++ b/TwinskaraokeShared/Components/AppHaptic.swift
@@ -131,21 +131,6 @@ extension View {
     HapticsInjector(content: self)
   }
 
-  /// Plays a tick for a tap that navigates.
-  ///
-  /// `NavigationLink` exposes no action closure to hang a haptic on, and a
-  /// custom `ButtonStyle` is *not* a reliable substitute: SwiftUI swaps in its
-  /// own style inside toolbars and some list contexts, which silently discards
-  /// the style's haptic along with it.  A simultaneous `TapGesture` runs
-  /// alongside the link's own recognizer without consuming the tap, so
-  /// navigation still happens.
-  ///
-  /// `TapGesture` only recognises a press with no travel, so this does not
-  /// compete with scrolling or with drag-driven transitions.
-  func navigationTapHaptic(_ haptic: AppHaptic = .selection) -> some View {
-    simultaneousGesture(TapGesture().onEnded { haptic.play() })
-  }
-
   /// Plays a flip whenever a bound `Bool` changes — for `Toggle`s built on a
   /// plain binding, which SwiftUI gives no action hook of their own.
   ///
@@ -333,6 +318,9 @@ enum AppHaptic {
 
     private var engine: CHHapticEngine?
     private var enginePrepared = false
+    /// Bumped whenever an engine is created or torn down, so a late
+    /// `stoppedHandler`/`resetHandler` can tell whether it still owns the engine.
+    private var engineGeneration = 0
 
     struct ImpactKey: Hashable {
       let haptic: AppHaptic
@@ -383,8 +371,19 @@ enum AppHaptic {
       // Every impact funnels through here, which makes this the one place the
       // shared 32Hz server budget can be enforced.  Roles that want to be
       // sparser than the floor (detents) pass their own spacing.
+      // `.commit` is exempt for the same reason the notification roles are: it is
+      // the confirmation that closes an interaction, and it *always* lands right
+      // behind another impact — a scrub's final detent, or the `.grab` from a
+      // tap-to-seek that resolves within a few milliseconds. Under the shared
+      // floor the most meaningful haptic in the gesture is the one most likely to
+      // be swallowed. It is discrete and hand-driven, so it cannot flood alone.
       let interval = max(minimumInterval ?? 0, Self.systemRateLimitInterval)
-      guard allowsImpact(minimumInterval: interval) else { return }
+      if haptic == .commit {
+        // Still stamps the clock, so whatever follows is spaced from here.
+        lastImpactTime = ProcessInfo.processInfo.systemUptime
+      } else {
+        guard allowsImpact(minimumInterval: interval) else { return }
+      }
       // `.detent` stays on the canned generator at *every* strength.
       // `UIImpactFeedbackGenerator` is the API built for rapid repeated feedback
       // and can be held armed between ticks (see the `prepare()` call below),
@@ -588,7 +587,18 @@ enum AppHaptic {
     func sleep() {
       // Players do not survive the engine stopping.
       impactPlayers.removeAll()
-      engine?.stop()
+      // Drop our reference *before* stopping, and hand `stop()` the local. The
+      // stop completes asynchronously and then fires `stoppedHandler`; if the
+      // scene became active again in the meantime, `wake()` will have built a
+      // new engine, and a handler still holding the old one would otherwise nil
+      // it out. That left `playCoreImpact` returning false for every call, so
+      // `.strong`/`.heavy` silently degraded to the canned generators until the
+      // next sleep/wake cycle happened to land in the other order.
+      let stopping = engine
+      engine = nil
+      enginePrepared = false
+      engineGeneration += 1
+      stopping?.stop()
     }
 
     // MARK: CoreHaptics
@@ -625,18 +635,29 @@ enum AppHaptic {
         // otherwise inherit @MainActor and trap at runtime when CoreHaptics
         // invokes them off the main queue — the same trap SDWebImage's
         // request modifiers and unguarded Combine sinks hit here before.
+        //
+        // Both are also generation-guarded. They arrive asynchronously, so a
+        // sleep/wake cycle can replace `engine` before the handler for the *old*
+        // one runs; without the guard that stale handler would invalidate the
+        // live engine. Comparing a captured generation is what keeps them from
+        // acting on an engine they no longer own — capturing the engine itself
+        // would retain it inside its own handler.
+        engineGeneration += 1
+        let generation = engineGeneration
         engine.stoppedHandler = { @Sendable [weak self] _ in
           Task { @MainActor in
-            self?.impactPlayers.removeAll()
-            self?.engine = nil
+            guard let self, self.engineGeneration == generation else { return }
+            self.impactPlayers.removeAll()
+            self.engine = nil
           }
         }
         engine.resetHandler = { @Sendable [weak self] in
           Task { @MainActor in
+            guard let self, self.engineGeneration == generation else { return }
             // Players are bound to the engine that built them and do not
             // survive a reset; Apple requires recreating them here.
-            self?.impactPlayers.removeAll()
-            try? self?.engine?.start()
+            self.impactPlayers.removeAll()
+            try? self.engine?.start()
           }
         }
         try engine.start()

--- a/TwinskaraokeShared/Components/PressableButtonStyle.swift
+++ b/TwinskaraokeShared/Components/PressableButtonStyle.swift
@@ -22,46 +22,6 @@ extension View {
   }
 }
 
-enum AppHaptic {
-  case light
-  case medium
-  case selection
-  case success
-  case warning
-  case error
-
-  func play() {
-    #if os(iOS)
-      switch self {
-      case .light:
-        let generator = UIImpactFeedbackGenerator(style: .light)
-        generator.prepare()
-        generator.impactOccurred()
-      case .medium:
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.prepare()
-        generator.impactOccurred()
-      case .selection:
-        let generator = UISelectionFeedbackGenerator()
-        generator.prepare()
-        generator.selectionChanged()
-      case .success:
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-        generator.notificationOccurred(.success)
-      case .warning:
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-        generator.notificationOccurred(.warning)
-      case .error:
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-        generator.notificationOccurred(.error)
-      }
-    #endif
-  }
-}
-
 struct PressableButtonStyle: ButtonStyle {
   var scale: CGFloat = 0.97
   var dim: Double = 0.7


### PR DESCRIPTION
## Why

`AppHaptic` had six flat cases named after textures, and `.selection` had become the dumping ground for **61% of every haptic in the app**. It also allocated a `UIFeedbackGenerator` per call and `prepare()`d it immediately before firing, which buys nothing — the generator needs lead time to warm the Taptic Engine.

## What changed

`AppHaptic` moves out of `PressableButtonStyle` into its own file and takes the shape `AppMotion` already has: **pick a role, not a texture**, so the feel behind a role can be retuned once instead of per call site.

Roles are `selection`, `detent`, `grab`, `commit`, `dismiss`, `boundary`, `success`, `warning`, `error`, `celebrate`. `.light`/`.medium` are gone and all 47 sites that used them are migrated. Generators are cached; `celebrate` is a CoreHaptics pattern.

A **Haptics** section in Settings adds an on/off switch and a Light/Medium/Strong/Heavy baseline, defaulting to Medium. The role picks character, the baseline picks weight, and roles keep their relative ordering at every level so raising it never collapses two into the same sensation. Strong and Heavy render impacts through CoreHaptics, where intensity, sharpness and duration are continuous — the canned generators top out at `.heavy` at full intensity and several roles already sat there.

Two roles are deliberately rationed:

- **`.warning`** now means "finished, but needs attention" rather than "you deleted something" — 16 sites down to 6. Deliberate destructive actions use `.dismiss` when performed and `.selection` when they only open a confirmation.
- **`.celebrate`** fires from one place, and only for a batch.

## Bugs fixed

- **Four buttons fired twice on one tap**, having both an action haptic and a style haptic. `PlayerArtworkView` already showed the convention (`haptic: nil` on the style when the action plays one).
- **`DownloadedSongsView` played `.warning` twice** for a single tap, the second through a nested call.
- **A `haptic:` on `PressableButtonStyle` is unreliable inside a `ToolbarItem`** — SwiftUI substitutes its own style there and discards the custom style's feedback with it. That is why the account toolbar button looked wired and felt dead.

## Coverage added

Places that previously had no feedback at all: 19 navigation links, 14 Settings toggles, 4 pickers, scrub detents with end-stops, slider detents, scroll edges, remote/lock-screen play-pause, pull-to-refresh completion, and the mini player's expand/collapse.

Three helpers cover controls SwiftUI gives no action closure: `navigationTapHaptic`, `toggleHaptic`, `selectionHaptic`.

## Continuous interactions and the 32Hz limit

Worth reading the comments here, because both guards are counter-intuitive and were established by measuring on device:

1. **`prepare()` after every impact.** The generator's reporter otherwise idles out between ticks, and the reconnection churn is what trips the haptic server's 32Hz limit — not the fire rate. Throttling harder made it *worse*: at 50ms gaps the server complained ~2.2x per impact, at 83ms gaps ~2.5x, and at 10Hz (well under the ceiling) it still complained.
2. **One shared 20Hz clock for every impact.** Roles sharing a clock mean the loosest interval sets the real ceiling. With a looser global floor, a scrub end-stop interleaved with detents and slipped through at 33ms while every role individually respected its own spacing.

Detent spacing exists so ticks stay perceptually distinct, never as a rate-limit remedy.

## Audio session

The CoreHaptics engine now shares the app's `AVAudioSession` instead of creating its own, and is set to `playsHapticsOnly`. Per the header, engines sharing a session get identical interruption behaviour — worth having in an app with crossfade and stem separation. The system volume bridge also pushes at 20Hz instead of display rate, which is imperceptible on a volume slider.

## Testing

- iOS Debug (simulator), iOS Release (arm64 device), watchOS and tvOS all build warning-clean.
- `TwinskaraokeTests` passes.
- Device-tested on iPhone across several rounds — haptics can't be verified in the simulator, which has no Taptic Engine. Final run showed zero rate-limit warnings and zero reporter-churn lines while scrubbing as fast as possible.

## Notes for review

- Three settings toggles were found to be **dead** — `nk.downloadOnPlay`, `nk.addPlaylistSongsToLibrary`, `nk.addFavoriteSongsToLibrary` are declared in `SettingsView` and read nowhere else. Pre-existing and left alone, but worth knowing.
- `UIImpactFeedbackGenerator(style:)` is marked `API_DEPRECATED_WITH_REPLACEMENT` in favour of `init(style:view:)` (iOS 17.5+). Not adopted here: the engine is a view-less singleton, so adopting it means resolving a key window. Known debt, and the remaining lead if reporter churn ever returns.
- Coverage is iOS/iPadOS only. The shared file is guarded with `#if os(iOS)`, and watchOS/tvOS build clean.

## Summary by Sourcery

Unify haptic feedback behind a single role-based API, add global haptic preferences, and extend tactile coverage across core interactions while tuning strengths and fixing duplicated or missing feedback.

New Features:
- Introduce a centralized AppHaptic system with semantic roles instead of texture-based cases, including support for CoreHaptics-based patterns.
- Add user-facing haptic settings to toggle feedback and choose baseline strength, wired through an environment injector.
- Provide reusable helpers to attach haptic feedback to navigation taps, toggles, pickers, scroll edges, and other SwiftUI interactions.

Bug Fixes:
- Resolve cases where buttons produced duplicate haptics by removing overlapping style and action feedback.
- Fix double-warning feedback in DownloadedSongsView by consolidating haptic calls.
- Work around ToolbarItem button-style substitution by moving account toolbar haptics to an explicit gesture.

Enhancements:
- Retune haptic roles throughout the app to distinguish selection, commit, dismiss, boundary, and celebration interactions, and migrate all previous light/medium usages.
- Add scrub detents, slider ticks, and scroll edge haptics to make continuous interactions feel more tactile without exceeding system rate limits.
- Align remote and lock-screen playback controls with in-app controls by adding appropriate commit haptics.
- Throttle volume bridge updates and haptic impacts to respect system rate limits while maintaining perceived responsiveness.

Tests:
- Ensure existing iOS, watchOS, and tvOS builds and tests continue to pass with the new haptics infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable haptic feedback controls, including enablement and strength preferences.
  * Added tactile feedback when reaching scroll limits and crossing progress-bar scrubber notches.
  * Added celebratory feedback after successful multi-downloads and completed refreshes.
* **Enhancements**
  * Improved consistency and timing of feedback across playback, navigation, playlists, downloads, account actions, and radio controls.
  * Refined feedback for confirmations, dismissals, destructive actions, and successful operations.
  * Improved volume scrubbing responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->