### PR TITLE
Improve cache invalidation and task lifecycle

### DIFF
--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -143,12 +143,12 @@ struct RemoteArtworkImage: View {
         ArtworkFailureBackoff.shared.clear(loadedURL)
     }
 
-    private func markFinishedAfterFailure(for failedURL: URL, error: Error) {
+    private func markFinishedAfterFailure(for failedURL: URL, error _: Error) {
         guard url == failedURL else { return }
 
         let safeURL = Self.redactedURLString(failedURL)
         DebugLogger.log(
-            "Artwork load failed for \(safeURL): \(error.localizedDescription)",
+            "Artwork load failed for \(safeURL)",
             category: .cache
         )
         // The shared backoff is the single retry owner. Its generation update

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -16,7 +16,6 @@ struct RemoteArtworkImage: View {
     // isBlocked when the window ends instead of showing the placeholder forever.
     private let failureBackoff = ArtworkFailureBackoff.shared
     @State private var fullLoaded: Bool = false
-    @State private var loadFailed: Bool = false
     @State private var renderedFullURL: URL?
     var body: some View {
         // Load-bearing read: `isBlocked(url)` below is a method call over
@@ -39,7 +38,6 @@ struct RemoteArtworkImage: View {
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         .onChange(of: url) {
             fullLoaded = false
-            loadFailed = false
             renderedFullURL = nil
         }
     }
@@ -91,7 +89,7 @@ struct RemoteArtworkImage: View {
                     Color.clear
                 }
             }
-            if let url, !loadFailed, !ArtworkFailureBackoff.shared.isBlocked(url) {
+            if let url, !ArtworkFailureBackoff.shared.isBlocked(url) {
                 WebImage(
                     url: url,
                     options: ImageCacheConfig.defaultOptions,
@@ -137,48 +135,30 @@ struct RemoteArtworkImage: View {
 
     @MainActor
     private func markRendered(_ loadedURL: URL) {
-        guard url == loadedURL, renderedFullURL != loadedURL || !fullLoaded || loadFailed else { return }
+        guard url == loadedURL, renderedFullURL != loadedURL || !fullLoaded else { return }
         withOptionalAnimation(loadAnimation) {
             renderedFullURL = loadedURL
             fullLoaded = true
-            loadFailed = false
         }
         ArtworkFailureBackoff.shared.clear(loadedURL)
     }
 
     private func markFinishedAfterFailure(for failedURL: URL, error: Error) {
-    // 1. Guard check handles condition gating consistently up front
-    guard url == failedURL, !loadFailed else { return }
+        guard url == failedURL else { return }
 
-    let safeURL = Self.redactedURLString(failedURL)
-    DebugLogger.log(
-        "Artwork load failed for \(safeURL): \(error.localizedDescription)",
-        category: .cache
-    )
-    ArtworkFailureBackoff.shared.recordFailure(failedURL)
-    evictFailedImageCache(for: failedURL)
-
-    // 2. Task block cleanly isolated using standard MainActor syntax
-    Task { @MainActor in
-        self.loadFailed = true
-        
-        // 3. CodeRabbit Fix: Safe sleep wrapper to catch cancellation
-        do {
-            try await Task.sleep(for: ArtworkFailureBackoff.shared.cooldownDuration)
-        } catch {
-            // Reset flag on cancellation so the image doesn't stay frozen
-            self.loadFailed = false
-            return 
-        }
-        
-        // 4. Reset failure flag if the user hasn't scrolled to a new URL
-        if self.url == failedURL {
-            self.loadFailed = false
-        }
+        let safeURL = Self.redactedURLString(failedURL)
+        DebugLogger.log(
+            "Artwork load failed for \(safeURL): \(error.localizedDescription)",
+            category: .cache
+        )
+        // The shared backoff is the single retry owner. Its generation update
+        // removes this WebImage immediately, and its scheduled expiry
+        // recomposes every view for the URL after the cooldown. A per-view
+        // five-minute Task here duplicated that timer and retained off-screen
+        // view state throughout CDN outages.
+        ArtworkFailureBackoff.shared.recordFailure(failedURL)
+        evictFailedImageCache(for: failedURL)
     }
-}
-
-
 
     private var shouldAnimateLoad: Bool {
         !scrollState.isScrolling && shouldPreferProgressiveArtwork

--- a/Twinskaraoke/Models/Home/HomeViewModel.swift
+++ b/Twinskaraoke/Models/Home/HomeViewModel.swift
@@ -25,6 +25,7 @@ final class HomeViewModel {
     @ObservationIgnored private var topPicksSource: TopPicksSource = .setlists
     @ObservationIgnored private var dataGeneration = 0
     @ObservationIgnored private var homeLoadTask: Task<Void, Never>?
+    @ObservationIgnored private var topPicksLoadMoreTask: Task<Void, Never>?
 
     // No work in init. This type is held in `@State`, whose initial-value
     // expression is re-evaluated on every re-initialization of the owning view
@@ -41,6 +42,8 @@ final class HomeViewModel {
 
         if hasLoaded, !force { return }
         homeLoadTask?.cancel()
+        topPicksLoadMoreTask?.cancel()
+        topPicksLoadMoreTask = nil
         dataGeneration += 1
         let generation = dataGeneration
         hasLoaded = true
@@ -116,7 +119,8 @@ final class HomeViewModel {
         let source = topPicksSource
         let pageSize = topPicksPageSize
         let generation = dataGeneration
-        Task { [weak self] in
+        topPicksLoadMoreTask = Task { [weak self] in
+            guard let self else { return }
             let playlists: [Playlist] = switch source {
             case .setlists:
                 await (try? KaraokeAPIClient.playlists(
@@ -131,18 +135,17 @@ final class HomeViewModel {
                     pageSize: pageSize
                 )) ?? []
             }
-            await MainActor.run {
-                guard let self, self.dataGeneration == generation else { return }
-                if !playlists.isEmpty {
-                    let existing = Set(self.recentPlaylists.map(\.id))
-                    self.recentPlaylists += playlists.filter { !existing.contains($0.id) }
-                    self.topPicksPage += 1
-                    self.canLoadMoreTopPicks = playlists.count == self.topPicksPageSize
-                } else {
-                    self.canLoadMoreTopPicks = false
-                }
-                self.isLoadingMoreTopPicks = false
+            guard !Task.isCancelled, dataGeneration == generation else { return }
+            if !playlists.isEmpty {
+                let existing = Set(recentPlaylists.map(\.id))
+                recentPlaylists += playlists.filter { !existing.contains($0.id) }
+                topPicksPage += 1
+                canLoadMoreTopPicks = playlists.count == topPicksPageSize
+            } else {
+                canLoadMoreTopPicks = false
             }
+            isLoadingMoreTopPicks = false
+            topPicksLoadMoreTask = nil
         }
     }
 
@@ -242,5 +245,6 @@ final class HomeViewModel {
 
     deinit {
         homeLoadTask?.cancel()
+        topPicksLoadMoreTask?.cancel()
     }
 }

--- a/Twinskaraoke/Models/Home/HomeViewModel.swift
+++ b/Twinskaraoke/Models/Home/HomeViewModel.swift
@@ -120,7 +120,6 @@ final class HomeViewModel {
         let pageSize = topPicksPageSize
         let generation = dataGeneration
         topPicksLoadMoreTask = Task { [weak self] in
-            guard let self else { return }
             let playlists: [Playlist] = switch source {
             case .setlists:
                 await (try? KaraokeAPIClient.playlists(
@@ -135,7 +134,7 @@ final class HomeViewModel {
                     pageSize: pageSize
                 )) ?? []
             }
-            guard !Task.isCancelled, dataGeneration == generation else { return }
+            guard !Task.isCancelled, let self, self.dataGeneration == generation else { return }
             if !playlists.isEmpty {
                 let existing = Set(recentPlaylists.map(\.id))
                 recentPlaylists += playlists.filter { !existing.contains($0.id) }

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -73,6 +73,10 @@ actor UploadedSongMetadataCache {
 
   func invalidate() {
     cachedValue = nil
+    // Dropping only our reference still lets current awaiters receive the
+    // previous account's response. Cancellation makes invalidation a delivery
+    // boundary as well as a cache boundary.
+    inFlight?.task.cancel()
     inFlight = nil
     epoch &+= 1
   }
@@ -224,6 +228,9 @@ actor FavoriteCatalogMetadataCache {
 
   func invalidate() {
     cachedValue = nil
+    // Favorite mutations and signout must not deliver metadata fetched for
+    // the state that was just invalidated.
+    inFlight.values.forEach { $0.task.cancel() }
     inFlight.removeAll()
     epoch &+= 1
   }
@@ -287,6 +294,9 @@ actor FavoriteSongsCache {
 
   func invalidate() {
     cachedValue = nil
+    // Prevent an older favorite list from reaching an awaiting screen after a
+    // toggle or account change.
+    inFlight?.task.cancel()
     inFlight = nil
     epoch &+= 1
   }

--- a/TwinskaraokeShared/Services/KaraokeAPIClient.swift
+++ b/TwinskaraokeShared/Services/KaraokeAPIClient.swift
@@ -49,16 +49,15 @@ actor UploadedSongMetadataCache {
 
     do {
       let songs = try await request.task.value
-      if epoch == startEpoch {
-        let coveredIDs = (cachedValue?.coveredIDs ?? [])
-          .union(requestedIDs)
-          .union(songs.map(\.id))
-        cachedValue = Entry(
-          songs: songs,
-          coveredIDs: coveredIDs,
-          expiresAt: now.addingTimeInterval(lifetime)
-        )
-      }
+      guard epoch == startEpoch else { throw CancellationError() }
+      let coveredIDs = (cachedValue?.coveredIDs ?? [])
+        .union(requestedIDs)
+        .union(songs.map(\.id))
+      cachedValue = Entry(
+        songs: songs,
+        coveredIDs: coveredIDs,
+        expiresAt: now.addingTimeInterval(lifetime)
+      )
       if inFlight?.id == request.id {
         inFlight = nil
       }
@@ -211,9 +210,8 @@ actor FavoriteCatalogMetadataCache {
 
     do {
       let songs = try await request.task.value
-      if epoch == startEpoch {
-        cachedValue = Entry(key: key, songs: songs, expiresAt: now.addingTimeInterval(lifetime))
-      }
+      guard epoch == startEpoch else { throw CancellationError() }
+      cachedValue = Entry(key: key, songs: songs, expiresAt: now.addingTimeInterval(lifetime))
       if inFlight[key]?.id == request.id {
         inFlight[key] = nil
       }
@@ -277,9 +275,8 @@ actor FavoriteSongsCache {
 
     do {
       let songs = try await request.task.value
-      if epoch == startEpoch {
-        cachedValue = Entry(songs: songs, expiresAt: now.addingTimeInterval(lifetime))
-      }
+      guard epoch == startEpoch else { throw CancellationError() }
+      cachedValue = Entry(songs: songs, expiresAt: now.addingTimeInterval(lifetime))
       if inFlight?.id == request.id {
         inFlight = nil
       }

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -20,7 +20,13 @@ private actor CancellableSongLoaderProbe {
 
     func load() async throws -> [Song] {
         calls += 1
-        try await Task.sleep(for: .seconds(60))
+        do {
+            try await Task.sleep(for: .seconds(60))
+        } catch is CancellationError {
+            // Deliberately return after cancellation to prove that each cache
+            // rejects results from an invalidated generation independently of
+            // loader cooperation.
+        }
         return []
     }
 

--- a/TwinskaraokeTests/SongModelTests.swift
+++ b/TwinskaraokeTests/SongModelTests.swift
@@ -15,6 +15,22 @@ private actor UploadedSongLoaderProbe {
     }
 }
 
+private actor CancellableSongLoaderProbe {
+    private var calls = 0
+
+    func load() async throws -> [Song] {
+        calls += 1
+        try await Task.sleep(for: .seconds(60))
+        return []
+    }
+
+    func waitUntilStarted() async {
+        while calls == 0 {
+            await Task.yield()
+        }
+    }
+}
+
 @Suite("Song model")
 struct SongModelTests {
     private func useGlobalStorageRegion() {
@@ -517,6 +533,69 @@ struct SongModelTests {
         #expect(callsForStableFavorites == 1)
         #expect(callsAfterAddingFavorite == 2)
         #expect(callsAfterExpiration == 3)
+    }
+
+    @Test("Uploaded metadata invalidation cancels an in-flight response")
+    func uploadedSongMetadataInvalidationCancelsInFlightResponse() async {
+        let cache = UploadedSongMetadataCache(lifetime: 60)
+        let loader = CancellableSongLoaderProbe()
+        let request = Task {
+            try await cache.value(for: ["first"]) { try await loader.load() }
+        }
+
+        await loader.waitUntilStarted()
+        await cache.invalidate()
+
+        do {
+            _ = try await request.value
+            Issue.record("Expected invalidation to cancel the in-flight upload metadata response")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+    }
+
+    @Test("Favorite catalog invalidation cancels in-flight metadata")
+    func favoriteCatalogInvalidationCancelsInFlightResponse() async {
+        let cache = FavoriteCatalogMetadataCache(lifetime: 60)
+        let loader = CancellableSongLoaderProbe()
+        let request = Task {
+            try await cache.value(for: ["first"]) { try await loader.load() }
+        }
+
+        await loader.waitUntilStarted()
+        await cache.invalidate()
+
+        do {
+            _ = try await request.value
+            Issue.record("Expected invalidation to cancel the in-flight catalog metadata response")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+    }
+
+    @Test("Favorite list invalidation cancels an in-flight response")
+    func favoriteSongsInvalidationCancelsInFlightResponse() async {
+        let cache = FavoriteSongsCache(lifetime: 60)
+        let loader = CancellableSongLoaderProbe()
+        let request = Task {
+            try await cache.value { try await loader.load() }
+        }
+
+        await loader.waitUntilStarted()
+        await cache.invalidate()
+
+        do {
+            _ = try await request.value
+            Issue.record("Expected invalidation to cancel the in-flight favorite list response")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
     }
 
     @Test("Uploaded song metadata takes priority when hydrating favorites")


### PR DESCRIPTION
## Summary

- cancel in-flight uploaded-song and favorite requests when their caches are invalidated, preventing stale responses after account or favorite changes
- cancel superseded home pagination work and rely on the shared artwork backoff instead of retaining a retry task per view
- add regression coverage for cancellation at each cache invalidation boundary

## Testing

- 154 unit tests passed on an iOS 26.5 simulator
- 154 unit tests passed on a physical iPhone running iOS 26.6.1
- Debug device build, installation, and launch succeeded
- Xcode static analysis and Release simulator build succeeded

## Summary by Sourcery

Harden cache invalidation and asynchronous task lifecycles to prevent stale data and redundant retry work.

Bug Fixes:
- Prevent stale uploaded-song and favorite responses from being delivered after cache invalidation.
- Cancel superseded home pagination requests to prevent outdated results from updating the home screen.
- Avoid retaining per-view artwork retry tasks during image-load failures.

Enhancements:
- Use shared artwork backoff state as the single retry and recomposition mechanism.
- Treat cache invalidation as a response-delivery boundary by rejecting results from prior cache generations.

Tests:
- Add regression tests covering cancellation of in-flight requests for uploaded metadata, favorite catalog metadata, and favorite songs caches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artwork loading recovery by preventing repeated failures and removing failed images from the cache.
  * Cancelled outdated metadata requests when account or application state changes, preventing stale results from appearing.
  * Improved home-screen refresh and pagination handling to avoid conflicting or outdated updates.

* **Tests**
  * Added coverage confirming that invalidated metadata requests are cancelled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->