### PR TITLE
Sweep the remaining pre-iOS-26 UI idioms

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -594,19 +594,12 @@ private struct PopupBarTrailingItems: View, Equatable {
     var body: some View {
         HStack(spacing: 16) {
             Button(action: onTogglePlayPause) {
-                Group {
-                    if #available(iOS 17.0, *) {
-                        Image(systemName: playPauseSymbol)
-                            .contentTransition(.symbolEffect(.replace))
-                    } else {
-                        Image(systemName: playPauseSymbol)
-                            .contentTransition(.opacity)
-                    }
-                }
-                .font(.title3.bold())
-                .foregroundStyle(.primary)
-                .frame(width: 44, height: 44)
-                .contentShape(Rectangle())
+                Image(systemName: playPauseSymbol)
+                    .contentTransition(.symbolEffect(.replace))
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(PressableButtonStyle(scale: 0.86, dim: 0.65, haptic: .commit))
             .accessibilityLabel(playPauseAccessibilityLabel)

--- a/Twinskaraoke/App/TwinskaraokeApp.swift
+++ b/Twinskaraoke/App/TwinskaraokeApp.swift
@@ -1,9 +1,5 @@
 import SwiftUI
 
-#if canImport(UIKit)
-    import UIKit
-#endif
-
 @main
 struct TwinskaraokeApp: App {
     @AppStorage("nk.appearance") private var appearanceMode: String = AppearanceMode.dark.rawValue
@@ -14,14 +10,6 @@ struct TwinskaraokeApp: App {
         // Mirrors the signed-in session to the paired watch, which has no way
         // to sign in on its own. No-op on devices that can't pair one.
         WatchSessionPublisher.shared.activate()
-        #if canImport(UIKit)
-            let accent = UIColor(red: 0.99, green: 0.19, blue: 0.35, alpha: 1)
-            UIView.appearance().tintColor = accent
-            UIWindow.appearance().tintColor = accent
-            UINavigationBar.appearance().tintColor = accent
-            UITabBar.appearance().tintColor = accent
-            UISwitch.appearance().onTintColor = accent
-        #endif
     }
 
     var body: some Scene {

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -79,7 +79,7 @@ struct AddToPlaylistSheet: View {
                     .padding(.horizontal, 20)
                     .padding(.top, 10)
                     .padding(.bottom, 10)
-                    .background(.regularMaterial)
+                    .appGlassBackground(in: Rectangle())
                 }
             }
             .navigationTitle("Add to Playlist")

--- a/Twinskaraoke/Components/Media/ArtThumbnail.swift
+++ b/Twinskaraoke/Components/Media/ArtThumbnail.swift
@@ -20,7 +20,7 @@ struct ArtThumbnail: View {
             if let upvotes = art.upvotes, upvotes > 0 {
                 Label("\(upvotes)", systemImage: "heart.fill")
                     .scaledSystemFont(size: 11, weight: .bold)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 5)
                     .background(Color.black.opacity(0.45), in: Capsule())

--- a/Twinskaraoke/Components/Media/ArtworkViewerLiquidGlassCircle.swift
+++ b/Twinskaraoke/Components/Media/ArtworkViewerLiquidGlassCircle.swift
@@ -13,20 +13,12 @@ struct ArtworkViewerLiquidGlassCircle: ViewModifier {
                 .overlay(glassStroke(lineWidth: strokeWidth))
                 .clipShape(Circle())
                 .contentShape(Circle())
-        } else if #available(iOS 26.0, *) {
+        } else {
             content
                 .glassEffect(.regular.interactive(), in: Circle())
                 .overlay(glassStroke(lineWidth: strokeWidth))
                 .overlay(specularHighlight)
                 .shadow(color: .black.opacity(0.28), radius: 18, y: 8)
-                .contentShape(Circle())
-        } else {
-            content
-                .background(.ultraThinMaterial, in: Circle())
-                .overlay(glassStroke(lineWidth: strokeWidth))
-                .overlay(specularHighlight)
-                .shadow(color: .black.opacity(0.28), radius: 18, y: 8)
-                .clipShape(Circle())
                 .contentShape(Circle())
         }
     }

--- a/Twinskaraoke/Components/Player/QueueComponents.swift
+++ b/Twinskaraoke/Components/Player/QueueComponents.swift
@@ -113,7 +113,7 @@ struct QueueModeButton: View {
     var body: some View {
         Button(action: action) {
             Group {
-                if #available(iOS 17.0, *), !reduceMotion {
+                if !reduceMotion {
                     Image(systemName: symbol)
                         .contentTransition(.symbolEffect(.replace))
                 } else {
@@ -136,17 +136,10 @@ struct QueueModeButton: View {
 struct QueueModeBackground: ViewModifier {
     let isActive: Bool
     func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            if isActive {
-                content.background(Capsule().fill(Color.appControlActiveFill))
-            } else {
-                content.glassEffect(in: Capsule())
-            }
+        if isActive {
+            content.background(Capsule().fill(Color.appControlActiveFill))
         } else {
-            content.background(
-                Capsule()
-                    .fill(isActive ? Color.appControlActiveFill : Color.appControlInactiveFill)
-            )
+            content.glassEffect(in: Capsule())
         }
     }
 }

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -484,16 +484,7 @@ private struct ToolbarAvatarLabel: View {
     let url: URL
 
     var body: some View {
-        if #available(iOS 26.0, *) {
-            avatarImage(diameter: 30)
-        } else {
-            ZStack {
-                ToolbarControlBackground()
-                avatarImage(diameter: 32)
-            }
-            .frame(width: 44, height: 44)
-            .contentShape(Circle())
-        }
+        avatarImage(diameter: 30)
     }
 
     private func avatarImage(diameter: CGFloat) -> some View {
@@ -518,17 +509,7 @@ private struct ToolbarIconLabel: View {
     @Environment(\.isEnabled) private var isEnabled
 
     var body: some View {
-        if #available(iOS 26.0, *) {
-            iconImage
-        } else {
-            ZStack {
-                ToolbarControlBackground()
-                iconImage
-                    .offset(x: iconHorizontalOffset)
-            }
-            .frame(width: 44, height: 44)
-            .contentShape(Circle())
-        }
+        iconImage
     }
 
     private var iconImage: some View {
@@ -536,66 +517,6 @@ private struct ToolbarIconLabel: View {
             .font(.headline)
             .symbolRenderingMode(.monochrome)
             .foregroundStyle(isEnabled ? foregroundColor : .secondary)
-    }
-
-    private var iconHorizontalOffset: CGFloat {
-        0
-    }
-}
-
-private struct ToolbarControlBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-
-    private var backgroundStyle: AnyShapeStyle {
-        reduceTransparency ? AnyShapeStyle(Color.appSecondaryBackground) : AnyShapeStyle(Material.regular)
-    }
-
-    var body: some View {
-        Circle()
-            .fill(backgroundStyle)
-            .overlay {
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            stops: [
-                                .init(color: sheenColor, location: 0),
-                                .init(color: .clear, location: 0.55),
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-            }
-            .overlay {
-                Circle()
-                    .strokeBorder(
-                        LinearGradient(
-                            colors: [rimHighlight, rimShadow],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        ),
-                        lineWidth: 0.8
-                    )
-            }
-            .shadow(color: shadowColor, radius: 3, x: 0, y: 1)
-            .padding(4)
-    }
-
-    private var sheenColor: Color {
-        colorScheme == .dark ? Color.white.opacity(0.12) : Color.white.opacity(0.55)
-    }
-
-    private var rimHighlight: Color {
-        colorScheme == .dark ? Color.white.opacity(0.24) : Color.white.opacity(0.90)
-    }
-
-    private var rimShadow: Color {
-        colorScheme == .dark ? Color.white.opacity(0.04) : Color.black.opacity(0.06)
-    }
-
-    private var shadowColor: Color {
-        colorScheme == .dark ? Color.black.opacity(0.28) : Color.black.opacity(0.10)
     }
 }
 

--- a/Twinskaraoke/Components/Shared/ContextPreviewCard.swift
+++ b/Twinskaraoke/Components/Shared/ContextPreviewCard.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Shared card shell for context-menu previews. The common visual contract
 /// is a 252 pt-wide card with a 220 pt artwork area and a text label below,
-/// padded 16 pt inside a `.regularMaterial` rounded rectangle.
+/// padded 16 pt inside a Liquid Glass rounded rectangle.
 ///
 /// Replaces the six near-identical private `XxxContextPreview` / `XxxPreview`
 /// structs that duplicated the shell in `SongRow`, `LibraryView`,
@@ -27,9 +27,6 @@ struct ContextPreviewCard<Artwork: View, Label: View>: View {
         }
         .padding(16)
         .frame(width: 252, alignment: .leading)
-        .background(
-            .regularMaterial,
-            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-        )
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }

--- a/Twinskaraoke/Components/Shared/GlassComponents.swift
+++ b/Twinskaraoke/Components/Shared/GlassComponents.swift
@@ -13,7 +13,7 @@ struct GlassCircle: ViewModifier {
                 .overlay(Circle().stroke(Color.appDivider, lineWidth: contrast == .increased ? 1 : 0.5))
                 .clipShape(Circle())
                 .contentShape(Circle())
-        } else if #available(iOS 26.0, *) {
+        } else {
             content
                 .glassEffect(.regular.interactive(), in: Circle())
                 .overlay {
@@ -21,18 +21,6 @@ struct GlassCircle: ViewModifier {
                         Circle().stroke(Color.appDivider, lineWidth: 1)
                     }
                 }
-                .contentShape(Circle())
-        } else {
-            content
-                .background(
-                    Circle()
-                        .fill(Color.appGlassFill)
-                )
-                .overlay(
-                    Circle()
-                        .stroke(Color.appDivider.opacity(contrast == .increased ? 1 : 0.7), lineWidth: contrast == .increased ? 1 : 0.5)
-                )
-                .clipShape(Circle())
                 .contentShape(Circle())
         }
     }
@@ -54,15 +42,9 @@ struct GlassRoundedRect: ViewModifier {
                     }
                 }
                 .shadow(color: .appShadow, radius: 14, y: 6)
-        } else if #available(iOS 26.0, *) {
-            content
-                .glassEffect(in: shape)
-                .shadow(color: .appShadow, radius: 14, y: 6)
         } else {
             content
-                .background(
-                    shape.fill(Color.appGlassFill)
-                )
+                .glassEffect(in: shape)
                 .shadow(color: .appShadow, radius: 14, y: 6)
         }
     }

--- a/Twinskaraoke/Components/Shared/GlassComponents.swift
+++ b/Twinskaraoke/Components/Shared/GlassComponents.swift
@@ -2,6 +2,44 @@ import SwiftUI
 
 // MARK: - Glass Modifiers
 
+/// Shape-agnostic Liquid Glass background for cards, panels and pills.
+///
+/// Falls back to an opaque fill when Reduce Transparency is on, strokes the
+/// edge under Increase Contrast so it stays visible without the material, and
+/// otherwise renders glass. `GlassRoundedRect` is this plus a drop shadow.
+///
+/// `GlassCircle` deliberately stays separate: it uses *interactive* glass and
+/// always strokes its reduced-transparency fill, both specific to the floating
+/// circular buttons it backs.
+struct AppGlassBackground<S: Shape>: ViewModifier {
+    let shape: S
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    func body(content: Content) -> some View {
+        if reduceTransparency {
+            content
+                .background(shape.fill(Color.appSecondaryBackground))
+                .overlay {
+                    if contrast == .increased {
+                        shape.stroke(Color.appDivider, lineWidth: 1)
+                    }
+                }
+        } else {
+            content.glassEffect(in: shape)
+        }
+    }
+}
+
+extension View {
+    /// Backs the view with Liquid Glass in `shape`, honouring Reduce
+    /// Transparency and Increase Contrast.
+    func appGlassBackground(in shape: some Shape) -> some View {
+        modifier(AppGlassBackground(shape: shape))
+    }
+}
+
 struct GlassCircle: ViewModifier {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorSchemeContrast) private var contrast
@@ -28,25 +66,11 @@ struct GlassCircle: ViewModifier {
 
 struct GlassRoundedRect: ViewModifier {
     let cornerRadius: CGFloat
-    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-    @Environment(\.colorSchemeContrast) private var contrast
 
     func body(content: Content) -> some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-        if reduceTransparency {
-            content
-                .background(shape.fill(Color.appSecondaryBackground))
-                .overlay {
-                    if contrast == .increased {
-                        shape.stroke(Color.appDivider, lineWidth: 1)
-                    }
-                }
-                .shadow(color: .appShadow, radius: 14, y: 6)
-        } else {
-            content
-                .glassEffect(in: shape)
-                .shadow(color: .appShadow, radius: 14, y: 6)
-        }
+        content
+            .appGlassBackground(in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .shadow(color: .appShadow, radius: 14, y: 6)
     }
 }
 

--- a/Twinskaraoke/Components/Shared/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/Shared/ScrollOptimization.swift
@@ -119,16 +119,12 @@ private struct SmoothScrollingModifier: ViewModifier {
             .scrollBounceBehavior(bounceBehavior)
             .scrollDismissesKeyboard(.interactively)
 
-        if #available(iOS 18.0, *) {
-            configured
-                .onScrollPhaseChange { _, phase in
-                    ScrollPerformanceState.shared.update(id: scrollID, isScrolling: phase.isScrolling)
-                }
-                .onDisappear {
-                    ScrollPerformanceState.shared.update(id: scrollID, isScrolling: false)
-                }
-        } else {
-            configured
-        }
+        configured
+            .onScrollPhaseChange { _, phase in
+                ScrollPerformanceState.shared.update(id: scrollID, isScrolling: phase.isScrolling)
+            }
+            .onDisappear {
+                ScrollPerformanceState.shared.update(id: scrollID, isScrolling: false)
+            }
     }
 }

--- a/Twinskaraoke/Features/Account/LevelUpSheet.swift
+++ b/Twinskaraoke/Features/Account/LevelUpSheet.swift
@@ -39,7 +39,7 @@ struct LevelUpSheet: View {
                 Button("Keep Going") {
                     dismiss()
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.glassProminent)
                 .tint(.appAccent)
             }
             .padding(.horizontal, 24)

--- a/Twinskaraoke/Features/Account/LoginSheet.swift
+++ b/Twinskaraoke/Features/Account/LoginSheet.swift
@@ -147,18 +147,12 @@ struct LoginSheet: View {
                     AppHaptic.selection.play()
                     showPassword.toggle()
                 } label: {
-                    Group {
-                        if #available(iOS 17.0, *) {
-                            Image(systemName: showPassword ? "eye.slash.fill" : "eye.fill")
-                                .contentTransition(.symbolEffect(.replace))
-                        } else {
-                            Image(systemName: showPassword ? "eye.slash.fill" : "eye.fill")
-                        }
-                    }
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .frame(width: 44, height: 44)
-                    .contentShape(Rectangle())
+                    Image(systemName: showPassword ? "eye.slash.fill" : "eye.fill")
+                        .contentTransition(.symbolEffect(.replace))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.72))
                 .accessibilityLabel(showPassword ? "Hide Password" : "Show Password")

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -209,7 +209,7 @@ struct QRApproveView: View {
         }
         .padding(24)
         .frame(maxWidth: 390)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 26, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 26, style: .continuous)
                 .stroke(Color.appDivider, lineWidth: 1)
