### PR TITLE
Stop a drag from the artwork opening the cover art

### DIFF
--- a/Twinskaraoke/Components/Player/PlayerArtworkView.swift
+++ b/Twinskaraoke/Components/Player/PlayerArtworkView.swift
@@ -9,13 +9,34 @@ struct PlayerArtworkView: View {
     var body: some View {
         Group {
             if let onTap {
-                Button {
-                    AppHaptic.selection.play()
-                    onTap()
-                } label: {
-                    artwork
-                }
-                .buttonStyle(PressableButtonStyle(scale: 0.985, dim: 0.88, haptic: nil))
+                artwork
+                    // A tap gesture rather than a `Button`, and the difference
+                    // is the whole point. A SwiftUI button fires on touch-up
+                    // whenever the touch is still inside its bounds; it has no
+                    // notion of the finger having travelled. This is the largest
+                    // target on the player, so a drag down that began and ended
+                    // on the artwork stayed in bounds and opened the full-screen
+                    // cover art instead of dismissing the player. Drags long
+                    // enough to leave the artwork behaved, which is what made it
+                    // intermittent.
+                    //
+                    // `TapGesture` fails once the touch moves past its
+                    // tolerance, so the drag reaches `NowPlayingOverlay` — child
+                    // gestures resolve first, and a failed one yields. A
+                    // deliberate tap is unaffected; both halves are covered by
+                    // `testDraggingDownFromTheArtworkDoesNotOpenTheCoverArt` and
+                    // `testTappingTheArtworkOpensTheCoverArt`.
+                    //
+                    // The cost is the press-in scale and dim that
+                    // `PressableButtonStyle` gave this. No gesture reports a
+                    // press state without claiming the touch, and claiming it is
+                    // exactly what must not happen here; the selection haptic
+                    // still marks the moment.
+                    .contentShape(.rect)
+                    .onTapGesture {
+                        AppHaptic.selection.play()
+                        onTap()
+                    }
             } else {
                 artwork
             }
@@ -23,8 +44,12 @@ struct PlayerArtworkView: View {
         .frame(maxWidth: .infinity)
         .opacity(NowPlayingPresentation.shared.isMorphingArtwork ? 0 : 1)
         .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("PlayerArtwork")
         .accessibilityLabel("\(song.title) artwork")
         .accessibilityHint(onTap == nil ? "Album artwork." : "Opens full-screen artwork.")
+        // Explicit now that this is no longer a `Button`, so VoiceOver still
+        // announces it as one and offers the action below.
+        .accessibilityAddTraits(onTap == nil ? [] : .isButton)
         .accessibilityAction {
             onTap?()
         }

--- a/Twinskaraoke/Components/Player/PlayerArtworkView.swift
+++ b/Twinskaraoke/Components/Player/PlayerArtworkView.swift
@@ -5,33 +5,35 @@ struct PlayerArtworkView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     let song: Song
     let size: CGFloat
+
+    /// Opens the full-screen cover art. Nil on the surfaces where the artwork
+    /// is just a picture — the radio player is one — which is why every
+    /// interactive and assistive affordance below is conditional on it.
+    ///
+    /// It is deliberately wired to a `TapGesture` and not to a `Button`. A
+    /// SwiftUI button fires on touch-up whenever the touch is still inside its
+    /// bounds; it has no notion of the finger having travelled. The artwork is
+    /// the largest target on the player, so a drag down that began and ended on
+    /// it stayed in bounds and opened the cover art instead of dismissing the
+    /// player. Drags long enough to leave the artwork behaved, which is what
+    /// made it intermittent. A `TapGesture` fails once the touch moves past its
+    /// tolerance, so the drag reaches `NowPlayingOverlay` — child gestures
+    /// resolve before the container's, and a failed one yields.
+    ///
+    /// Both halves are covered by
+    /// `testDraggingDownFromTheArtworkDoesNotOpenTheCoverArt` and
+    /// `testTappingTheArtworkOpensTheCoverArt`.
+    ///
+    /// The cost is the press-in scale and dim `PressableButtonStyle` gave this.
+    /// No gesture reports a press state without claiming the touch, and
+    /// claiming it is exactly what must not happen here; the selection haptic
+    /// still marks the moment.
     var onTap: (() -> Void)?
+
     var body: some View {
         Group {
             if let onTap {
                 artwork
-                    // A tap gesture rather than a `Button`, and the difference
-                    // is the whole point. A SwiftUI button fires on touch-up
-                    // whenever the touch is still inside its bounds; it has no
-                    // notion of the finger having travelled. This is the largest
-                    // target on the player, so a drag down that began and ended
-                    // on the artwork stayed in bounds and opened the full-screen
-                    // cover art instead of dismissing the player. Drags long
-                    // enough to leave the artwork behaved, which is what made it
-                    // intermittent.
-                    //
-                    // `TapGesture` fails once the touch moves past its
-                    // tolerance, so the drag reaches `NowPlayingOverlay` — child
-                    // gestures resolve first, and a failed one yields. A
-                    // deliberate tap is unaffected; both halves are covered by
-                    // `testDraggingDownFromTheArtworkDoesNotOpenTheCoverArt` and
-                    // `testTappingTheArtworkOpensTheCoverArt`.
-                    //
-                    // The cost is the press-in scale and dim that
-                    // `PressableButtonStyle` gave this. No gesture reports a
-                    // press state without claiming the touch, and claiming it is
-                    // exactly what must not happen here; the selection haptic
-                    // still marks the moment.
                     .contentShape(.rect)
                     .onTapGesture {
                         AppHaptic.selection.play()
@@ -48,11 +50,9 @@ struct PlayerArtworkView: View {
         .accessibilityLabel("\(song.title) artwork")
         .accessibilityHint(onTap == nil ? "Album artwork." : "Opens full-screen artwork.")
         // Explicit now that this is no longer a `Button`, so VoiceOver still
-        // announces it as one and offers the action below.
+        // announces it as one and offers the activation below.
         .accessibilityAddTraits(onTap == nil ? [] : .isButton)
-        .accessibilityAction {
-            onTap?()
-        }
+        .accessibilityActivation(onTap)
     }
 
     private var artwork: some View {
@@ -124,5 +124,22 @@ struct PlayerArtworkView: View {
 
     private var bufferingTransition: AnyTransition {
         reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.96))
+    }
+}
+
+private extension View {
+    /// Registers the default activation only when there is something to run.
+    ///
+    /// An unconditional `accessibilityAction` leaves VoiceOver offering an
+    /// activation that does nothing on the surfaces that pass no `onTap` — the
+    /// radio player's artwork is one — which reads as a control that is simply
+    /// broken. Gating it matches how the `.isButton` trait is applied.
+    @ViewBuilder
+    func accessibilityActivation(_ action: (() -> Void)?) -> some View {
+        if let action {
+            accessibilityAction { action() }
+        } else {
+            self
+        }
     }
 }

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -375,6 +375,9 @@ struct FullScreenPlayerView: View {
                     title: isEasterEgg ? easterEggArtistName : coverArtArtistName,
                     subtitle: isEasterEgg ? easterEggArtistLink : coverArtArtistLink
                 )
+                // Named so a test can assert this did *not* open. Dragging the
+                // player down from the artwork used to bring it up by accident.
+                .accessibilityIdentifier("CoverArtViewer")
                 .onDisappear {
                     easterEggImageURL = nil
                     easterEggArtistName = nil

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -574,6 +574,13 @@ final class TwinskaraokeUITests: XCTestCase {
       coverArtViewer(in: app).waitForExistence(timeout: 3),
       "Dragging the player down from the artwork opened the cover art."
     )
+    // Both halves, because either one alone can be satisfied by a broken
+    // player: a gesture that swallowed the drag outright would open no cover
+    // art and dismiss nothing, and pass the assertion above on its own.
+    XCTAssertTrue(
+      waitUntil(timeout: 5) { self.miniPlayerIsHittable(in: app) },
+      "Dragging down from the artwork did not dismiss the full-screen player."
+    )
   }
 
   /// The other half of the bargain: a deliberate tap must still open it.

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -528,6 +528,86 @@ final class TwinskaraokeUITests: XCTestCase {
     }
   }
 
+  /// Dragging the player down from the artwork must not be mistaken for a tap
+  /// on it.
+  ///
+  /// The artwork used to be a `Button`, and a SwiftUI button fires on touch-up
+  /// whenever the touch is still inside its bounds — it has no notion of the
+  /// finger having travelled. The artwork is the largest target on the player,
+  /// so a downward drag that began and ended on it stayed in bounds and opened
+  /// the full-screen cover art instead of dismissing the player. Drags long
+  /// enough to leave the artwork behaved, which is why it only happened
+  /// sometimes.
+  ///
+  /// The drag here is deliberately contained within the artwork, since that is
+  /// the only shape of gesture that ever reproduced it.
+  func testDraggingDownFromTheArtworkDoesNotOpenTheCoverArt() throws {
+    let app = launchApp(initialSection: "home")
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
+
+    XCTAssertTrue(
+      app.staticTexts["Made for You"].waitForExistence(timeout: 8),
+      "Expected Home song shelf to be visible."
+    )
+    openVisibleItem(
+      "Wake Me Up Before You Go-Go",
+      identifier: "HomeSongSection.Made for You.ui-home-song-1",
+      in: app
+    )
+
+    openMiniPlayer(in: app)
+    let player = app.otherElements["FullScreenPlayer"]
+    XCTAssertTrue(
+      waitUntil(timeout: 8) { player.isHittable },
+      "The mini player did not open the full-screen player."
+    )
+
+    let artwork = playerArtwork(in: app)
+    XCTAssertTrue(artwork.waitForExistence(timeout: 8), "Missing the player artwork.")
+
+    // Both ends inside the artwork, so the touch never leaves the old button.
+    let start = artwork.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12))
+    let end = artwork.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.92))
+    start.press(forDuration: 0.05, thenDragTo: end, withVelocity: 400, thenHoldForDuration: 0.1)
+
+    XCTAssertFalse(
+      coverArtViewer(in: app).waitForExistence(timeout: 3),
+      "Dragging the player down from the artwork opened the cover art."
+    )
+  }
+
+  /// The other half of the bargain: a deliberate tap must still open it.
+  func testTappingTheArtworkOpensTheCoverArt() throws {
+    let app = launchApp(initialSection: "home")
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
+
+    XCTAssertTrue(
+      app.staticTexts["Made for You"].waitForExistence(timeout: 8),
+      "Expected Home song shelf to be visible."
+    )
+    openVisibleItem(
+      "Wake Me Up Before You Go-Go",
+      identifier: "HomeSongSection.Made for You.ui-home-song-1",
+      in: app
+    )
+
+    openMiniPlayer(in: app)
+    let player = app.otherElements["FullScreenPlayer"]
+    XCTAssertTrue(
+      waitUntil(timeout: 8) { player.isHittable },
+      "The mini player did not open the full-screen player."
+    )
+
+    let artwork = playerArtwork(in: app)
+    XCTAssertTrue(artwork.waitForExistence(timeout: 8), "Missing the player artwork.")
+    artwork.tap()
+
+    XCTAssertTrue(
+      coverArtViewer(in: app).waitForExistence(timeout: 8),
+      "Tapping the artwork no longer opens the cover art."
+    )
+  }
+
   func testHomeSongOpensFullScreenPlayerControls() throws {
     let app = launchApp(initialSection: "home")
     XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
@@ -836,6 +916,17 @@ final class TwinskaraokeUITests: XCTestCase {
     let firstNavigationButton = app.navigationBars.buttons.element(boundBy: 0)
     XCTAssertTrue(firstNavigationButton.waitForExistence(timeout: 5), "Missing back navigation button.")
     firstNavigationButton.tap()
+  }
+
+  /// Matched on any element type: the artwork was a `Button` and is now a
+  /// plain element carrying the button trait, and the identifier is the part
+  /// that is meant to be stable across that.
+  private func playerArtwork(in app: XCUIApplication) -> XCUIElement {
+    app.descendants(matching: .any).matching(identifier: "PlayerArtwork").firstMatch
+  }
+
+  private func coverArtViewer(in app: XCUIApplication) -> XCUIElement {
+    app.descendants(matching: .any).matching(identifier: "CoverArtViewer").firstMatch
   }
 
   private func openMiniPlayer(in app: XCUIApplication) {


### PR DESCRIPTION
Dragging the player down with a finger on the artwork could open the full-screen cover art instead of dismissing the player.

## Cause

The artwork was a `Button`, and a SwiftUI button fires on touch-up whenever the touch is still inside its bounds — it has no notion of the finger having travelled. The artwork is the largest target on the player, so a drag that *began and ended* on it stayed in bounds and activated. Drags long enough to leave the artwork behaved, which is what made it intermittent.

## Fix

A `TapGesture` instead. It fails once the touch moves past its tolerance, so the drag reaches `NowPlayingOverlay`: child gestures resolve before the container's, and a failed one yields. A deliberate tap is unaffected.

## Verification

The tests were written before the change and reproduced the bug headlessly:

```
testDraggingDownFromTheArtworkDoesNotOpenTheCoverArt … failed
    XCTAssertFalse failed - Dragging the player down from the artwork opened the cover art.
testTappingTheArtworkOpensTheCoverArt … passed
```

The drag is deliberately contained within the artwork, since that is the only shape of gesture that ever triggered it. Both directions are covered — the drag must not open the cover art, and a tap must still open it. After the change both pass, along with the existing `testDraggingDownDismissesTheFullScreenPlayer`.

151 unit tests and 17 UI tests pass; build is warning-clean. Confirmed fixed on device.

## Tradeoff

This loses the press-in scale and dim that `PressableButtonStyle` gave the artwork. No gesture reports a press state without claiming the touch, and claiming it is exactly what must not happen here — that is the bug. The selection haptic still marks the moment. The scale was 1.5% and barely visible; the dim to 0.88 was more noticeable. Worth reinstating separately if it is missed, in a form that cannot swallow the drag.

## Summary by Sourcery

Prevent downward drags starting on the player artwork from opening the full-screen cover art while preserving tap-to-open behavior.

Bug Fixes:
- Fix unintended activation of the full-screen cover art when dragging the player down from the artwork area.

Enhancements:
- Replace the artwork button with a tap gesture and explicit accessibility traits so drags are passed through to the player while taps still trigger haptics and cover art.
- Add stable accessibility identifiers for the player artwork and cover art viewer to support interaction-based tests.

Tests:
- Add UI tests that verify dragging down from the artwork does not open the cover art while tapping the artwork still does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved full-screen player artwork interactions so downward drags dismiss the player normally without accidentally opening the cover art.
  - Deliberate taps on artwork continue to open the cover-art viewer.
- **Accessibility**
  - Improved artwork controls for VoiceOver and other assistive technologies by providing appropriate button semantics and activation behavior.
- **Tests**
  - Added automated coverage for artwork dragging, tapping, and cover-art viewer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->