### PR TITLE
Adopt the iOS 26 chrome APIs the audit missed

### DIFF
--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -224,7 +224,10 @@ private struct PopupHostView: View {
             }
             .listStyle(.sidebar)
             .navigationTitle("Twinskaraoke")
-            .safeAreaInset(edge: .bottom, spacing: 0) {
+            // `safeAreaBar`, not `safeAreaInset`: this is a bar, so it should
+            // get the bar treatment — glass and scroll-edge behaviour — rather
+            // than painting its own `.bar` background under a plain inset.
+            .safeAreaBar(edge: .bottom, spacing: 0) {
                 SidebarNowPlayingHint()
             }
         } detail: {
@@ -413,12 +416,9 @@ private struct SidebarNowPlayingHint: View {
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
-                .background(.bar)
-                .overlay(alignment: .top) {
-                    Rectangle()
-                        .fill(Color.appDivider)
-                        .frame(height: 0.5)
-                }
+                // No background or hairline of its own — `safeAreaBar` gives the
+                // content the system bar treatment, and painting `.bar` plus a
+                // divider on top of that just doubles it.
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Now Playing")
                 .accessibilityValue(popupState.subtitle.isEmpty ? popupState.title : "\(popupState.title), \(popupState.subtitle)")

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -62,7 +62,11 @@ struct AddToPlaylistSheet: View {
             }
             .smoothScrolling()
             .musicScreenBackground()
-            .safeAreaInset(edge: .bottom) {
+            // `safeAreaBar`, not `safeAreaInset`: this is a bar, so the system
+            // supplies its background and scroll-edge behaviour. That replaces
+            // the hand-applied glass this used to carry, which never sat right
+            // — glass suits a floating shape, and this is flush and full-width.
+            .safeAreaBar(edge: .bottom) {
                 if !manager.playlists.isEmpty {
                     Button {
                         AppHaptic.commit.play()
@@ -79,18 +83,20 @@ struct AddToPlaylistSheet: View {
                     .padding(.horizontal, 20)
                     .padding(.top, 10)
                     .padding(.bottom, 10)
-                    .appGlassBackground(in: Rectangle())
                 }
             }
             .navigationTitle("Add to Playlist")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                // These carry their own glass, so the toolbar must not put its
+                // shared glass behind them as well.
                 ToolbarItem(placement: .cancellationAction) {
                     GlassXButton(action: {
                         AppHaptic.selection.play()
                         dismiss()
                     })
                 }
+                .sharedBackgroundVisibility(.hidden)
                 ToolbarItem(placement: .confirmationAction) {
                     GlassCheckmarkButton(
                         action: {
@@ -100,8 +106,9 @@ struct AddToPlaylistSheet: View {
                         isEnabled: !added.isEmpty
                     )
                 }
+                .sharedBackgroundVisibility(.hidden)
             }
-            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
             .task { manager.loadIfNeeded() }
             .sheet(isPresented: $showCreatePlaylist) {
                 CreatePlaylistSheet()

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -355,6 +355,16 @@ extension View {
     func tabBarBottomPadding() -> some View {
         modifier(TabBarBottomPaddingModifier())
     }
+
+    /// Search on a screen whose subject is the list, not the searching: the
+    /// field collapses to a toolbar button until tapped, so the content keeps
+    /// the room.
+    ///
+    /// The Search tab deliberately does not use this. Its field stays expanded,
+    /// because searching is the whole point of that screen.
+    func secondarySearchBehavior() -> some View {
+        searchToolbarBehavior(.minimize)
+    }
 }
 
 @MainActor

--- a/Twinskaraoke/Features/Account/LoginSheet.swift
+++ b/Twinskaraoke/Features/Account/LoginSheet.swift
@@ -46,11 +46,14 @@ struct LoginSheet: View {
             .background(Color(.systemGroupedBackground).ignoresSafeArea())
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                // GlassXButton carries its own glass, so the toolbar must not
+                // put its shared glass behind it as well.
                 ToolbarItem(placement: .cancellationAction) {
                     GlassXButton(action: { dismiss() })
                 }
+                .sharedBackgroundVisibility(.hidden)
             }
-            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
             .onChange(of: auth.isLoggedIn) { _, isLoggedIn in
                 if isLoggedIn { dismiss() }
             }

--- a/Twinskaraoke/Features/Account/QRApproveView.swift
+++ b/Twinskaraoke/Features/Account/QRApproveView.swift
@@ -47,7 +47,7 @@ struct QRApproveView: View {
                     }
                 }
             }
-            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
         }
         .task { await checkPermission() }
         .animation(phaseAnimation, value: phaseKey)

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -33,7 +33,7 @@ struct BrowseSongCollectionView: View {
         .musicScreenBackground()
         .navigationTitle(showsCollapsedTitle ? title : "")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
+        .toolbarBackgroundVisibility(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
         .animation(
             reduceMotion ? nil : AppMotion.quick,
             value: showsCollapsedTitle

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -72,6 +72,9 @@ struct PlaylistListView: View {
             text: $searchText,
             prompt: "Search Playlists"
         )
+        // Collapses to a toolbar button until tapped, keeping the list the focus.
+        // The Search tab keeps its field expanded — searching is the point there.
+        .searchToolbarBehavior(.minimize)
         .onAppear {
             if let apiURL {
                 loader.bootstrap(initial: playlists, urlBuilder: apiURL)

--- a/Twinskaraoke/Features/Home/PlaylistListView.swift
+++ b/Twinskaraoke/Features/Home/PlaylistListView.swift
@@ -72,9 +72,7 @@ struct PlaylistListView: View {
             text: $searchText,
             prompt: "Search Playlists"
         )
-        // Collapses to a toolbar button until tapped, keeping the list the focus.
-        // The Search tab keeps its field expanded — searching is the point there.
-        .searchToolbarBehavior(.minimize)
+        .secondarySearchBehavior()
         .onAppear {
             if let apiURL {
                 loader.bootstrap(initial: playlists, urlBuilder: apiURL)

--- a/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
@@ -49,23 +49,30 @@ struct ZoomableImageViewer: View {
             }
             if showOverlay {
                 VStack {
-                    HStack {
-                        GlassXButton(action: {
-                            AppHaptic.dismiss.play()
-                            dismiss()
-                        })
-                        Spacer()
-                        GlassActionButton(
-                            action: {
-                                AppHaptic.selection.play()
-                                onSave()
-                            },
-                            systemImage: saveIconName,
-                            foregroundColor: saveIconColor,
-                            isLoading: saveStatus == .saving,
-                            accessibilityLabel: saveAccessibilityLabel
-                        )
-                        .disabled(saveStatus.isSaving)
+                    // The only place two glass elements share a layer. A
+                    // container renders them in one pass rather than compositing
+                    // each separately; they sit at opposite edges so nothing
+                    // merges visually, but the grouping is still what the
+                    // effect expects.
+                    GlassEffectContainer {
+                        HStack {
+                            GlassXButton(action: {
+                                AppHaptic.dismiss.play()
+                                dismiss()
+                            })
+                            Spacer()
+                            GlassActionButton(
+                                action: {
+                                    AppHaptic.selection.play()
+                                    onSave()
+                                },
+                                systemImage: saveIconName,
+                                foregroundColor: saveIconColor,
+                                isLoading: saveStatus == .saving,
+                                accessibilityLabel: saveAccessibilityLabel
+                            )
+                            .disabled(saveStatus.isSaving)
+                        }
                     }
                     .padding()
                     Spacer()

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -79,9 +79,7 @@ struct ArtistsView: View {
             text: $searchText,
             prompt: "Search Artists"
         )
-        // Collapses to a toolbar button until tapped, keeping the list the focus.
-        // The Search tab keeps its field expanded — searching is the point there.
-        .searchToolbarBehavior(.minimize)
+        .secondarySearchBehavior()
         .refreshable {
             AppHaptic.selection.play()
             await viewModel.refreshArtists()

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -79,6 +79,9 @@ struct ArtistsView: View {
             text: $searchText,
             prompt: "Search Artists"
         )
+        // Collapses to a toolbar button until tapped, keeping the list the focus.
+        // The Search tab keeps its field expanded — searching is the point there.
+        .searchToolbarBehavior(.minimize)
         .refreshable {
             AppHaptic.selection.play()
             await viewModel.refreshArtists()
@@ -226,7 +229,7 @@ struct ArtistDetailView: View {
         .musicScreenBackground()
         .navigationTitle(showsCollapsedTitle ? current.name : "")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
+        .toolbarBackgroundVisibility(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
         .toolbar {
             if !songs.isEmpty {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -98,12 +98,15 @@ struct CreatePlaylistSheet: View {
             .navigationTitle("New Playlist")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                // These carry their own glass, so the toolbar must not put its
+                // shared glass behind them as well.
                 ToolbarItem(placement: .cancellationAction) {
                     GlassXButton(action: {
                         AppHaptic.selection.play()
                         dismiss()
                     })
                 }
+                .sharedBackgroundVisibility(.hidden)
                 ToolbarItem(placement: .confirmationAction) {
                     if isSaving {
                         ProgressView()
@@ -115,8 +118,9 @@ struct CreatePlaylistSheet: View {
                         )
                     }
                 }
+                .sharedBackgroundVisibility(.hidden)
             }
-            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
             .interactiveDismissDisabled(isSaving)
             .onAppear {
                 focusedField = .name

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -80,7 +80,7 @@ struct DownloadedSongsView: View {
         }
         .navigationTitle(showsCollapsedTitle ? "Downloaded" : "")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
+        .toolbarBackgroundVisibility(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 if !localSongs.isEmpty {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -460,9 +460,7 @@ struct LibrarySongsView: View {
             text: $viewModel.searchText,
             prompt: "Search Songs"
         )
-        // Collapses to a toolbar button until tapped, keeping the list the focus.
-        // The Search tab keeps its field expanded — searching is the point there.
-        .searchToolbarBehavior(.minimize)
+        .secondarySearchBehavior()
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 sortMenu
@@ -710,9 +708,7 @@ struct PlaylistsGridScreen: View {
             text: $searchText,
             prompt: "Search Playlists"
         )
-        // Collapses to a toolbar button until tapped, keeping the list the focus.
-        // The Search tab keeps its field expanded — searching is the point there.
-        .searchToolbarBehavior(.minimize)
+        .secondarySearchBehavior()
         .toolbar {
             if isLoggedIn {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -460,6 +460,9 @@ struct LibrarySongsView: View {
             text: $viewModel.searchText,
             prompt: "Search Songs"
         )
+        // Collapses to a toolbar button until tapped, keeping the list the focus.
+        // The Search tab keeps its field expanded — searching is the point there.
+        .searchToolbarBehavior(.minimize)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 sortMenu
@@ -707,6 +710,9 @@ struct PlaylistsGridScreen: View {
             text: $searchText,
             prompt: "Search Playlists"
         )
+        // Collapses to a toolbar button until tapped, keeping the list the focus.
+        // The Search tab keeps its field expanded — searching is the point there.
+        .searchToolbarBehavior(.minimize)
         .toolbar {
             if isLoggedIn {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -282,7 +282,7 @@ struct PlaylistDetailView: View {
         .musicScreenBackground()
         .navigationTitle(showsCollapsedTitle ? playlist.name : "")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
+        .toolbarBackgroundVisibility(showsCollapsedTitle ? .visible : .hidden, for: .navigationBar)
         .animation(
             reduceMotion ? nil : AppMotion.quick,
             value: showsCollapsedTitle

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -56,9 +56,7 @@ struct UploadedSongsView: View {
             text: $viewModel.searchText,
             prompt: "Search Uploads"
         )
-        // Collapses to a toolbar button until tapped, keeping the list the focus.
-        // The Search tab keeps its field expanded — searching is the point there.
-        .searchToolbarBehavior(.minimize)
+        .secondarySearchBehavior()
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 sortMenu

--- a/Twinskaraoke/Features/Library/UploadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/UploadedSongsView.swift
@@ -56,6 +56,9 @@ struct UploadedSongsView: View {
             text: $viewModel.searchText,
             prompt: "Search Uploads"
         )
+        // Collapses to a toolbar button until tapped, keeping the list the focus.
+        // The Search tab keeps its field expanded — searching is the point there.
+        .searchToolbarBehavior(.minimize)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 sortMenu


### PR DESCRIPTION
A recheck of the iOS/iPadOS app against the iOS 26 SDK — this time enumerating
what the SDK actually declares rather than checking remembered API names, which
is how the first pass missed a deprecation.

## `toolbarBackground(_:for:)` is deprecated — 8 sites

The SDK renames it outright:

```
@available(iOS, introduced: 16.0, deprecated: 100000.0,
           renamed: "toolbarBackgroundVisibility(_:for:)")
func toolbarBackground(_ visibility: Visibility, for bars: ToolbarPlacement...)
```

All eight call sites pass a `Visibility`, so all eight were on the deprecated
overload. It's a *soft* deprecation (`100000.0`), which is exactly why the build
never warned — the same reason `foregroundColor` had to be found by reading
rather than by the compiler. The `ShapeStyle` overload is not deprecated and
nothing here used it.

## `safeAreaBar` for the two bottom bars

iOS 26 added `safeAreaBar(edge:)` for precisely this shape. It gives the content
the system bar treatment instead of the view hand-rolling one.

- `SidebarNowPlayingHint` drops its own `.background(.bar)` and hairline overlay,
  which would now sit on top of the treatment the bar already supplies.
- `AddToPlaylistSheet`'s action bar **drops the Liquid Glass added in #103**.
  Glass suits a floating shape and that bar is flush and full width — it was
  flagged in that PR as the least convincing conversion in the sweep, and
  `safeAreaBar` is what it actually wanted.

## Glass grouping and un-doubling

- `GlassEffectContainer` wraps the one place two glass elements share a layer
  (`ZoomableImageViewer`'s close and save buttons). They sit at opposite edges so
  nothing merges visually, but grouping is what the effect expects.
- `sharedBackgroundVisibility(.hidden)` on the four toolbar items that supply
  their own glass — they were stacking glass on the toolbar's own. Worth knowing:
  this is *toolbar content*, not a view modifier, so it goes on the `ToolbarItem`
  and not after the `.toolbar` block (I got that wrong first and the compiler
  caught it).

## `searchToolbarBehavior(.minimize)` — 5 screens

Collapses search to a toolbar button on the secondary search screens (Library
songs and playlists, Artists, Uploads, playlist lists), keeping the list the
focus. The Search tab deliberately keeps its field expanded — searching is the
whole point there.

## Two I stopped short of, with reasons

Both were in scope, but checking the code turned up evidence against them:

**`backgroundExtensionEffect()` — no valid candidate.** It's for imagery that
should extend behind adjacent chrome. Every "hero" here is a **240 pt inset
artwork with a drop shadow**, not full-bleed — the effect would mirror-blur its
edges into empty space. The one genuinely full-bleed surface,
`ArtworkDetailAmbientBackground`, already fades its own edges
(`.blur(radius: 28).opacity(0.36)` under a `LinearGradient`), so the effect would
fight it.

**`scrollEdgeEffectStyle` — speculative here.** Four screens already hand-roll a
large-title collapse via `toolbarBackgroundVisibility(showsCollapsedTitle ? …)`.
Layering `.soft` on top interacts with that in ways I can't evaluate without
seeing it, and the surfaces involved are exactly the ones `simctl` can't capture.
Happy to add it if you want to try it — it's one line per screen.

## Verification

Build clean, `TwinskaraokeTests` pass. Everything here is chrome, so it needs a
device: toolbar backgrounds on the collapsing-title screens, the two bottom bars,
whether the toolbar glass buttons look right now they're not double-backed, and
the minimized search on the five secondary screens.

Scope note: iOS/iPadOS only. Also found — **the watch target is on
`WATCHOS_DEPLOYMENT_TARGET = 10.6`**, so Liquid Glass is unavailable there
entirely; tvOS (26.0) and macOS (26.0) both *can* use glass and currently use
none. Left alone here by request.

## Summary by Sourcery

Adopt updated iOS 26 chrome APIs for toolbars, bars, and search, refining glass effects and bar treatments across the library and account flows.

Enhancements:
- Replace deprecated toolbar background API usages with the new toolbarBackgroundVisibility variant on collapsing-title and sheet navigation bars.
- Use safeAreaBar for the library sidebar now playing hint and AddToPlaylist bottom action bar so they receive system bar background and scroll-edge behavior instead of custom insets and backgrounds.
- Wrap the zoomable artwork viewer’s paired glass buttons in a shared GlassEffectContainer and hide shared toolbar backgrounds behind glass buttons that provide their own material.
- Minimize search fields into toolbar buttons on secondary search screens (library songs, playlists, artists, uploads, and playlist lists) to keep list content visually prioritized.