@@ -263,7 +263,7 @@ struct QRApproveView: View {
         }
         .padding(24)
         .frame(maxWidth: 390)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 26, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 26, style: .continuous)
                 .stroke(Color.appDivider, lineWidth: 1)
@@ -440,7 +440,7 @@ private struct QRPermissionLoadingView: View {
         }
         .padding(24)
         .frame(maxWidth: 360)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 26, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 26, style: .continuous)
                 .stroke(Color.appDivider, lineWidth: 1)
@@ -482,7 +482,7 @@ private struct QRPermissionDeniedView: View {
         }
         .padding(24)
         .frame(maxWidth: 380)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 26, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 26, style: .continuous)
                 .stroke(Color.appDivider, lineWidth: 1)
@@ -524,7 +524,7 @@ private struct QRCameraUnavailableView: View {
         }
         .padding(24)
         .frame(maxWidth: 380)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 26, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 26, style: .continuous)
                 .stroke(Color.appDivider, lineWidth: 1)
@@ -671,7 +671,7 @@ private struct QRScannerInstructionPanel: View {
         }
         .padding(16)
         .frame(maxWidth: 420, alignment: .leading)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color.white.opacity(0.16), lineWidth: 1)

--- a/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailContextPreview.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ArtworkDetailContextPreview.swift
@@ -21,6 +21,6 @@ struct ArtworkDetailContextPreview: View {
         }
         .padding(14)
         .frame(width: 248, alignment: .leading)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }

