### PR TITLE
Fix the stalling marquee, and scroll long titles everywhere they truncate

### DIFF
--- a/Twinskaraoke/Components/Shared/MarqueeText.swift
+++ b/Twinskaraoke/Components/Shared/MarqueeText.swift
@@ -1,5 +1,24 @@
 import SwiftUI
 
+/// A single line of text that scrolls itself when it is wider than the space it
+/// has, then wraps around after a pause.
+///
+/// The offset is a pure function of elapsed time, sampled by a `TimelineView`,
+/// rather than an implicit animation stepped by a `Task`. That is a deliberate
+/// correction, and the reason is worth keeping: the previous version drove
+/// `phase` with `withAnimation(.linear(duration:))` and then slept for exactly
+/// that duration before resetting, which assumed the wall clock and the
+/// animation stayed in step. Opening or dismissing the full-screen player runs
+/// a `withAnimation` transaction across the whole player subtree
+/// (`NowPlayingOverlay`), and a re-render inside somebody else's transaction can
+/// drop or re-target an animation already in flight. The sleep kept counting
+/// regardless, so `phase` snapped back at a moment unrelated to where the text
+/// actually was — the text appeared to stall, jump, and sometimes carry on.
+///
+/// Sampling time has no such failure mode: whatever happens during a transition,
+/// the next frame recomputes the offset the elapsed time says it should have.
+/// It is also how the rest of the app animates continuously — see
+/// `EqualizerBars` and `PlayerAmbientBackground`.
 struct MarqueeText: View {
     let text: String
     let font: Font
@@ -7,13 +26,42 @@ struct MarqueeText: View {
     var speed: CGFloat = 35
     var gap: CGFloat = 48
     var startDelay: Double = 1.2
+
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var textSize: CGSize = .zero
     @State private var containerWidth: CGFloat = 0
-    @State private var phase: CGFloat = 0
-    @State private var animationTask: Task<Void, Never>?
+
+    /// Whether this view is in the render tree at all, so an off-screen marquee
+    /// does not keep a display link alive.
+    ///
+    /// The `onAppear` half is load-bearing, and its absence was the other half
+    /// of the stall. The old version cancelled its animation task in
+    /// `onDisappear` and had nothing to restart it: the only paths back in were
+    /// a change of text or of measured width. The full-screen player comes back
+    /// with the same song at the same size, so neither fired and the marquee
+    /// stayed dead until the track changed.
+    @State private var isVisible = false
+
+    /// When the current cycle began. Reset rather than accumulated, so the
+    /// dwell always lands at the start of a pass.
+    @State private var startDate = Date()
+
     private var needsScroll: Bool {
         !reduceMotion && containerWidth > 0 && textSize.width > containerWidth + 0.5
+    }
+
+    private var isScrolling: Bool {
+        needsScroll && isVisible
+    }
+
+    /// One text plus one gap: the point at which the trailing copy sits exactly
+    /// where the leading one started, so wrapping back to zero is invisible.
+    private var travel: CGFloat {
+        textSize.width + gap
+    }
+
+    private var scrollDuration: TimeInterval {
+        Double(travel) / Double(max(1, speed))
     }
 
     var body: some View {
@@ -23,43 +71,50 @@ struct MarqueeText: View {
             .opacity(0)
             .frame(maxWidth: .infinity, alignment: .leading)
             .overlay(
-                ZStack(alignment: .leading) {
-                    if needsScroll {
-                        HStack(spacing: gap) {
-                            Text(text).font(font).foregroundStyle(color).fixedSize()
+                TimelineView(
+                    .animation(
+                        minimumInterval: DisplayRefreshRate.decorativeAnimationInterval,
+                        paused: !isScrolling
+                    )
+                ) { context in
+                    ZStack(alignment: .leading) {
+                        if needsScroll {
+                            HStack(spacing: gap) {
+                                Text(text).font(font).foregroundStyle(color).fixedSize()
+                                Text(text).font(font).foregroundStyle(color).fixedSize()
+                            }
+                            .offset(x: -phase(at: context.date))
+                        } else {
                             Text(text).font(font).foregroundStyle(color).fixedSize()
                         }
-                        .offset(x: -phase)
-                    } else {
-                        Text(text).font(font).foregroundStyle(color).fixedSize()
                     }
-                }
-                // The invisible base Text below is the accessibility
-                // element; these overlay copies are visual-only.
-                .accessibilityHidden(true)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                .clipped()
-                .mask(
-                    LinearGradient(
-                        stops: needsScroll
-                            ? [
-                                .init(color: .clear, location: 0),
-                                .init(color: .black, location: 0.04),
-                                .init(color: .black, location: 0.96),
-                                .init(color: .clear, location: 1),
-                            ]
-                            : [
-                                .init(color: .black, location: 0),
-                                .init(color: .black, location: 1),
-                            ],
-                        startPoint: .leading, endPoint: .trailing
+                    // The invisible base Text below is the accessibility
+                    // element; these overlay copies are visual-only.
+                    .accessibilityHidden(true)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                    .clipped()
+                    .mask(
+                        LinearGradient(
+                            stops: needsScroll
+                                ? [
+                                    .init(color: .clear, location: 0),
+                                    .init(color: .black, location: 0.04),
+                                    .init(color: .black, location: 0.96),
+                                    .init(color: .clear, location: 1),
+                                ]
+                                : [
+                                    .init(color: .black, location: 0),
+                                    .init(color: .black, location: 1),
+                                ],
+                            startPoint: .leading, endPoint: .trailing
+                        )
                     )
-                )
+                }
             )
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { newWidth in
                 guard abs(containerWidth - newWidth) > 0.5 else { return }
                 containerWidth = newWidth
-                restartAnimation()
+                restartCycle()
             }
             .background(
                 Text(text)
@@ -71,35 +126,55 @@ struct MarqueeText: View {
                     .onGeometryChange(for: CGSize.self) { $0.size } action: { size in
                         guard abs(textSize.width - size.width) > 0.5 else { return }
                         textSize = size
-                        restartAnimation()
+                        restartCycle()
                     }
             )
             .onChange(of: text) {
-                restartAnimation()
+                restartCycle()
+            }
+            .onAppear {
+                isVisible = true
+                restartCycle()
             }
             .onDisappear {
-                animationTask?.cancel()
-                animationTask = nil
+                isVisible = false
             }
     }
 
-    private func restartAnimation() {
-        animationTask?.cancel()
-        phase = 0
-        guard needsScroll else { return }
-        let distance = textSize.width + gap
-        let duration = Double(distance) / Double(speed)
-        animationTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(startDelay))
-            while !Task.isCancelled {
-                withOptionalAnimation(AppMotion.linear(duration: duration)) {
-                    phase = distance
-                }
-                try? await Task.sleep(for: .seconds(duration))
-                if Task.isCancelled { break }
-                phase = 0
-                try? await Task.sleep(for: .seconds(startDelay))
-            }
-        }
+    private func phase(at date: Date) -> CGFloat {
+        Self.phase(
+            elapsed: date.timeIntervalSince(startDate),
+            travel: travel,
+            scrollDuration: scrollDuration,
+            startDelay: startDelay
+        )
+    }
+
+    private func restartCycle() {
+        startDate = Date()
+    }
+
+    /// How far the text has scrolled `elapsed` seconds into a run.
+    ///
+    /// Each cycle is a dwell of `startDelay` followed by a linear pass of
+    /// `scrollDuration`, and cycles repeat by taking the elapsed time modulo the
+    /// two. Being total over every input is the point — there is no state to
+    /// fall out of step with, so a pass interrupted by a player transition
+    /// resumes at the position the clock says it reached.
+    nonisolated static func phase(
+        elapsed: TimeInterval,
+        travel: CGFloat,
+        scrollDuration: TimeInterval,
+        startDelay: TimeInterval
+    ) -> CGFloat {
+        guard travel > 0, scrollDuration > 0 else { return 0 }
+        let dwell = max(0, startDelay)
+        let cycle = dwell + scrollDuration
+        // Clamped rather than mirrored: `startDate` is only ever set to now, so
+        // a negative elapsed means the clock moved under us, and starting the
+        // cycle over is the sane reading of that.
+        let position = max(0, elapsed).truncatingRemainder(dividingBy: cycle)
+        guard position > dwell else { return 0 }
+        return travel * CGFloat((position - dwell) / scrollDuration)
     }
 }

--- a/Twinskaraoke/Components/Shared/MarqueeText.swift
+++ b/Twinskaraoke/Components/Shared/MarqueeText.swift
@@ -27,6 +27,13 @@ struct MarqueeText: View {
     var gap: CGFloat = 48
     var startDelay: Double = 1.2
 
+    /// Set by a host that knows this marquee is on screen but not *visible* —
+    /// the mini player while the full-screen player covers it, and the player
+    /// while it is parked below the screen. Neither unmounts the other, so
+    /// `onDisappear` never fires for either and both would otherwise keep a
+    /// display link alive to scroll text nobody can see.
+    var isPaused: Bool = false
+
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var textSize: CGSize = .zero
     @State private var containerWidth: CGFloat = 0
@@ -51,7 +58,7 @@ struct MarqueeText: View {
     }
 
     private var isScrolling: Bool {
-        needsScroll && isVisible
+        needsScroll && isVisible && !isPaused
     }
 
     /// One text plus one gap: the point at which the trailing copy sits exactly
@@ -71,45 +78,59 @@ struct MarqueeText: View {
             .opacity(0)
             .frame(maxWidth: .infinity, alignment: .leading)
             .overlay(
-                TimelineView(
-                    .animation(
-                        minimumInterval: DisplayRefreshRate.decorativeAnimationInterval,
-                        paused: !isScrolling
-                    )
-                ) { context in
-                    ZStack(alignment: .leading) {
-                        if needsScroll {
+                // The timeline wraps only the part that moves; the sizing and
+                // the clip stay outside it.
+                ZStack(alignment: .leading) {
+                    if needsScroll {
+                        TimelineView(
+                            .animation(
+                                minimumInterval: DisplayRefreshRate.decorativeAnimationInterval,
+                                paused: !isScrolling
+                            )
+                        ) { context in
                             HStack(spacing: gap) {
-                                Text(text).font(font).foregroundStyle(color).fixedSize()
-                                Text(text).font(font).foregroundStyle(color).fixedSize()
+                                copy
+                                copy
                             }
                             .offset(x: -phase(at: context.date))
-                        } else {
-                            Text(text).font(font).foregroundStyle(color).fixedSize()
                         }
+                    } else {
+                        copy
                     }
-                    // The invisible base Text below is the accessibility
-                    // element; these overlay copies are visual-only.
-                    .accessibilityHidden(true)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                    .clipped()
-                    .mask(
-                        LinearGradient(
-                            stops: needsScroll
-                                ? [
-                                    .init(color: .clear, location: 0),
-                                    .init(color: .black, location: 0.04),
-                                    .init(color: .black, location: 0.96),
-                                    .init(color: .clear, location: 1),
-                                ]
-                                : [
-                                    .init(color: .black, location: 0),
-                                    .init(color: .black, location: 1),
-                                ],
-                            startPoint: .leading, endPoint: .trailing
-                        )
-                    )
                 }
+                // The invisible base Text below is the accessibility
+                // element; these overlay copies are visual-only.
+                .accessibilityHidden(true)
+                // The measured width, not `maxWidth: .infinity`. Inside an
+                // overlay that flexible frame does not resolve against the row's
+                // width, so it came out unbounded and `.clipped()` had an
+                // infinite rectangle to clip to — which is to say it did
+                // nothing, and a long title scrolled clean across the buttons
+                // next to it and off both edges of the screen. Measured on the
+                // simulator: the row's own frame was correct throughout, only
+                // the drawing escaped it. `containerWidth` is the same number
+                // `needsScroll` is already decided from, so there is nothing new
+                // to keep in step.
+                .frame(width: containerWidth > 0 ? containerWidth : nil, alignment: .leading)
+                .mask(
+                    LinearGradient(
+                        stops: needsScroll
+                            ? [
+                                .init(color: .clear, location: 0),
+                                .init(color: .black, location: 0.04),
+                                .init(color: .black, location: 0.96),
+                                .init(color: .clear, location: 1),
+                            ]
+                            : [
+                                .init(color: .black, location: 0),
+                                .init(color: .black, location: 1),
+                            ],
+                        startPoint: .leading, endPoint: .trailing
+                    )
+                )
+                // Last, so the hard edge is the final word on where this may
+                // draw whatever the mask does with its own bounds.
+                .clipped()
             )
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { newWidth in
                 guard abs(containerWidth - newWidth) > 0.5 else { return }
@@ -132,6 +153,13 @@ struct MarqueeText: View {
             .onChange(of: text) {
                 restartCycle()
             }
+            // Resuming starts a fresh dwell rather than picking the pass up
+            // where it left off. A host only pauses this when it is covered, so
+            // there is no jump to see, and coming back to a title that starts
+            // from its first character is the more useful of the two.
+            .onChange(of: isPaused) { _, paused in
+                if !paused { restartCycle() }
+            }
             .onAppear {
                 isVisible = true
                 restartCycle()
@@ -139,6 +167,23 @@ struct MarqueeText: View {
             .onDisappear {
                 isVisible = false
             }
+    }
+
+    /// One drawn copy of the text. Two of these ride the scroll, spaced a `gap`
+    /// apart, so the wrap back to zero lands the trailing copy exactly where the
+    /// leading one started.
+    ///
+    /// `contentTransition` is here rather than at the call sites because the
+    /// title rows that adopted this used to crossfade between songs, and a
+    /// `Text` nested inside a component cannot be reached by the caller's
+    /// modifier. The ancestor `.animation(_:value: song.id)` still supplies the
+    /// transaction.
+    private var copy: some View {
+        Text(text)
+            .font(font)
+            .foregroundStyle(color)
+            .contentTransition(.opacity)
+            .fixedSize()
     }
 
     private func phase(at date: Date) -> CGFloat {

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -908,23 +908,29 @@ struct FullScreenPlayerView: View {
     ) -> some View {
         HStack(alignment: .center, spacing: compact ? 8 : 12) {
             VStack(alignment: .leading, spacing: compact ? 2 : 4) {
-                Text(song.title)
-                    .font(compact || metrics.titleSize <= 20 ? .headline.bold() : AM.Font.nowPlayingTitle)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .contentTransition(.opacity)
-                Text(song.displayArtist)
-                    .font(compact || metrics.artistSize <= 15 ? .subheadline : AM.Font.nowPlayingArtist)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .contentTransition(.opacity)
+                MarqueeText(
+                    text: song.title,
+                    font: compact || metrics.titleSize <= 20
+                        ? .headline.bold() : AM.Font.nowPlayingTitle,
+                    color: .primary,
+                    isPaused: !presentation.isExpanded
+                )
+                MarqueeText(
+                    text: song.displayArtist,
+                    font: compact || metrics.artistSize <= 15
+                        ? .subheadline : AM.Font.nowPlayingArtist,
+                    color: .secondary,
+                    isPaused: !presentation.isExpanded
+                )
             }
             .animation(reduceMotion ? nil : AppMotion.quick, value: song.id)
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Now playing")
             .accessibilityValue("\(song.title), \(song.displayArtist)")
-            Spacer(minLength: 8)
+            // Not a `Spacer`: the titles are flexible now, and two flexible
+            // children split the free width between them, which would start a
+            // title scrolling while half the row sat empty beside it.
+            .padding(.trailing, 8)
             PlayerFavoriteButton(
                 song: song,
                 font: .title2,

--- a/Twinskaraoke/Features/Player/NowPlaying/MiniPlayerBar.swift
+++ b/Twinskaraoke/Features/Player/NowPlaying/MiniPlayerBar.swift
@@ -41,8 +41,13 @@ struct MiniPlayerBar: View {
     var body: some View {
         HStack(spacing: 10) {
             artwork
+            // No `Spacer` between the titles and the controls. The titles now
+            // grow to fill, and a `Spacer` is flexible too — SwiftUI would split
+            // the free width between them, so a title would start scrolling with
+            // half the bar sitting empty next to it. The trailing padding keeps
+            // the gap the `Spacer(minLength: 8)` used to guarantee.
             titles
-            Spacer(minLength: 8)
+                .padding(.trailing, 8)
             MiniPlayerTransportControls(
                 isPlaying: snapshot.isPlaying,
                 isRadioMode: snapshot.isRadioMode,
@@ -133,21 +138,38 @@ struct MiniPlayerBar: View {
     /// The minimized bar keeps both lines and just drops a type size. An
     /// earlier version hid the artist there to save room, which lost the one
     /// piece of information that tells two versions of the same song apart.
+    ///
+    /// Both lines scroll when they outgrow the bar, which is what makes keeping
+    /// the artist in the minimized placement affordable: there is very little
+    /// room there, and truncating to "Bohemian Rha…" tells you less than a line
+    /// that eventually shows all of it. Paused while the full-screen player is
+    /// up — the bar is behind it, and nothing should be scrolling out of sight.
     private var titles: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(snapshot.title)
-                .font(titleFont)
-                .foregroundStyle(Color.primary)
-                .lineLimit(1)
+            MarqueeText(
+                text: snapshot.title,
+                font: titleFont,
+                color: .primary,
+                gap: Self.marqueeGap,
+                isPaused: presentation.isExpanded
+            )
             if !snapshot.subtitle.isEmpty {
-                Text(snapshot.subtitle)
-                    .font(subtitleFont)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                MarqueeText(
+                    text: snapshot.subtitle,
+                    font: subtitleFont,
+                    color: .secondary,
+                    gap: Self.marqueeGap,
+                    isPaused: presentation.isExpanded
+                )
             }
         }
         .accessibilityHidden(true)
     }
+
+    /// Tighter than the marquee's default, which is sized for the full-screen
+    /// player. At 48pt a quarter of the minimized pill would be blank as the
+    /// title wraps.
+    private static let marqueeGap: CGFloat = 28
 
     private var titleFont: Font {
         isInline ? .caption.weight(.semibold) : .subheadline.weight(.semibold)

--- a/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
+++ b/Twinskaraoke/Features/Player/RadioPlayerLayout.swift
@@ -4,6 +4,9 @@ struct RadioPlayerLayout: View {
     @Environment(AudioPlayerManager.self) var audioManager
     let favorites: FavoritesManager
     private let radio = RadioController.shared
+    /// Only to stop the marquees while this layout is parked below the screen —
+    /// the player stays mounted when it is closed, so nothing else would.
+    private let presentation = NowPlayingPresentation.shared
     @Environment(\.appReduceMotion) private var reduceMotion
     @Binding var showingQueue: Bool
     let song: Song
@@ -64,17 +67,24 @@ struct RadioPlayerLayout: View {
                 MarqueeText(
                     text: song.title,
                     font: AM.Font.nowPlayingTitle,
-                    color: .primary
+                    color: .primary,
+                    isPaused: !presentation.isExpanded
                 )
-                Text(song.displayArtist)
-                    .font(AM.Font.nowPlayingArtist)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                MarqueeText(
+                    text: song.displayArtist,
+                    font: AM.Font.nowPlayingArtist,
+                    color: .secondary,
+                    isPaused: !presentation.isExpanded
+                )
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Live radio")
             .accessibilityValue("\(song.title), \(song.displayArtist)")
-            Spacer(minLength: 8)
+            // Not a `Spacer`. The title has been flexible ever since it became a
+            // marquee, and a `Spacer` is flexible too, so the two were quietly
+            // splitting the free width — the title scrolled from about half the
+            // row while the other half sat empty.
+            .padding(.trailing, 8)
             if canFavoriteRadioSong, let songID = radioFavoriteID {
                 Button {
                     toggleRadioFavorite(songID)

--- a/TwinskaraokeTests/MarqueeTextPhaseTests.swift
+++ b/TwinskaraokeTests/MarqueeTextPhaseTests.swift
@@ -1,0 +1,126 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+/// Guards the scrolling title in the radio player.
+///
+/// These are regression tests. `MarqueeText` used to drive its offset with an
+/// implicit animation and step the loop with `Task.sleep`, which assumed the
+/// wall clock and the animation stayed in step. Opening or dismissing the
+/// full-screen player runs a `withAnimation` transaction over the player's whole
+/// subtree, which could drop the in-flight animation while the sleep carried on
+/// — the title stalled mid-pass, then jumped. Making the offset a total function
+/// of elapsed time is the fix, so what is worth testing is that it really is
+/// total: same input, same output, no matter what happened in between.
+@Suite("Marquee scrolling")
+struct MarqueeTextPhaseTests {
+    /// A title about twice the width of the space it has, at the default gap.
+    private let travel: CGFloat = 400
+    private let scrollDuration: TimeInterval = 400 / 35
+    private let startDelay: TimeInterval = 1.2
+
+    private func phase(_ elapsed: TimeInterval) -> CGFloat {
+        MarqueeText.phase(
+            elapsed: elapsed,
+            travel: travel,
+            scrollDuration: scrollDuration,
+            startDelay: startDelay
+        )
+    }
+
+    // MARK: - One cycle
+
+    @Test("The title holds still for the opening dwell")
+    func dwellsBeforeScrolling() {
+        #expect(phase(0) == 0)
+        #expect(phase(startDelay - 0.01) == 0)
+        #expect(phase(startDelay) == 0)
+    }
+
+    @Test("A pass runs from the start of the text to the second copy")
+    func scrollsAcrossOneFullTravel() {
+        #expect(phase(startDelay + 0.001) > 0)
+        #expect(phase(startDelay + scrollDuration / 2).isApproximatelyEqual(to: travel / 2))
+        // The end of a pass is the start of the next cycle's dwell, so it wraps
+        // to zero rather than landing on `travel`. Visually they are the same
+        // point: the trailing copy is exactly where the leading one began.
+        #expect(phase(startDelay + scrollDuration * 0.999).isApproximatelyEqual(to: travel, within: 1))
+        #expect(phase(startDelay + scrollDuration) == 0)
+    }
+
+    @Test("A pass advances steadily and never goes backwards within itself")
+    func advancesMonotonicallyWithinAPass() {
+        var previous: CGFloat = 0
+        for step in 1 ... 50 {
+            let current = phase(startDelay + scrollDuration * Double(step) / 51)
+            #expect(current > previous)
+            previous = current
+        }
+    }
+
+    @Test("Cycles repeat identically")
+    func repeatsEveryCycle() {
+        let cycle = startDelay + scrollDuration
+        for offset in stride(from: 0.0, to: cycle, by: cycle / 17) {
+            #expect(phase(offset).isApproximatelyEqual(to: phase(offset + cycle * 4)))
+        }
+    }
+
+    // MARK: - The regression
+
+    /// The property the old implementation did not have. Nothing carries over
+    /// between samples, so a gap — a dropped frame, a paused display link, a
+    /// player transition that swallowed the animation — cannot leave the title
+    /// stranded: the position is whatever the clock says, both across a gap and
+    /// after one.
+    @Test("A gap in sampling does not shift the title")
+    func survivesAGapInSampling() {
+        let cycle = startDelay + scrollDuration
+        let resumed = startDelay + scrollDuration * 0.75
+
+        // Sampled continuously or not at all since t=0, the answer is the same.
+        #expect(phase(resumed).isApproximatelyEqual(to: travel * 0.75))
+        // And a gap spanning several whole cycles still lands in the right place.
+        #expect(phase(resumed + cycle * 3).isApproximatelyEqual(to: travel * 0.75))
+    }
+
+    // MARK: - Degenerate input
+
+    @Test("Text that fits, or a zero-length pass, never moves")
+    func staysPutWithNothingToScroll() {
+        #expect(
+            MarqueeText.phase(
+                elapsed: 99, travel: 0, scrollDuration: scrollDuration, startDelay: startDelay
+            ) == 0
+        )
+        #expect(
+            MarqueeText.phase(
+                elapsed: 99, travel: travel, scrollDuration: 0, startDelay: startDelay
+            ) == 0
+        )
+    }
+
+    @Test("No dwell means the pass starts immediately")
+    func honoursAZeroDwell() {
+        let immediate = MarqueeText.phase(
+            elapsed: scrollDuration / 4, travel: travel, scrollDuration: scrollDuration,
+            startDelay: 0
+        )
+        #expect(immediate.isApproximatelyEqual(to: travel / 4))
+    }
+
+    /// `startDate` is only ever set to the present, so a negative elapsed means
+    /// the clock moved underneath us. Restarting the cycle beats a negative
+    /// offset, which would push the text off to the right.
+    @Test("A clock that moves backwards restarts the cycle")
+    func clampsNegativeElapsedTime() {
+        #expect(phase(-5) == 0)
+    }
+}
+
+private extension CGFloat {
+    func isApproximatelyEqual(to other: CGFloat, within tolerance: CGFloat = 0.001) -> Bool {
+        abs(self - other) <= tolerance
+    }
+}


### PR DESCRIPTION
Radio's scrolling title could stall when the full-screen player was opened or dismissed — sometimes it picked up again, sometimes it never moved until the track changed. Fixing that turned into two commits: the stall itself, then adopting the (now reliable) marquee in the places that were still truncating.

## The stall

Two separate defects in `MarqueeText`, which is why there were two different outcomes.

**Stall, then jump.** The offset was driven by `withAnimation(.linear(duration:))` with the loop stepped by a `Task` that slept for exactly that duration — which assumes the wall clock and the animation stay in step. They don't. Presenting the player runs a `withAnimation` transaction across the player's whole subtree, and a re-render inside someone else's transaction can drop or re-target an animation already in flight. The sleep kept counting regardless, so the reset to zero fired at a moment unrelated to where the text actually was.

**Stopped for good.** `onDisappear` cancelled the task and there was no `onAppear` to start another. The only routes back in were a change of text or of measured width — and the player returns with the same song at the same size, so neither fired.

Both go away by sampling elapsed time instead: a dwell, then a linear pass, repeating modulo the two, sampled by a `TimelineView`. That's the pattern `EqualizerBars` and `PlayerAmbientBackground` already use here. There's no state left to fall out of step with, so a pass interrupted by a transition resumes wherever the clock says it got to, and pausing off-screen becomes a property of the schedule rather than something that has to be undone by hand.

## Scrolling the rest of the titles

Apple Music scrolls a now-playing title that won't fit rather than truncating it, in the pill and at full size. This adopts the marquee for the title and artist in the mini player (both placements) and in the full-screen player's title row, and pairs the radio player's artist with the title that was already scrolling.

Two things had to be sorted out first.

**The rows fought the marquee for width.** They were built around `Spacer(minLength: 8)`, which is flexible — and so is a marquee. Two flexible children split the free space between them, so a title would have started scrolling with half the row sitting empty next to it. The spacers become trailing padding: same minimum gap, marquee gets the rest. The radio row already had this latent, since its title has been flexible ever since it became a marquee, so that one is a fix rather than a precaution.

**`MarqueeText` never actually clipped.** `.frame(maxWidth: .infinity)` inside an `.overlay` doesn't resolve against the width the row has to offer — it comes out unbounded, so `.clipped()` had an infinite rectangle and did nothing. A long title scrolled straight across the favourite and more buttons and off both edges of the screen. It clips against the measured width now, the same number `needsScroll` is already decided from.

That bug predates this branch. It went unnoticed for as long as the only marquee was the radio title, where the overflow fell on empty space.

Hosts that know they're covered pass `isPaused`, so the mini player stops while the full player is over it and the player stops while it's parked below the screen. Neither unmounts the other, so `onDisappear` would never have fired for either.

## Verification

- 151 unit tests (143 + 8 new in `MarqueeTextPhaseTests`) and 15 UI tests pass; build is warning-clean.
- The new tests cover the property the old implementation lacked: sampling after a gap of several whole cycles lands in exactly the same place as continuous sampling, so an interrupted pass can't strand the title.
- The full-screen player was checked visually in the simulator across a full scroll cycle — wrap point, edge fades, and clearance from the favourite and more buttons. The clipping bug was found this way, and confirmed with a temporary border proving the layout frame was correct and only the drawing was escaping it.
- Appearance and behaviour verified on device, including the mini player — which can't be judged from a simulator capture, since `simctl` omits the Liquid Glass tab bar and the accessory renders without its chrome.

## Summary by Sourcery

Stabilize and extend the self-scrolling title marquee, fixing animation stalls and clipping issues, and adopt it across now-playing surfaces where text was previously truncated.

New Features:
- Enable marquee scrolling for truncated titles and artists in the mini player, full-screen player, and radio player title rows.

Bug Fixes:
- Fix stalling and permanently stopped marquee animations by driving scroll offset from elapsed time rather than task-based implicit animations.
- Ensure marquee text is correctly clipped within its container so long titles no longer scroll over adjacent controls.

Enhancements:
- Pause marquee scrolling when the associated UI is covered or off-screen to avoid invisible animations and unnecessary display link usage.
- Adjust title row layouts to give marquee text full use of available width instead of competing with spacers for space.

Tests:
- Add regression test suite for MarqueeText phase calculation, covering cycle behaviour, sampling gaps, and degenerate inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scrolling song titles and artist names to the full-screen player, mini player, and radio player.
  - Long titles now move smoothly instead of being truncated, with consistent spacing and readable transitions.
  - Scrolling automatically pauses when the relevant player view is hidden or not expanded and resumes when visible again.

- **Bug Fixes**
  - Improved marquee behavior when titles, available space, or player presentation state changes.
  - Prevented scrolling text from rendering outside its available area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->