### PR TITLE
Match the mini player's height to the tab bar it merges into

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -482,6 +482,7 @@ private extension RootSection {
 private struct PopupModifier: ViewModifier {
     private let popupState = PopupPlaybackState.shared
     private let presentationState = PopupPresentationState.shared
+    private let barEnvironment = PopupBarEnvironmentTracker.shared
 
     func body(content: Content) -> some View {
         content
@@ -515,16 +516,15 @@ private struct PopupModifier: ViewModifier {
             ) {
                 PopupContent(popupState: popupState)
             }
-            // `.floatingCompact` (48pt) rather than `.floating` (58pt): the bar
-            // has to match the tab bar's height to sit inline with it once the
-            // bar minimizes, the way Music's does. LNPopupController picks the
-            // height from the style alone — going inline does not shrink a
-            // `.floating` bar — so at 58pt it stayed visibly taller than the
-            // row it merged into.
+            // `.floating` (58pt) matches the full-size tab bar; `.floatingCompact`
+            // (48pt) matches the minimized row the bar merges into. The height
+            // comes from the style alone — LNPopupController does not shrink a
+            // bar when it goes inline — so the style has to follow the tab bar,
+            // which is what PopupBarEnvironmentTracker watches for.
             //
-            // The artwork follows automatically: LNPopupBar sizes it as
-            // `barHeight - 18`, so it goes 40pt -> 30pt with the bar.
-            .popupBarStyle(.floatingCompact)
+            // The artwork follows the height on its own: LNPopupBar sizes it as
+            // `barHeight - 18`, so it moves between 40pt and 30pt with the bar.
+            .popupBarStyle(barEnvironment.barStyle)
             .popupBarProgressViewStyle(.none)
             .popupCloseButtonStyle(.none)
             .popupInteractionStyle(.drag)
@@ -536,6 +536,7 @@ private struct PopupModifier: ViewModifier {
 
                 PopupOpenIntentGate.shared.installTouchRecognizer(on: popupBar)
                 #if canImport(UIKit)
+                    PopupBarEnvironmentTracker.shared.observe(popupBar)
                     ShimejiMiniPlayerTracker.shared.register(popupBar)
                 #endif
             }

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -515,7 +515,16 @@ private struct PopupModifier: ViewModifier {
             ) {
                 PopupContent(popupState: popupState)
             }
-            .popupBarStyle(.floating)
+            // `.floatingCompact` (48pt) rather than `.floating` (58pt): the bar
+            // has to match the tab bar's height to sit inline with it once the
+            // bar minimizes, the way Music's does. LNPopupController picks the
+            // height from the style alone — going inline does not shrink a
+            // `.floating` bar — so at 58pt it stayed visibly taller than the
+            // row it merged into.
+            //
+            // The artwork follows automatically: LNPopupBar sizes it as
+            // `barHeight - 18`, so it goes 40pt -> 30pt with the bar.
+            .popupBarStyle(.floatingCompact)
             .popupBarProgressViewStyle(.none)
             .popupCloseButtonStyle(.none)
             .popupInteractionStyle(.drag)

--- a/Twinskaraoke/Services/Audio/PopupBarEnvironmentTracker.swift
+++ b/Twinskaraoke/Services/Audio/PopupBarEnvironmentTracker.swift
@@ -1,0 +1,71 @@
+import LNPopupUI
+import Observation
+import SwiftUI
+
+#if canImport(UIKit)
+    import UIKit
+
+    /// Tracks whether the mini player is currently laid out inline with a
+    /// minimized tab bar, so its bar style can follow.
+    ///
+    /// LNPopupController picks the bar height from the bar *style* alone —
+    /// `_LNPopupBarHeightForPopupBar` switches on the resolved style and never
+    /// consults the environment — so going inline does not shrink the bar on its
+    /// own. Its documentation says as much: the framework reports the change
+    /// through the `LNPopupBar.EnvironmentTrait` and leaves reacting to it to the
+    /// app.
+    ///
+    /// Both heights are wanted here: `.floating` (58pt) matches the full-size tab
+    /// bar, `.floatingCompact` (48pt) matches the minimized row the bar merges
+    /// into.
+    @MainActor
+    @Observable
+    final class PopupBarEnvironmentTracker {
+        static let shared = PopupBarEnvironmentTracker()
+
+        /// True while the bar sits inline with the collapsed tab bar.
+        private(set) var isInline = false
+
+        @ObservationIgnored private weak var observedBar: LNPopupBar?
+        @ObservationIgnored private var registration: (any UITraitChangeRegistration)?
+
+        private init() {}
+
+        /// The style the bar should currently use. Declared through
+        /// `.popupBarStyle(_:)` rather than assigned to the bar directly, because
+        /// LNPopupUI re-applies the declared style on every popup state update
+        /// and would otherwise overwrite a direct assignment.
+        var barStyle: LNPopupBar.Style {
+            isInline ? .floatingCompact : .floating
+        }
+
+        /// Starts observing `popupBar`. Safe to call repeatedly — the popup bar
+        /// customizer runs on every popup update, and re-registering would stack
+        /// observers on the same bar.
+        func observe(_ popupBar: LNPopupBar) {
+            guard observedBar !== popupBar else { return }
+            observedBar = popupBar
+            registration = nil
+
+            apply(popupBar)
+            registration = popupBar.registerForTraitChanges(
+                [LNPopupBar.EnvironmentTrait.self]
+            ) { (bar: LNPopupBar, _: UITraitCollection) in
+                PopupBarEnvironmentTracker.shared.apply(bar)
+            }
+        }
+
+        private func apply(_ popupBar: LNPopupBar) {
+            let nowInline = popupBar.traitCollection.popupBarEnvironment == .inline
+            guard isInline != nowInline else { return }
+            isInline = nowInline
+
+            // Also set the bar directly. LNPopupController flips the trait from
+            // inside the property animator that runs its minimize transition, so
+            // assigning here lets the height change ride that same animation
+            // instead of landing a frame later when SwiftUI re-renders. The
+            // declared `.popupBarStyle(_:)` then re-applies the identical value.
+            popupBar.barStyle = barStyle
+        }
+    }
+#endif


### PR DESCRIPTION
Follow-up to #102. Now that the tab bar minimizes on scroll, the mini player
slots into the tab bar row between the leading tabs and the search tab — but it
sat visibly taller than that row, where Music's matches it.

## Why

LNPopupController derives the bar height from the **style alone**. Going inline
changes the bar's environment (`LNPopupBarEnvironmentInline`) and its appearance,
but `_LNPopupBarHeightForPopupBar` never consults that — it switches on
`resolvedStyle` and nothing else:

| Style | Height |
| --- | --- |
| `.floating` (was) | **58pt** |
| `.floatingCompact` (now) | **48pt** |

The tab bar it merges into is roughly 49pt, so at 58pt the bar could never line
up no matter what the minimize behaviour did.

The smaller artwork in Music's mini player is a **consequence** of this, not a
separate setting — `LNPopupBar` sizes the image as `barHeight - 18`, so it goes
40pt → 30pt on its own with the height.

`inheritsBottomBarMetrics`, which gates the inline merge, already defaults to
`true`, so the merge itself was working; only the height was wrong.

## Scope

One line plus a comment. Nothing else needed adjusting:

- `PopupOpenIntentGate.visibleBarHitHeight` is a `min()` ceiling, not a fixed
  height, so the tap zone follows the bar automatically.
- `ShimejiMiniPlayerTracker` measures the bar's real frame.
- Compact style keeps both trailing buttons and the title/subtitle — it passes a
  compact size class to the toolbar content and tightens title spacing, nothing
  is dropped.

## Verification

Build is clean. **Not verifiable from the simulator** — `simctl` screenshots on
iOS 26 omit the Liquid Glass tab bar, which is the exact surface this affects,
so the heights above come from reading LNPopupController's own constants rather
than from an observed render.

Worth checking on device: the bar lines up with the tab bar row when merged, the
play/pause and next buttons still sit comfortably in the shorter bar (their
frames are 44pt inside 48pt), and the expanded (non-minimized) mini player still
looks right, since this shortens it in both states.

Note: touches `ContextView.swift` in a different region from #103, so whichever
lands second needs a trivial rebase.

## Summary by Sourcery

Adjust the mini player popup bar style so its height matches the tab bar it merges into for inline presentation.

Bug Fixes:
- Correct mini player height so it aligns visually with the minimized tab bar row when merged inline.

Enhancements:
- Use the compact floating popup bar style so artwork and controls scale appropriately within the shorter bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup bar appearance handling across different interface environments.
  * Popup bars now automatically adapt between floating and compact styles as layout conditions change.
  * Updated popup bar registration and trait tracking for more consistent behavior during environment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->