--- a/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
@@ -74,14 +74,14 @@ struct ZoomableImageViewer: View {
                             if let title = visibleTitle {
                                 Text(title)
                                     .scaledSystemFont(size: 17, weight: .bold)
-                                    .foregroundColor(.white)
+                                    .foregroundStyle(.white)
                                     .lineLimit(2)
                                     .multilineTextAlignment(.center)
                             }
                             if let subtitle = visibleSubtitle {
                                 Text(subtitle)
                                     .scaledSystemFont(size: 14)
-                                    .foregroundColor(.white.opacity(0.7))
+                                    .foregroundStyle(.white.opacity(0.7))
                                     .lineLimit(1)
                             }
                         }

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
@@ -132,7 +132,7 @@ private struct ArtistArtsHero: View {
                     if let social = artist.socialLink, !social.isEmpty {
                         Text(social)
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
                 }
@@ -172,7 +172,7 @@ private struct HeroArtwork: View {
                     .overlay(
                         Text(initial(artistName))
                             .font(.system(size: 70, weight: .bold))
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                     )
             }
         }

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistArtsView.swift
@@ -266,6 +266,6 @@ private struct ArtContextPreview: View {
         }
         .padding(14)
         .frame(width: 248, alignment: .leading)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistCircleCard.swift
@@ -22,7 +22,7 @@ struct ArtistCircleCard: View {
                         .overlay(
                             Text(initials(artist.name))
                                 .font(.system(size: 24, weight: .semibold))
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                         )
                 }
             }
