### PR TITLE
Let CI run Pillarbox's build tool plugin

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -24,4 +24,7 @@ jobs:
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild clean build analyze -scheme "$scheme" -"$filetype_parameter" "$file_to_build"
+          # -skipPackagePluginValidation: Pillarbox ships a build tool plugin,
+          # and Xcode refuses to run an untrusted one. Trust is normally granted
+          # by a prompt, which no runner can answer. See tests.yml.
+          xcodebuild clean build analyze -skipPackagePluginValidation -scheme "$scheme" -"$filetype_parameter" "$file_to_build"

--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -25,8 +25,12 @@ jobs:
 
       - name: Archive iPhone
         run: |
+          # -skipPackagePluginValidation: Pillarbox ships a build tool plugin that
+          # Xcode refuses to run until it is trusted, and the prompt that grants
+          # trust cannot be answered on a runner. See tests.yml.
           xcodebuild archive \
             -project Twinskaraoke.xcodeproj \
+            -skipPackagePluginValidation \
             -scheme "Twinskaraoke" \
             -archivePath build/iPhone.xcarchive \
             -destination "generic/platform=iOS" \
@@ -56,6 +60,7 @@ jobs:
         run: |
           xcodebuild archive \
             -project Twinskaraoke.xcodeproj \
+            -skipPackagePluginValidation \
             -scheme "TwinskaraokeWatchApp" \
             -archivePath build/Watch.xcarchive \
             -destination "generic/platform=watchOS" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,14 @@ jobs:
             end
           ')
           echo "Using simulator UDID: $udid"
+          # -skipPackagePluginValidation: Pillarbox ships PillarboxPackageInfoPlugin,
+          # an SPM build tool plugin, and Xcode will not run a plugin that has not
+          # been trusted. Trust is normally granted through a prompt in the GUI,
+          # which a runner has no way to answer, so every build since Pillarbox
+          # arrived died on "must be enabled before it can be used".
           xcodebuild test \
             -project Twinskaraoke.xcodeproj \
+            -skipPackagePluginValidation \
             -scheme "Twinskaraoke" \
             -destination "platform=iOS Simulator,id=$udid" \
             -only-testing:TwinskaraokeTests \
@@ -70,6 +76,7 @@ jobs:
           echo "Using simulator UDID: $udid"
           xcodebuild test \
             -project Twinskaraoke.xcodeproj \
+            -skipPackagePluginValidation \
             -scheme "TwinskaraokeWatchApp" \
             -destination "platform=watchOS Simulator,id=$udid" \
             -only-testing:'Twinskaraoke Watch AppTests' \


### PR DESCRIPTION
## The failure

Every **Tests** and **Build IPAs** run has failed since Pillarbox arrived, on:

```
Plugin "PillarboxPackageInfoPlugin" from package "Pillarbox" must be enabled before it can be used
```

Pillarbox ships `PillarboxPackageInfoPlugin`, an SPM build tool plugin. Xcode will not run a plugin until it has been trusted, and trust is granted through a prompt in the GUI. That is why this never shows up locally — the prompt was answered once and remembered — and always fails on a runner, where there is nobody to answer it.

## The fix

Pass `-skipPackagePluginValidation` on the `xcodebuild` invocations in `tests.yml` (iOS + watchOS) and `build-ipa.yml` (iPhone + Watch archives), plus the manually dispatched `analyze.yml`, which builds the same project and would fail the same way.

The flag reads as a security trade-off, so worth being explicit: the plugin only stamps package version info into the build, and it comes from the same pinned dependency the project already compiles and ships. Nothing is trusted here that was not already being built.

## Not caused by anything merged recently

- **Build IPAs** last succeeded on the commit *before* Pillarbox merged, and failed on the merge commit itself.
- **Tests** was already failing on the Pillarbox branch before it merged.

## Deploy Docs is a different problem

Its `build` job succeeds and uploads the artifact fine. The `deploy` step then fails inside `actions/deploy-pages`:

```
##[error]Creating Pages deployment failed
##[error]HttpError: self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
```

That is a TLS failure talking to the GitHub Pages API — infrastructure, not repo configuration. Nothing in the workflow can fix it, and it clears on a re-run. Deliberately left untouched here rather than papering over it with a change that would not help.

## Verification

`-skipPackagePluginValidation` confirmed present in `xcodebuild -help` and accepted against this project; all four workflow files re-validated as YAML. The Tests workflow runs on `pull_request`, so this PR exercises the `tests.yml` fix directly — see its check below.

## Summary by Sourcery

Allow CI workflows to run the Pillarbox SPM build tool plugin by disabling package plugin validation in xcodebuild commands.

CI:
- Add -skipPackagePluginValidation to xcodebuild test invocations in the iOS and watchOS tests workflow to prevent plugin trust prompts from breaking CI.
- Add -skipPackagePluginValidation to xcodebuild archive steps in the IPA build workflow so archives succeed under CI.
- Add -skipPackagePluginValidation to the analyze workflow’s xcodebuild invocation and document the Pillarbox plugin trust behavior in workflow comments.