### PR TITLE
Record playlists only when playback starts

### DIFF
--- a/Twinskaraoke/App/TwinskaraokeApp.swift
+++ b/Twinskaraoke/App/TwinskaraokeApp.swift
@@ -11,6 +11,11 @@ struct TwinskaraokeApp: App {
     @AppStorage(AppLanguage.storageKey) private var languageMode: String = AppLanguage.system.rawValue
 
     init() {
+        if AppRuntime.isUITestMode,
+           ProcessInfo.processInfo.arguments.contains("-UITestResetRecentlyPlayed")
+        {
+            RecentlyPlayedStore.resetPersistedHistoryForUITesting()
+        }
         ImageCacheConfig.applyLimits()
         // Mirrors the signed-in session to the paired watch, which has no way
         // to sign in on its own. No-op on devices that can't pair one.

--- a/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
+++ b/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
@@ -27,8 +27,7 @@ struct PlaylistActionsMenuItems: View {
             Button {
                 AppHaptic.selection.play()
                 if let first = songs.first {
-                    RecentlyPlayedStore.shared.record(playlist)
-                    AudioPlayerManager.shared.playInOrder(song: first, context: songs)
+                    PlaylistPlayback.playInOrder(first, from: playlist, context: songs)
                 }
             } label: {
                 Label("Play", systemImage: "play.fill")
@@ -36,8 +35,7 @@ struct PlaylistActionsMenuItems: View {
 
             Button {
                 AppHaptic.selection.play()
-                RecentlyPlayedStore.shared.record(playlist)
-                AudioPlayerManager.shared.playShuffled(from: songs)
+                PlaylistPlayback.playShuffled(from: playlist, songs: songs)
             } label: {
                 Label("Shuffle", systemImage: "shuffle")
             }

--- a/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
+++ b/Twinskaraoke/Components/Library/PlaylistActionsMenuItems.swift
@@ -27,6 +27,7 @@ struct PlaylistActionsMenuItems: View {
             Button {
                 AppHaptic.selection.play()
                 if let first = songs.first {
+                    RecentlyPlayedStore.shared.record(playlist)
                     AudioPlayerManager.shared.playInOrder(song: first, context: songs)
                 }
             } label: {
@@ -35,6 +36,7 @@ struct PlaylistActionsMenuItems: View {
 
             Button {
                 AppHaptic.selection.play()
+                RecentlyPlayedStore.shared.record(playlist)
                 AudioPlayerManager.shared.playShuffled(from: songs)
             } label: {
                 Label("Shuffle", systemImage: "shuffle")

--- a/Twinskaraoke/Features/CarPlay/CarPlaySceneDelegate.swift
+++ b/Twinskaraoke/Features/CarPlay/CarPlaySceneDelegate.swift
@@ -527,8 +527,12 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         }
 
         template.updateSections([
-            songActionSection(title: playlist.name, songs: songs),
-            CPListSection(items: songItems(songs, context: songs), header: "Songs", sectionIndexTitle: nil),
+            songActionSection(title: playlist.name, songs: songs, playlist: playlist),
+            CPListSection(
+                items: songItems(songs, context: songs, playlist: playlist),
+                header: "Songs",
+                sectionIndexTitle: nil
+            ),
         ])
     }
 
@@ -702,14 +706,19 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         rebuildRadioTemplate()
     }
 
-    private func songActionSection(title: String, songs: [Song], includeRefresh: Bool = false) -> CPListSection {
+    private func songActionSection(
+        title: String,
+        songs: [Song],
+        playlist: Playlist? = nil,
+        includeRefresh: Bool = false
+    ) -> CPListSection {
         var items: [CPListItem] = []
 
         let playAll = CPListItem(text: "Play All", detailText: SongCountText.songs(songs.count))
         playAll.isEnabled = !songs.isEmpty
         playAll.handler = { [weak self] _, completion in
             if let first = songs.first {
-                self?.play(first, in: songs)
+                self?.play(first, in: songs, playlist: playlist)
             }
             completion()
         }
@@ -718,7 +727,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         let shuffle = CPListItem(text: "Shuffle", detailText: title)
         shuffle.isEnabled = !songs.isEmpty
         shuffle.handler = { [weak self] _, completion in
-            self?.playShuffled(songs)
+            self?.playShuffled(songs, playlist: playlist)
             completion()
         }
         items.append(shuffle)
@@ -735,13 +744,13 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         return CPListSection(items: items, header: nil, sectionIndexTitle: nil)
     }
 
-    private func songItems(_ songs: [Song], context: [Song]) -> [CPListItem] {
+    private func songItems(_ songs: [Song], context: [Song], playlist: Playlist? = nil) -> [CPListItem] {
         songs.prefix(maximumBrowseRows).map { song in
-            songItem(song, context: context)
+            songItem(song, context: context, playlist: playlist)
         }
     }
 
-    private func songItem(_ song: Song, context: [Song]) -> CPListItem {
+    private func songItem(_ song: Song, context: [Song], playlist: Playlist? = nil) -> CPListItem {
         let item = CPListItem(
             text: song.title,
             detailText: songDetailText(song),
@@ -751,7 +760,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         )
         item.isPlaying = player.isPlaying && player.currentSong?.id == song.id
         item.handler = { [weak self] _, completion in
-            self?.play(song, in: context)
+            self?.play(song, in: context, playlist: playlist)
             completion()
         }
         loadSongArtwork(for: song, into: item)
@@ -825,14 +834,23 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         return UIImage(systemName: "dot.radiowaves.left.and.right", withConfiguration: configuration) ?? fallbackSongImage()
     }
 
-    private func play(_ song: Song, in context: [Song]) {
-        player.playInOrder(song: song, context: context.isEmpty ? [song] : context)
+    private func play(_ song: Song, in context: [Song], playlist: Playlist? = nil) {
+        let playbackContext = context.isEmpty ? [song] : context
+        if let playlist {
+            PlaylistPlayback.playInOrder(song, from: playlist, context: playbackContext)
+        } else {
+            player.playInOrder(song: song, context: playbackContext)
+        }
         refreshVisibleTemplates()
         showNowPlaying()
     }
 
-    private func playShuffled(_ songs: [Song]) {
-        player.playShuffled(from: songs)
+    private func playShuffled(_ songs: [Song], playlist: Playlist? = nil) {
+        if let playlist {
+            PlaylistPlayback.playShuffled(from: playlist, songs: songs)
+        } else {
+            player.playShuffled(from: songs)
+        }
         refreshVisibleTemplates()
         showNowPlaying()
     }

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -80,6 +80,7 @@ struct HomeView: View {
 
             if !recentlyPlayed.playlists.isEmpty {
                 PlaylistCarousel(title: "Recently Played", playlists: recentlyPlayed.playlists)
+                    .accessibilityIdentifier("Home.RecentlyPlayed")
                     .shelfEntrance(index: 1)
             }
 
@@ -124,6 +125,7 @@ struct HomeView: View {
                             playlists: recentlyPlayed.playlists,
                             horizontalPadding: 0
                         )
+                        .accessibilityIdentifier("Home.RecentlyPlayed")
                     }
 
                     if !viewModel.suggestions.isEmpty {

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -343,8 +343,7 @@ private struct WideLibraryHero: View {
                     Button {
                         if let first = playableSongs.first {
                             AppHaptic.selection.play()
-                            RecentlyPlayedStore.shared.record(playlist)
-                            AudioPlayerManager.shared.playInOrder(song: first, context: playableSongs)
+                            PlaylistPlayback.playInOrder(first, from: playlist, context: playableSongs)
                         }
                     } label: {
                         LibraryActionButtonLabel(symbol: "play.fill", text: "Play")
@@ -354,8 +353,7 @@ private struct WideLibraryHero: View {
 
                     Button {
                         AppHaptic.selection.play()
-                        RecentlyPlayedStore.shared.record(playlist)
-                        AudioPlayerManager.shared.playShuffled(from: playableSongs)
+                        PlaylistPlayback.playShuffled(from: playlist, songs: playableSongs)
                     } label: {
                         LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
                     }

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -343,6 +343,7 @@ private struct WideLibraryHero: View {
                     Button {
                         if let first = playableSongs.first {
                             AppHaptic.selection.play()
+                            RecentlyPlayedStore.shared.record(playlist)
                             AudioPlayerManager.shared.playInOrder(song: first, context: playableSongs)
                         }
                     } label: {
@@ -353,6 +354,7 @@ private struct WideLibraryHero: View {
 
                     Button {
                         AppHaptic.selection.play()
+                        RecentlyPlayedStore.shared.record(playlist)
                         AudioPlayerManager.shared.playShuffled(from: playableSongs)
                     } label: {
                         LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -60,13 +60,9 @@ struct PlaylistDetailView: View {
     @State private var rowArmingTask: Task<Void, Never>?
     private var playbackTapsArmed: Bool { hasSettledAfterAppear && !isArriving }
     /// onAppear fires repeatedly for one visit — device logs show appeared and
-    /// disappeared 1ms apart, over and over. Everything below it is one-shot
-    /// work: reload cancels and restarts the network load, and record() writes
-    /// UserDefaults *and* mutates an @Observable that HomeView and NewView both
-    /// read, so it re-renders two always-alive tab roots and every carousel in
-    /// them. Running that several times per navigation was pure churn.
+    /// disappeared 1ms apart, over and over. Reloading below cancels and restarts
+    /// the network load, so it remains one-shot work for a visit.
     @State private var hasStartedVisit = false
-    @State private var hasRecordedVisit = false
     private let userPlaylists = UserPlaylistsManager.shared
 
     init(playlist: Playlist) {
@@ -481,21 +477,6 @@ struct PlaylistDetailView: View {
             }
         }
         .onDisappear {
-            // Recorded on the way out, not the way in. This reorders the list
-            // that Home's "Recently Played" carousel is bound to, and doing that
-            // mid-navigation moved the very cell that had just been tapped.
-            // Under the cover presentation that broke outright — the cover lived
-            // on that cell, so the tap appeared to do nothing. Pushing is not as
-            // fragile, but reordering two always-alive tab roots while a
-            // transition runs is still wasted work at the worst moment.
-            // Latched: onDisappear fires repeatedly for a single visit, and
-            // record() writes UserDefaults and mutates an @Observable that two
-            // always-alive tab roots read. Without this the churn was relocated
-            // from appear to disappear rather than removed.
-            if !hasRecordedVisit {
-                hasRecordedVisit = true
-                RecentlyPlayedStore.shared.record(playlist)
-            }
             rowArmingTask?.cancel()
             hasSettledAfterAppear = false
             prefetchTask?.cancel()
@@ -783,6 +764,7 @@ struct PlaylistDetailView: View {
             Button {
                 if let first = songs.first {
                     AppHaptic.selection.play()
+                    RecentlyPlayedStore.shared.record(playlist)
                     AudioPlayerManager.shared.playInOrder(song: first, context: songs)
                 }
             } label: {
@@ -792,6 +774,7 @@ struct PlaylistDetailView: View {
             .accessibilityLabel("Play playlist")
             Button {
                 AppHaptic.selection.play()
+                RecentlyPlayedStore.shared.record(playlist)
                 AudioPlayerManager.shared.playShuffled(from: songs)
             } label: {
                 LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
@@ -807,6 +790,7 @@ struct PlaylistDetailView: View {
 
     private func play(_ song: Song, context: [Song]) {
         AppHaptic.selection.play()
+        RecentlyPlayedStore.shared.record(playlist)
         AudioPlayerManager.shared.play(song: song, context: context)
     }
 
@@ -969,4 +953,3 @@ private struct PlaylistMoreMenu: View {
         .accessibilityIdentifier("PlaylistDetail.moreActions")
     }
 }
-

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -764,8 +764,7 @@ struct PlaylistDetailView: View {
             Button {
                 if let first = songs.first {
                     AppHaptic.selection.play()
-                    RecentlyPlayedStore.shared.record(playlist)
-                    AudioPlayerManager.shared.playInOrder(song: first, context: songs)
+                    PlaylistPlayback.playInOrder(first, from: playlist, context: songs)
                 }
             } label: {
                 LibraryActionButtonLabel(symbol: "play.fill", text: "Play")
@@ -774,8 +773,7 @@ struct PlaylistDetailView: View {
             .accessibilityLabel("Play playlist")
             Button {
                 AppHaptic.selection.play()
-                RecentlyPlayedStore.shared.record(playlist)
-                AudioPlayerManager.shared.playShuffled(from: songs)
+                PlaylistPlayback.playShuffled(from: playlist, songs: songs)
             } label: {
                 LibraryActionButtonLabel(symbol: "shuffle", text: "Shuffle")
             }
@@ -790,8 +788,7 @@ struct PlaylistDetailView: View {
 
     private func play(_ song: Song, context: [Song]) {
         AppHaptic.selection.play()
-        RecentlyPlayedStore.shared.record(playlist)
-        AudioPlayerManager.shared.play(song: song, context: context)
+        PlaylistPlayback.play(song, from: playlist, context: context)
     }
 
     /// Non-nil only for a playlist the signed-in user owns. Favorites is

--- a/Twinskaraoke/Services/Audio/PlaylistPlayback.swift
+++ b/Twinskaraoke/Services/Audio/PlaylistPlayback.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Keeps recently played history tied to explicit playback from a playlist.
+@MainActor
+enum PlaylistPlayback {
+    static func play(_ song: Song, from playlist: Playlist, context: [Song]) {
+        RecentlyPlayedStore.shared.record(playlist)
+        AudioPlayerManager.shared.play(song: song, context: context)
+    }
+
+    static func playInOrder(_ song: Song, from playlist: Playlist, context: [Song]) {
+        RecentlyPlayedStore.shared.record(playlist)
+        AudioPlayerManager.shared.playInOrder(song: song, context: context)
+    }
+
+    static func playShuffled(from playlist: Playlist, songs: [Song]) {
+        guard !songs.isEmpty else { return }
+        RecentlyPlayedStore.shared.record(playlist)
+        AudioPlayerManager.shared.playShuffled(from: songs)
+    }
+}

--- a/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
+++ b/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
@@ -9,11 +9,13 @@ final class RecentlyPlayedStore {
     private static let storageKey = "nk.recentlyPlayed.playlists.v1"
     private static let limit = 20
     private(set) var playlists: [Playlist] = []
+
     private init() {
-        if ProcessInfo.processInfo.arguments.contains("-UITestResetRecentlyPlayed") {
-            UserDefaults.standard.removeObject(forKey: Self.storageKey)
-        }
         load()
+    }
+
+    static func resetPersistedHistoryForUITesting() {
+        UserDefaults.standard.removeObject(forKey: Self.storageKey)
     }
 
     func record(_ playlist: Playlist) {

--- a/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
+++ b/Twinskaraoke/Services/User/RecentlyPlayedStore.swift
@@ -10,6 +10,9 @@ final class RecentlyPlayedStore {
     private static let limit = 20
     private(set) var playlists: [Playlist] = []
     private init() {
+        if ProcessInfo.processInfo.arguments.contains("-UITestResetRecentlyPlayed") {
+            UserDefaults.standard.removeObject(forKey: Self.storageKey)
+        }
         load()
     }
 

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -180,6 +180,47 @@ final class TwinskaraokeUITests: XCTestCase {
     )
   }
 
+  func testOpeningPlaylistDoesNotAddItToRecentlyPlayed() throws {
+    let app = launchApp(initialSection: "search", resetRecentlyPlayed: true)
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
+    openVisibleItem("Public Playlists", identifier: "SearchCategory.PublicPlaylists", in: app)
+    openVisibleItem(
+      "Karaoke Essentials",
+      identifier: "PlaylistList.ui-search-playlist-essentials",
+      in: app
+    )
+    XCTAssertTrue(
+      app.staticTexts["Karaoke Essentials"].waitForExistence(timeout: 8)
+        || app.navigationBars["Karaoke Essentials"].waitForExistence(timeout: 8),
+      "Expected the playlist detail to open before checking playback history."
+    )
+
+    openRootSection("Home", in: app)
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 8))
+    XCTAssertFalse(
+      accessibleElementExists(identifier: "Home.RecentlyPlayed", in: app, timeout: 2),
+      "Opening a playlist without playing from it must not add it to Recently Played."
+    )
+
+    openRootSection("Search", in: app)
+    scrollToVisibleItem(
+      "Wake Me Up Before You Go-Go",
+      identifier: "PlaylistDetail.song.0.ui-search-song-1",
+      in: app
+    )
+    let firstSong = element(identifier: "PlaylistDetail.song.0.ui-search-song-1", in: app)
+    XCTAssertTrue(
+      waitUntil(timeout: 5) { firstSong.isHittable && self.tapStartsPlayback(firstSong, in: app) },
+      "Expected deliberate playlist playback to start."
+    )
+
+    openRootSection("Home", in: app)
+    XCTAssertTrue(
+      accessibleElementExists(identifier: "Home.RecentlyPlayed", in: app, timeout: 5),
+      "Playing from the playlist must add it to Recently Played."
+    )
+  }
+
   /// Swiping a zoom-pushed screen away must not start playback.
   ///
   /// Two ways it did, both measured on iOS 26.5 before `ZoomPushDismissal`
@@ -799,9 +840,15 @@ final class TwinskaraokeUITests: XCTestCase {
     )
   }
 
-  private func launchApp(initialSection: String? = nil) -> XCUIApplication {
+  private func launchApp(
+    initialSection: String? = nil,
+    resetRecentlyPlayed: Bool = false
+  ) -> XCUIApplication {
     let app = XCUIApplication()
     app.launchArguments += ["-UITestMode", "1"]
+    if resetRecentlyPlayed {
+      app.launchArguments.append("-UITestResetRecentlyPlayed")
+    }
     if let initialSection {
       app.launchArguments += ["-UITestInitialSection", initialSection]
     }


### PR DESCRIPTION
## Summary

- stop recording a playlist merely because its detail screen disappears
- record Recently Played history from actual song, Play, Shuffle, and playlist-menu playback actions
- add an end-to-end regression that proves opening alone does not create history while deliberate playback does

## Testing

- targeted Recently Played UI regression passed on an iPhone 17 Pro simulator
- all 154 unit tests passed

## Summary by Sourcery

Tie Recently Played playlist history to explicit playback actions and prevent passive playlist navigation from creating history.

Bug Fixes:
- Record playlists in Recently Played only when playback is explicitly initiated, rather than when a playlist detail view is opened or dismissed.

Enhancements:
- Centralize playlist playback handling across playlist detail views, menus, library actions, and CarPlay so all deliberate playback actions update history consistently.

Tests:
- Add an end-to-end regression covering both non-recording playlist navigation and recording after deliberate playback.