@@ -30,7 +30,7 @@ struct ArtistCircleCard: View {
             .clipShape(Circle())
             Text(artist.name)
                 .scaledSystemFont(size: 13, weight: .medium)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
                 .frame(width: 100)

--- a/Twinskaraoke/Features/Library/ArtGallery/ArtistListRow.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/ArtistListRow.swift
@@ -22,7 +22,7 @@ struct ArtistListRow: View {
                         .overlay(
                             Text(String(artist.name.first ?? "?").uppercased())
                                 .font(.system(size: 16, weight: .semibold))
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                         )
                 }
             }
@@ -31,16 +31,16 @@ struct ArtistListRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(artist.name)
                     .scaledSystemFont(size: 16, weight: .medium)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                     .lineLimit(1)
                 Text("\(artist.arts?.count ?? 0) artworks")
                     .scaledSystemFont(size: 13)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             Spacer()
             Image(systemName: "chevron.right")
                 .scaledSystemFont(size: 13, weight: .semibold)
-                .foregroundColor(.secondary.opacity(0.6))
+                .foregroundStyle(.secondary.opacity(0.6))
         }
         .padding(.vertical, 10)
         .contentShape(Rectangle())

--- a/Twinskaraoke/Features/Library/ArtGallery/FeaturedArtCard.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/FeaturedArtCard.swift
@@ -29,16 +29,16 @@ struct FeaturedArtCard: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("FEATURED ART")
                     .scaledSystemFont(size: 11, weight: .bold)
