### PR TITLE
Move the tab bar to the Tab value API, with a search-role tab and scroll minimize

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -207,6 +207,12 @@ private struct PopupHostView: View {
             }
         }
         .tint(.appAccent)
+        // Replaces the hand-rolled scroll-collapse that BottomChromeState was
+        // built for and never wired up. Worth re-checking on device if the
+        // mini player ever looks misplaced: LNPopupController floats its bar
+        // above the tab bar, and ShimejiFloorRegistry rests idle instances on
+        // the live UITabBar's top edge, both of which move as the bar minimizes.
+        .tabBarMinimizeBehavior(.onScrollDown)
     }
 
     private var sidebarShell: some View {

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -178,32 +178,23 @@ private struct PopupHostView: View {
     }
 
     private var rootTabs: some View {
-        // `systemImage:`, not `selectedSystemImage:` — the tab bar fills the
-        // symbol itself for the selected tab. Passing the filled variant here
-        // is what made Home and New render filled even while unselected.
+        // Driven off `allCases` and `content` so the enum stays the only place
+        // a section is described — the sidebar already builds itself the same
+        // way, and listing the screens here too let the two drift apart.
+        //
+        // `systemImage` is the unfilled symbol: the tab bar fills it for the
+        // selected tab itself. Passing the filled variant is what made Home and
+        // New render filled even while unselected.
         TabView(selection: selectedTabBinding) {
-            Tab(RootSection.home.title, systemImage: RootSection.home.systemImage, value: RootSection.home) {
-                HomeView()
-            }
-            Tab(RootSection.new.title, systemImage: RootSection.new.systemImage, value: RootSection.new) {
-                NewView()
-            }
-            Tab(RootSection.radio.title, systemImage: RootSection.radio.systemImage, value: RootSection.radio) {
-                RadioView()
-            }
-            Tab(RootSection.library.title, systemImage: RootSection.library.systemImage, value: RootSection.library) {
-                LibraryView()
-            }
-            // `role: .search` gives the tab its own affordance on iOS 26 —
-            // separated from the rest of the bar, and morphing into the search
-            // field rather than pushing a screen that happens to contain one.
-            Tab(
-                RootSection.search.title,
-                systemImage: RootSection.search.systemImage,
-                value: RootSection.search,
-                role: .search
-            ) {
-                SearchView()
+            ForEach(RootSection.allCases) { section in
+                Tab(
+                    section.title,
+                    systemImage: section.systemImage,
+                    value: section,
+                    role: section.tabRole
+                ) {
+                    section.content
+                }
             }
         }
         .tint(.appAccent)
@@ -321,21 +312,12 @@ private enum RootSection: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Sidebar only — the tab bar fills the selected symbol for itself.
-    ///
-    /// Radio, Library and Search repeat their unselected symbol because
-    /// `dot.radiowaves.left.and.right`, `music.note.list` and `magnifyingglass`
-    /// have no filled counterpart in SF Symbols. The sidebar still reads as
-    /// selected: `SidebarSectionRow` swaps the icon's tinted backing plate to
-    /// full opacity and its foreground to white.
-    var selectedSystemImage: String {
-        switch self {
-        case .home: "house.fill"
-        case .new: "square.grid.2x2.fill"
-        case .radio: "dot.radiowaves.left.and.right"
-        case .library: "music.note.list"
-        case .search: "magnifyingglass"
-        }
+    /// Search gets the system's search affordance on iOS 26 — separated from
+    /// the rest of the bar, and morphing into the search field rather than
+    /// pushing a screen that happens to contain one. Everything else is an
+    /// ordinary tab.
+    var tabRole: TabRole? {
+        self == .search ? .search : nil
     }
 
     @ViewBuilder
@@ -390,7 +372,7 @@ private struct SidebarSectionRow: View {
             ZStack {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
                     .fill(section.sidebarTint.opacity(isSelected ? 1 : 0.14))
-                Image(systemName: isSelected ? section.selectedSystemImage : section.systemImage)
+                Image(systemName: isSelected ? section.sidebarSelectedSystemImage : section.systemImage)
                     .font(.caption.bold())
                     .foregroundStyle(isSelected ? Color.white : section.sidebarTint)
             }
@@ -462,6 +444,25 @@ private struct SidebarNowPlayingHint: View {
 }
 
 private extension RootSection {
+    /// Sidebar only, and deliberately scoped to this extension: the tab bar
+    /// fills the selected symbol for itself, and handing it the filled variant
+    /// is what previously made Home and New render filled while unselected.
+    ///
+    /// Radio, Library and Search repeat their unselected symbol because
+    /// `dot.radiowaves.left.and.right`, `music.note.list` and `magnifyingglass`
+    /// have no filled counterpart in SF Symbols. The sidebar still reads as
+    /// selected: `SidebarSectionRow` swaps the icon's tinted backing plate to
+    /// full opacity and its foreground to white.
+    var sidebarSelectedSystemImage: String {
+        switch self {
+        case .home: "house.fill"
+        case .new: "square.grid.2x2.fill"
+        case .radio: "dot.radiowaves.left.and.right"
+        case .library: "music.note.list"
+        case .search: "magnifyingglass"
+        }
+    }
+
     var sidebarTint: Color {
         switch self {
         case .home:

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -178,22 +178,33 @@ private struct PopupHostView: View {
     }
 
     private var rootTabs: some View {
+        // `systemImage:`, not `selectedSystemImage:` — the tab bar fills the
+        // symbol itself for the selected tab. Passing the filled variant here
+        // is what made Home and New render filled even while unselected.
         TabView(selection: selectedTabBinding) {
-            HomeView()
-                .tabItem { Label(RootSection.home.title, systemImage: RootSection.home.selectedSystemImage) }
-                .tag(RootSection.home)
-            NewView()
-                .tabItem { Label(RootSection.new.title, systemImage: RootSection.new.selectedSystemImage) }
-                .tag(RootSection.new)
-            RadioView()
-                .tabItem { Label(RootSection.radio.title, systemImage: RootSection.radio.selectedSystemImage) }
-                .tag(RootSection.radio)
-            LibraryView()
-                .tabItem { Label(RootSection.library.title, systemImage: RootSection.library.selectedSystemImage) }
-                .tag(RootSection.library)
-            SearchView()
-                .tabItem { Label(RootSection.search.title, systemImage: RootSection.search.selectedSystemImage) }
-                .tag(RootSection.search)
+            Tab(RootSection.home.title, systemImage: RootSection.home.systemImage, value: RootSection.home) {
+                HomeView()
+            }
+            Tab(RootSection.new.title, systemImage: RootSection.new.systemImage, value: RootSection.new) {
+                NewView()
+            }
+            Tab(RootSection.radio.title, systemImage: RootSection.radio.systemImage, value: RootSection.radio) {
+                RadioView()
+            }
+            Tab(RootSection.library.title, systemImage: RootSection.library.systemImage, value: RootSection.library) {
+                LibraryView()
+            }
+            // `role: .search` gives the tab its own affordance on iOS 26 —
+            // separated from the rest of the bar, and morphing into the search
+            // field rather than pushing a screen that happens to contain one.
+            Tab(
+                RootSection.search.title,
+                systemImage: RootSection.search.systemImage,
+                value: RootSection.search,
+                role: .search
+            ) {
+                SearchView()
+            }
         }
         .tint(.appAccent)
     }
@@ -304,6 +315,13 @@ private enum RootSection: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Sidebar only — the tab bar fills the selected symbol for itself.
+    ///
+    /// Radio, Library and Search repeat their unselected symbol because
+    /// `dot.radiowaves.left.and.right`, `music.note.list` and `magnifyingglass`
+    /// have no filled counterpart in SF Symbols. The sidebar still reads as
+    /// selected: `SidebarSectionRow` swaps the icon's tinted backing plate to
+    /// full opacity and its foreground to white.
     var selectedSystemImage: String {
         switch self {
         case .home: "house.fill"

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -70,7 +70,6 @@ struct PlaylistListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .searchable(
             text: $searchText,
-            placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Search Playlists"
         )
         .onAppear {

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -77,7 +77,6 @@ struct ArtistsView: View {
         .navigationBarTitleDisplayMode(.large)
         .searchable(
             text: $searchText,
-            placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Search Artists"
         )
         .refreshable {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -460,7 +460,6 @@ struct LibrarySongsView: View {
         .navigationBarTitleDisplayMode(.large)
         .searchable(
             text: $viewModel.searchText,
-            placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Search Songs"
         )
         .toolbar {
@@ -708,7 +707,6 @@ struct PlaylistsGridScreen: View {
         .navigationBarTitleDisplayMode(.inline)
         .searchable(
             text: $searchText,
-            placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Search Playlists"
         )
         .toolbar {

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -54,7 +54,6 @@ struct UploadedSongsView: View {
         .navigationBarTitleDisplayMode(.large)
         .searchable(
             text: $viewModel.searchText,
-            placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Search Uploads"
         )
         .toolbar {

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -96,7 +96,6 @@ struct SearchView: View {
             }
             .searchable(
                 text: $viewModel.searchText,
-                placement: .navigationBarDrawer(displayMode: .always),
                 prompt: "Songs, Artists, Lyrics, and More"
             )
             .onChange(of: playback.currentSongID) { _, currentSongID in


### PR DESCRIPTION
Second of three batches from the iOS 26 UI audit. #101 covered the runtime
bugs; this one moves the tab bar off the superseded API. Branched off `main`
after #101 merged, since it rewrites the same region of `ContentView`.

## `.tabItem` → the `Tab` value API

`.tabItem`/`.tag` predates `Tab(_:systemImage:value:)` and, at a 26.0
deployment target, costs the tab bar two things.

**Search becomes `Tab(role: .search)`** — it gets the separated search
affordance and morphs into the search field, instead of being an ordinary tab
that happens to push a screen containing one.

**Unselected tabs no longer render filled icons.** Every `.tabItem` was handed
`selectedSystemImage` unconditionally, so Home always drew `house.fill` and New
always `square.grid.2x2.fill` whether or not they were selected — the unfilled
variants were only ever read by the sidebar. The tab bar fills the selected
symbol itself, so it now receives the unfilled one.

`selectedSystemImage` stays for the sidebar. Radio, Library and Search repeat
their unselected symbol there because `dot.radiowaves.left.and.right`,
`music.note.list` and `magnifyingglass` genuinely have no filled counterpart in
SF Symbols. `SidebarSectionRow` still reads as selected — it swaps the icon's
tinted backing plate to full opacity and its foreground to white — so this is
documented rather than worked around with a substitute symbol.

## `.searchable` placement

All six call sites forced `placement: .navigationBarDrawer(displayMode: .always)`,
the iOS 15 layout, overriding the current one. Dropped, so the system picks —
on iPhone that is the bottom-anchored glass search field.

## Tab bar minimize — separate commit, safe to drop

`.tabBarMinimizeBehavior(.onScrollDown)` is the behaviour `BottomChromeState`
was written for and never connected to anything (removed in #101).

Kept as its own commit (21dead8) so it can be reverted without losing the rest
of the branch. Two things track a tab bar that now moves on scroll:
LNPopupController floats the mini player bar above it, and
`ShimejiFloorRegistry` rests idle instances on the live `UITabBar`'s top edge.
Both re-measure, so they should follow, but this is the part worth watching.

## Verification

- Build stays warning-clean; `TwinskaraokeTests` pass.
- **Needs device testing**, and specifically cannot be checked from the
  simulator: `simctl` screenshots on iOS 26 omit the Liquid Glass tab bar
  entirely, which is exactly the surface this PR changes.
- Worth checking: unselected tab icons are unfilled; the search tab's affordance
  and field placement on iPhone vs iPad; the mini player's position while the
  bar minimizes and restores; Shimeji resting on the bar edge.

The 32 pt bottom content inset (`tabBarScrollInset()` / `AdaptiveBottomChrome`)
was reviewed and deliberately left alone — it is a design margin layered on top
of the safe area rather than a substitute for it, and nothing here changes how
it composes.

## Still to come

One batch left: the legacy sweep — `foregroundColor` → `foregroundStyle` across
48 sites, 17 unreachable `#available` branches, the global `UIView.appearance()`
tint proxies, materials → Liquid Glass, `.borderedProminent` → `.glassProminent`.

## Summary by Sourcery

Adopt the modern SwiftUI Tab value API for the main tab bar, integrate iOS 26 search-role behavior, and align search UI and tab bar scrolling with the system’s current patterns.

New Features:
- Make the Search tab use the dedicated search role so it gains the iOS 26 search affordance and integrated search field behavior.

Enhancements:
- Switch the main TabView from tabItem/tag to the Tab(_:systemImage:value:) API so the tab bar manages selection state and icon filling correctly.
- Use unfilled SF Symbols for tab bar items while keeping filled variants for the sidebar to improve visual consistency between selected and unselected tabs.
- Enable .tabBarMinimizeBehavior(.onScrollDown) so the tab bar collapses on scroll, allowing dependent UI like the mini player and Shimeji overlays to track the moving bar.
- Remove explicit .searchable placement overrides so the system chooses the appropriate search field presentation per platform and OS version.