-                    .foregroundColor(.white.opacity(0.85))
+                    .foregroundStyle(.white.opacity(0.85))
                     .tracking(0.6)
                 Text(artist.name)
                     .scaledSystemFont(size: 22, weight: .bold)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .lineLimit(1)
                 if let upvotes = art.upvotes, upvotes > 0 {
                     Label("\(upvotes)", systemImage: "heart.fill")
                         .scaledSystemFont(size: 13, weight: .semibold)
-                        .foregroundColor(.white.opacity(0.9))
+                        .foregroundStyle(.white.opacity(0.9))
                         .padding(.top, 2)
                 }
             }

--- a/Twinskaraoke/Features/Library/ArtGallery/GalleryArtPreview.swift
+++ b/Twinskaraoke/Features/Library/ArtGallery/GalleryArtPreview.swift
@@ -21,6 +21,6 @@ struct GalleryArtPreview: View {
         }
         .padding(14)
         .frame(width: 248, alignment: .leading)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -107,7 +107,7 @@ private struct ArtistRow: View {
                 if let count = artist.songCount, count > 0 {
                     Text("\(count) songs")
                         .font(AM.Font.rowSubtitle)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
             Spacer()
@@ -140,7 +140,7 @@ private struct ArtistAvatarPlaceholder: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: side * 0.55, height: side * 0.55)
-                    .foregroundColor(Color.appPlaceholderPrimary)
+                    .foregroundStyle(Color.appPlaceholderPrimary)
                     .offset(y: side * 0.06)
             }
             .frame(width: proxy.size.width, height: proxy.size.height)
@@ -176,11 +176,11 @@ struct ArtistDetailView: View {
                         if let count = current.songCount, count > 0 {
                             Text("\(count) songs")
                                 .font(.subheadline)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         } else if !songs.isEmpty {
                             Text("\(songs.count) songs")
                                 .font(.subheadline)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .padding(.horizontal)
@@ -235,7 +235,7 @@ struct ArtistDetailView: View {
                     } label: {
                         Image(systemName: "ellipsis")
                             .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.appAccent)
+                            .foregroundStyle(Color.appAccent)
                             .frame(width: 32, height: 32)
                             .contentShape(Rectangle())
                     }
@@ -309,7 +309,7 @@ struct ArtistDetailView: View {
                     .scaledSystemFont(size: 18, weight: .bold)
                 Text(summary)
                     .scaledSystemFont(size: 14)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -363,11 +363,11 @@ private struct ArtistDetailStateView: View {
             VStack(spacing: AM.Spacing.s) {
                 Text(title)
                     .scaledSystemFont(size: 23, weight: .bold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                     .multilineTextAlignment(.center)
                 Text(message)
                     .scaledSystemFont(size: 15)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .lineLimit(3)
             }
@@ -436,10 +436,10 @@ private struct ArtistDetailHintRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .scaledSystemFont(size: 14, weight: .semibold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                 Text(message)
                     .scaledSystemFont(size: 13)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
             Spacer(minLength: 0)

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -167,7 +167,7 @@ private struct CreatePlaylistArtworkPreview: View {
         VStack(spacing: 6) {
             Text(name.isEmpty ? "New Playlist" : name)
                 .scaledSystemFont(size: 28, weight: .bold)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
 
@@ -217,7 +217,7 @@ private struct CreatePlaylistPrivacyLabel: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(isPublic ? "Public" : "Private")
                     .scaledSystemFont(size: 16, weight: .semibold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                 Text(isPublic ? "Visible to other listeners" : "Only you can edit this playlist")
                     .scaledSystemFont(size: 13)
                     .foregroundStyle(.secondary)
@@ -262,7 +262,7 @@ private struct CreatePlaylistSaveLabel: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 15)
-        .foregroundColor(.appControlActiveForeground)
+        .foregroundStyle(Color.appControlActiveForeground)
         .background(Color.appControlActiveFill, in: Capsule())
         .opacity(isSaving ? 0.72 : 1)
     }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -35,7 +35,7 @@ struct DownloadedSongsView: View {
                                 .font(.title2.bold())
                             Text(downloadedSubtitle)
                                 .font(.subheadline)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                         actionButtons
                             .padding(.horizontal)
@@ -176,7 +176,7 @@ struct DownloadedSongsView: View {
             .overlay(
                 Image(systemName: "arrow.down.circle.fill")
                     .font(.system(size: 64, weight: .medium))
-                    .foregroundColor(.white.opacity(0.85))
+                    .foregroundStyle(.white.opacity(0.85))
             )
         }
     }
@@ -326,10 +326,10 @@ private struct DownloadedEmptyStateView: View {
             VStack(spacing: AM.Spacing.s) {
                 Text("No Downloads")
                     .scaledSystemFont(size: 23, weight: .bold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                 Text("Save songs from any song menu and they will appear here for offline playback.")
                     .scaledSystemFont(size: 15)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .lineLimit(3)
             }
@@ -393,10 +393,10 @@ private struct DownloadedEmptyHintRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .scaledSystemFont(size: 14, weight: .semibold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                 Text(message)
                     .scaledSystemFont(size: 13)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
             Spacer(minLength: 0)
@@ -477,7 +477,7 @@ private struct DownloadedSongsMenu: View {
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.appAccent)
+                .foregroundStyle(Color.appAccent)
                 .frame(width: 32, height: 32)
                 .contentShape(Rectangle())
         }

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -90,9 +90,7 @@ struct LibraryView: View {
                     )
                 }
 
-                if #available(iOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
-                }
+                ToolbarSpacer(.fixed, placement: .topBarTrailing)
 
                 ToolbarItem(placement: .topBarTrailing) {
                     AccountToolbarButton()

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -95,7 +95,7 @@ struct PlaylistDetailView: View {
         }
         .padding(.horizontal, 12)
         .frame(height: 40)
-        .background(.thinMaterial, in: Capsule())
+        .appGlassBackground(in: Capsule())
         .padding(.horizontal, AM.Spacing.screenMargin)
         .padding(.bottom, AM.Spacing.m)
         .accessibilityIdentifier("PlaylistDetail.search")

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -42,9 +42,7 @@ struct RandomSongsView: View {
                 .accessibilityHint("Loads a new random set.")
             }
 
-            if #available(iOS 26.0, *) {
-                ToolbarSpacer(.fixed, placement: .topBarTrailing)
-            }
+            ToolbarSpacer(.fixed, placement: .topBarTrailing)
 
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
@@ -291,21 +289,7 @@ private struct RandomSongsToolbarButtonLabel: View {
     @Environment(\.isEnabled) private var isEnabled
 
     var body: some View {
-        if #available(iOS 26.0, *) {
-            iconImage
-        } else {
-            ZStack {
-                Circle()
-                    .fill(.regularMaterial)
-                    .overlay {
-                        Circle()
-                            .stroke(Color.appDivider.opacity(0.7), lineWidth: 0.5)
-                    }
-                iconImage
-            }
-            .frame(width: 44, height: 44)
-            .contentShape(Circle())
-        }
+        iconImage
     }
 
     private var iconImage: some View {

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -127,7 +127,7 @@ struct RandomSongsView: View {
                     ProgressView()
                         .controlSize(.regular)
                         .padding(9)
-                        .background(.ultraThinMaterial, in: Circle())
+                        .appGlassBackground(in: Circle())
                         .padding(10)
                         .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale))
                 }

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -153,15 +153,15 @@ private struct FeaturedVideoCard: View {
                 HStack(spacing: 8) {
                     Image(systemName: "play.circle.fill")
                         .font(.system(size: 28))
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("LATEST VIDEO")
                             .scaledSystemFont(size: 11, weight: .bold)
-                            .foregroundColor(.white.opacity(0.85))
+                            .foregroundStyle(.white.opacity(0.85))
                             .tracking(0.5)
                         Text(video.songTitle ?? video.name)
                             .scaledSystemFont(size: 17, weight: .semibold)
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .lineLimit(2)
                             .multilineTextAlignment(.leading)
                     }
@@ -181,13 +181,13 @@ private struct VideoGalleryCell: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(video.songTitle ?? video.name)
                     .scaledSystemFont(size: 14, weight: .semibold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 if let creator = video.createdBy, !creator.isEmpty {
                     Text(creator)
                         .scaledSystemFont(size: 12)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
             }
@@ -222,11 +222,11 @@ private struct VideoGalleryStateView: View {
             VStack(spacing: AM.Spacing.s) {
                 Text(title)
                     .scaledSystemFont(size: 23, weight: .bold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                     .multilineTextAlignment(.center)
                 Text(message)
                     .scaledSystemFont(size: 15)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .lineLimit(3)
             }
@@ -293,10 +293,10 @@ private struct VideoGalleryHintRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .scaledSystemFont(size: 14, weight: .semibold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                 Text(message)
                     .scaledSystemFont(size: 13)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
             Spacer(minLength: 0)
@@ -367,16 +367,16 @@ private struct VideoContextPreview: View {
                 if isFeatured {
                     Text("Latest Video")
                         .scaledSystemFont(size: 11, weight: .bold)
-                        .foregroundColor(.appAccent)
+                        .foregroundStyle(Color.appAccent)
                 }
                 Text(video.displayTitle)
                     .scaledSystemFont(size: 17, weight: .semibold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                     .lineLimit(2)
                 if let creator = video.createdBy, !creator.isEmpty {
                     Text(creator)
                         .scaledSystemFont(size: 14)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
             }
@@ -654,13 +654,13 @@ private struct SimilarVideoRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(video.songTitle ?? video.name)
                     .scaledSystemFont(size: 14, weight: .semibold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
                 if let creator = video.createdBy, !creator.isEmpty {
                     Text(creator)
                         .scaledSystemFont(size: 12)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
             }

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -383,7 +383,7 @@ private struct VideoContextPreview: View {
         }
         .padding(16)
         .frame(width: 284, alignment: .leading)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }
 

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -250,7 +250,7 @@ private struct PlayerFavoriteButton: View {
             }
         } label: {
             Group {
-                if #available(iOS 17.0, *), !reduceMotion {
+                if !reduceMotion {
                     Image(systemName: isFavorite ? "star.fill" : "star")
                         .contentTransition(.symbolEffect(.replace))
                         .symbolEffect(.bounce, value: isFavorite)
@@ -1042,7 +1042,7 @@ struct FullScreenPlayerView: View {
                 audioManager.togglePlayPause()
             } label: {
                 Group {
-                    if #available(iOS 17.0, *), !reduceMotion {
+                    if !reduceMotion {
                         Image(systemName: audioManager.isPlaying ? "pause.fill" : "play.fill")
                             .contentTransition(.symbolEffect(.replace))
                     } else {

--- a/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
+++ b/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
@@ -81,7 +81,7 @@ struct RadioPlayerLayout: View {
                 } label: {
                     Group {
                         let isFav = favorites.isFavorite(songID)
-                        if #available(iOS 17.0, *), !reduceMotion {
+                        if !reduceMotion {
                             Image(systemName: isFav ? "star.fill" : "star")
                                 .contentTransition(.symbolEffect(.replace))
                         } else {
@@ -108,7 +108,7 @@ struct RadioPlayerLayout: View {
             audioManager.togglePlayPause()
         } label: {
             Group {
-                if #available(iOS 17.0, *), !reduceMotion {
+                if !reduceMotion {
                     Image(systemName: audioManager.isPlaying ? "stop.fill" : "play.fill")
                         .contentTransition(.symbolEffect(.replace))
                 } else {

--- a/Twinskaraoke/Features/Radio/RadioQueueHero.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueHero.swift
@@ -61,10 +61,7 @@ struct RadioQueueHero: View {
             .accessibilityLabel(isPlaying ? "Pause live station" : "Play live station")
         }
         .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(.regularMaterial)
-        )
+        .appGlassBackground(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .strokeBorder(Color.appDivider.opacity(0.8), lineWidth: 0.5)

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -92,9 +92,7 @@ struct RadioView: View {
                     .accessibilityHint("Shows live now, up next, and recently played songs.")
                 }
 
-                if #available(iOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
-                }
+                ToolbarSpacer(.fixed, placement: .topBarTrailing)
 
                 ToolbarItem(placement: .topBarTrailing) {
                     AccountToolbarButton()

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2181,9 +2181,7 @@ final class AudioPlayerManager {
         activateAudioSession()
         let item = AVPlayerItem(url: url)
         let player = AVPlayer(playerItem: item)
-        if #available(iOS 15.0, *) {
-            player.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
-        }
+        player.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
         player.automaticallyWaitsToMinimizeStalling = true
         player.allowsExternalPlayback = true
         player.volume = 1.0
@@ -2720,13 +2718,9 @@ final class AudioPlayerManager {
     private func configureAudioSessionCategory() {
         guard !audioSessionCategoryConfigured else { return }
         do {
-            if #available(iOS 13.0, *) {
-                try AVAudioSession.sharedInstance().setCategory(
-                    .playback, mode: .default, policy: .longFormAudio, options: []
-                )
-            } else {
-                try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
-            }
+            try AVAudioSession.sharedInstance().setCategory(
+                .playback, mode: .default, policy: .longFormAudio, options: []
+            )
             audioSessionCategoryConfigured = true
         } catch {
             DebugLogger.log("Audio session category configuration failed: \(error)", category: .playback)

--- a/Twinskaraoke/Services/Audio/VocalSeparator.swift
+++ b/Twinskaraoke/Services/Audio/VocalSeparator.swift
@@ -10,11 +10,7 @@ extension Notification.Name {
 
 enum DeviceCapability {
     static var supportsKaraoke: Bool {
-        if #available(iOS 18.0, *) {
-            VocalSeparator.shared.isAvailable
-        } else {
-            false
-        }
+        VocalSeparator.shared.isAvailable
     }
 }
 
@@ -187,11 +183,7 @@ final class VocalSeparator {
     private init() {
         let url = Bundle.main.url(forResource: "Spleeter2Model", withExtension: "mlmodelc")
         modelURL = url
-        if #available(iOS 18.0, *) {
-            isAvailable = (url != nil)
-        } else {
-            isAvailable = false
-        }
+        isAvailable = (url != nil)
         DebugLogger.log(
             "VocalSeparator init — available: \(isAvailable), model: \(url?.lastPathComponent ?? "nil")",
             category: .separation
@@ -317,7 +309,6 @@ final class VocalSeparator {
             lastPublishedProgressFraction = -1
             jobOwnership.cancelCurrent()
         }
-        guard #available(iOS 18.0, *) else { throw VocalSeparatorError.unavailable }
         DebugLogger.log("Starting full separation for \(songID)", category: .separation)
         processingSongID = songID
         activeTaskKind = initiatedByBackground ? .background : .foreground
@@ -385,7 +376,6 @@ final class VocalSeparator {
         }
 
         try Task.checkCancellation()
-        guard #available(iOS 18.0, *) else { throw VocalSeparatorError.unavailable }
 
         let normalizedStart = max(0, fromTime)
         DebugLogger.log(
@@ -780,7 +770,6 @@ final class VocalSeparator {
         }
     }
 
-    @available(iOS 18.0, *)
     private static func runSeparation2(
         modelURL: URL,
         jobID: UUID,


### PR DESCRIPTION
Last of three batches from the iOS 26 UI audit, after #101 (runtime bugs) and
#102 (tab bar). Mechanical and wide rather than deep — five separate commits so
each can be read on its own. Net **147 insertions, 307 deletions**.

## `foregroundColor` → `foregroundStyle` (48 sites)

Superseded since iOS 17. `foregroundStyle` resolves hierarchical styles,
gradients, materials and glass foregrounds where `foregroundColor` flattens to
a plain colour. The rest of the app had already moved; these sites, clustered in
the newer Art/Video gallery features, had not.

Sites reading `.appAccent` are now `Color.appAccent`. The leading-dot form
worked when the parameter was typed `Color?`, but `foregroundStyle` is generic
over `ShapeStyle`, which has no such member — this is how the rest of the app
already spells them.

Deliberately untouched: the stored properties and argument labels also called
`foregroundColor` (`AppTheme`, `GlassComponents`, `LibraryView`,
`ZoomableImageViewer`) and the `NSAttributedString.Key` in `AboutComponents`.
None are the modifier.

## 25 unreachable `#available` branches

At a 26.0 deployment target every one was either always true with a dead `else`,
or — for the iOS 26 checks — a no-op wrapper. Removed 15 below iOS 26 (17, 18,
15, 13) and 10 at iOS 26.

Where the condition also carried a real runtime test, **only the availability
clause went**: `if #available(iOS 17.0, *), !reduceMotion` is now
`if !reduceMotion`, so Reduce Motion behaviour is unchanged.

Several deleted `else` branches were pre-Liquid-Glass fallbacks, which removes
material backgrounds as a side effect. `ToolbarControlBackground` goes entirely
— both its callers were `else` branches, so nothing referenced it any more.

## Materials → Liquid Glass (14 sites)

`GlassComponents` gains `AppGlassBackground<S: Shape>`: the existing
`GlassRoundedRect` behaviour with the shape lifted out — glass normally, an
opaque `appSecondaryBackground` under Reduce Transparency, a stroke under
Increase Contrast. `GlassRoundedRect` is now that plus its drop shadow.

`GlassCircle` stays as it is: interactive glass, and it always strokes its
reduced-transparency fill. Folding those in would have meant flags for
behaviour only it wants.

Converted `ContextPreviewCard` (backs every context-menu preview),
`QRApproveView`'s six panels, the three gallery preview cards,
`VideoGalleryView`, `PlaylistDetailView`'s capsule, `RandomSongsView`'s spinner
chip, and `RadioQueueHero`.

## Global UIKit tint proxies

`UIView.appearance().tintColor` applied to every UIView subclass in the process,
including system UI the app does not own — share sheet, photo picker,
`SFSafariViewController`. It predates the `.tint(.appAccent)` already at the
scene root, and on iOS 26 glass controls take their tint from the environment.
Removed; UIKit-presented system UI goes back to the system tint.

## `.borderedProminent` → `.glassProminent`

One call site, `LevelUpSheet`.

## Verification

- iOS, **watchOS and tvOS** all build warning-clean (this touches `AppTheme` and
  `GlassComponents`, hence the cross-platform check). `TwinskaraokeTests` pass.

Two things I'd like a real device to confirm, both flagged in the commits:

1. **The four context-menu previews** (`ContextPreviewCard`,
   `ArtworkDetailContextPreview`, `GalleryArtPreview`, `ArtistArtsView`).
   Context menu previews render on a system-supplied platter, and glass needs
   content behind it to refract. If they read flat, reverting those four to
   `.regularMaterial` is a one-line change each.
2. **`AddToPlaylistSheet`'s bottom action bar** — the least certain conversion.
   It is flush and edge-to-edge rather than floating, which is the shape
   materials still suit. Converted for consistency, easiest one to put back.

Also worth a look with **Reduce Transparency** and **Increase Contrast** on,
since `AppGlassBackground` is what now decides those fallbacks, and
`QRApproveView` is a sign-in flow.

## Summary by Sourcery

Update remaining UI to align with iOS 26-era patterns and Liquid Glass styling while dropping obsolete availability checks and global UIKit tint overrides.

New Features:
- Introduce a reusable AppGlassBackground modifier to apply Liquid Glass backgrounds with accessibility-aware fallbacks.

Bug Fixes:
- Ensure scroll performance tracking, karaoke vocal separation, and audio session behavior are always enabled under the new minimum OS versions without dead code paths.

Enhancements:
- Replace deprecated foregroundColor uses with foregroundStyle across library and gallery views.
- Convert various material-backed cards, panels, and controls to use Liquid Glass via AppGlassBackground for consistent visual treatment.
- Simplify toolbar and button chrome by removing legacy ToolbarControlBackground and pre-glass fallback shapes.
- Remove unreachable #available branches and obsolete OS version guards now that the deployment target is iOS 26.
- Switch prominent buttons to use the .glassProminent style in LevelUpSheet and related UI.
- Remove global UIKit tintColor proxies so system-presented UI uses system tint instead of app-specific overrides.