### PR TITLE
Harden companion app async task lifecycles

### DIFF
--- a/TwinskaraokeShared/Models/UserPlaylist.swift
+++ b/TwinskaraokeShared/Models/UserPlaylist.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct UserPlaylist: Codable, Identifiable, Hashable {
+nonisolated struct UserPlaylist: Codable, Identifiable, Hashable, Sendable {
     let id: String
     let name: String
     let description: String?
@@ -52,7 +52,7 @@ struct UserPlaylist: Codable, Identifiable, Hashable {
     }
 }
 
-struct UserPlaylistMedia: Codable {
+nonisolated struct UserPlaylistMedia: Codable, Sendable {
     let id: String?
     let fileName: String?
     let contentType: String?

--- a/TwinskaraokeTVApp/Models/SearchViewModel.swift
+++ b/TwinskaraokeTVApp/Models/SearchViewModel.swift
@@ -28,6 +28,7 @@ final class SearchViewModel {
     var loadError: String?
 
     @ObservationIgnored private var queryToken = 0
+    @ObservationIgnored private var searchTask: Task<Void, Never>?
     @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
     @ObservationIgnored private var lastDispatchedQuery = ""
 
@@ -43,10 +44,7 @@ final class SearchViewModel {
             guard text != lastDispatchedQuery else { return }
             lastDispatchedQuery = text
             if text.isEmpty {
-                queryToken += 1
-                results = []
-                isLoading = false
-                loadError = nil
+                clearSearch()
             } else {
                 performSearch(query: text)
             }
@@ -54,22 +52,46 @@ final class SearchViewModel {
     }
 
     func performSearch(query: String) {
-        queryToken += 1
+        searchTask?.cancel()
+        queryToken &+= 1
         let token = queryToken
         isLoading = true
         loadError = nil
-        Task { [weak self] in
-            guard let self else { return }
-            defer { if queryToken == token { isLoading = false } }
+        searchTask = Task { [weak self] in
             do {
                 let items = try await KaraokeAPIClient.searchSongItems(query: query, pageSize: 40)
-                guard queryToken == token else { return }
-                results = items
+                try Task.checkCancellation()
+                guard let self, self.queryToken == token else { return }
+                self.results = items
+                self.finishSearch(token: token)
+            } catch is CancellationError {
+                return
             } catch {
-                guard queryToken == token else { return }
-                results = []
-                loadError = "Check your connection and try again."
+                guard let self, self.queryToken == token else { return }
+                self.results = []
+                self.loadError = "Check your connection and try again."
+                self.finishSearch(token: token)
             }
         }
+    }
+
+    private func clearSearch() {
+        searchTask?.cancel()
+        searchTask = nil
+        queryToken &+= 1
+        results = []
+        isLoading = false
+        loadError = nil
+    }
+
+    private func finishSearch(token: Int) {
+        guard queryToken == token else { return }
+        searchTask = nil
+        isLoading = false
+    }
+
+    deinit {
+        searchDebounceTask?.cancel()
+        searchTask?.cancel()
     }
 }

--- a/TwinskaraokeTVApp/Services/TVAuthManager.swift
+++ b/TwinskaraokeTVApp/Services/TVAuthManager.swift
@@ -31,6 +31,7 @@ final class TVAuthManager {
     }
 
     @ObservationIgnored private var qrTask: Task<Void, Never>?
+    @ObservationIgnored private var sessionExpiredObserver: NSObjectProtocol?
 
     private let defaults = UserDefaults.standard
 
@@ -52,7 +53,7 @@ final class TVAuthManager {
 
     init() {
         loadPersistedSession()
-        NotificationCenter.default.addObserver(
+        sessionExpiredObserver = NotificationCenter.default.addObserver(
             forName: .karaokeSessionExpired,
             object: nil,
             queue: .main
@@ -60,6 +61,13 @@ final class TVAuthManager {
             Task { @MainActor [weak self] in
                 await self?.expireSession()
             }
+        }
+    }
+
+    isolated deinit {
+        qrTask?.cancel()
+        if let sessionExpiredObserver {
+            NotificationCenter.default.removeObserver(sessionExpiredObserver)
         }
     }
 

--- a/TwinskaraokeWatchApp/Models/Library/FavoritesViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/FavoritesViewModel.swift
@@ -19,26 +19,56 @@ final class FavoritesViewModel {
     /// when the truth is "could not ask".
     var needsPhoneSession = false
 
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var loadGeneration = 0
+    @ObservationIgnored private let isAuthenticated: @Sendable () -> Bool
+    @ObservationIgnored private let loadSongs: @Sendable () async throws -> [Song]
+
+    init(
+        isAuthenticated: @escaping @Sendable () -> Bool = { CredentialStore.isAuthenticated },
+        loadSongs: @escaping @Sendable () async throws -> [Song] = {
+            try await KaraokeAPIClient.favoriteSongs()
+        }
+    ) {
+        self.isAuthenticated = isAuthenticated
+        self.loadSongs = loadSongs
+    }
+
+    isolated deinit {
+        loadTask?.cancel()
+    }
+
     func fetch(force: Bool = false) {
-        guard !isLoading else { return }
-        guard force || songs.isEmpty else { return }
-        guard CredentialStore.isAuthenticated else {
+        guard isAuthenticated() else {
+            cancelLoad()
             songs = []
             loadError = nil
             needsPhoneSession = true
             return
         }
+        guard !isLoading else { return }
+        guard force || songs.isEmpty else { return }
+
+        loadGeneration &+= 1
+        let generation = loadGeneration
+        let loader = loadSongs
         needsPhoneSession = false
         isLoading = true
         loadError = nil
-        Task { [weak self] in
-            guard let self else { return }
-            defer { isLoading = false }
+        loadTask = Task { [weak self] in
             do {
-                songs = try await KaraokeAPIClient.favoriteSongs()
-                needsPhoneSession = false
+                let loaded = try await loader()
+                try Task.checkCancellation()
+                guard let self, self.loadGeneration == generation else { return }
+                self.songs = loaded
+                self.needsPhoneSession = false
+                self.finishLoad(generation: generation)
+            } catch is CancellationError {
+                self?.finishLoad(generation: generation)
             } catch {
-                loadError = "Check your connection and try again."
+                guard let self, self.loadGeneration == generation else { return }
+                self.loadError = "Check your connection and try again."
+                self.finishLoad(generation: generation)
             }
         }
     }
@@ -50,8 +80,22 @@ final class FavoritesViewModel {
     }
 
     func reset() {
+        cancelLoad()
         songs = []
         loadError = nil
         needsPhoneSession = false
+    }
+
+    private func cancelLoad() {
+        loadGeneration &+= 1
+        loadTask?.cancel()
+        loadTask = nil
+        isLoading = false
+    }
+
+    private func finishLoad(generation: Int) {
+        guard loadGeneration == generation else { return }
+        loadTask = nil
+        isLoading = false
     }
 }

--- a/TwinskaraokeWatchApp/Models/Library/UserPlaylistsViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Library/UserPlaylistsViewModel.swift
@@ -16,26 +16,57 @@ final class UserPlaylistsViewModel {
     /// of showing a misleading empty state.
     var loadError: String?
 
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var loadGeneration = 0
+    @ObservationIgnored private let isAuthenticated: @Sendable () -> Bool
+    @ObservationIgnored private let loadPlaylists: @Sendable () async throws -> [Playlist]
+
+    init(
+        isAuthenticated: @escaping @Sendable () -> Bool = { CredentialStore.isAuthenticated },
+        loadPlaylists: @escaping @Sendable () async throws -> [Playlist] = {
+            let request = try KaraokeAPIClient.request(path: "/api/user/playlists")
+            let data = try await KaraokeAPIClient.data(for: request)
+            return try JSONDecoder()
+                .decode([UserPlaylist].self, from: data)
+                .map { $0.asPlaylist() }
+        }
+    ) {
+        self.isAuthenticated = isAuthenticated
+        self.loadPlaylists = loadPlaylists
+    }
+
+    isolated deinit {
+        loadTask?.cancel()
+    }
+
     func fetch(force: Bool = false) {
-        guard !isLoading else { return }
-        guard force || playlists.isEmpty else { return }
-        guard CredentialStore.isAuthenticated else {
+        guard isAuthenticated() else {
+            cancelLoad()
             playlists = []
+            loadError = nil
             return
         }
+        guard !isLoading else { return }
+        guard force || playlists.isEmpty else { return }
+
+        loadGeneration &+= 1
+        let generation = loadGeneration
+        let loader = loadPlaylists
         isLoading = true
         loadError = nil
-        Task { [weak self] in
-            guard let self else { return }
-            defer { isLoading = false }
+        loadTask = Task { [weak self] in
             do {
-                let request = try KaraokeAPIClient.request(path: "/api/user/playlists")
-                let data = try await KaraokeAPIClient.data(for: request)
-                playlists = try JSONDecoder()
-                    .decode([UserPlaylist].self, from: data)
-                    .map { $0.asPlaylist() }
+                let loaded = try await loader()
+                try Task.checkCancellation()
+                guard let self, self.loadGeneration == generation else { return }
+                self.playlists = loaded
+                self.finishLoad(generation: generation)
+            } catch is CancellationError {
+                self?.finishLoad(generation: generation)
             } catch {
-                loadError = "Check your connection and try again."
+                guard let self, self.loadGeneration == generation else { return }
+                self.loadError = "Check your connection and try again."
+                self.finishLoad(generation: generation)
             }
         }
     }
@@ -43,7 +74,21 @@ final class UserPlaylistsViewModel {
     /// Called when the watch loses its session, so another account's playlists
     /// can't linger on screen.
     func reset() {
+        cancelLoad()
         playlists = []
         loadError = nil
+    }
+
+    private func cancelLoad() {
+        loadGeneration &+= 1
+        loadTask?.cancel()
+        loadTask = nil
+        isLoading = false
+    }
+
+    private func finishLoad(generation: Int) {
+        guard loadGeneration == generation else { return }
+        loadTask = nil
+        isLoading = false
     }
 }

--- a/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
@@ -29,6 +29,7 @@ final class SearchViewModel {
     /// of showing a misleading "no results" state.
     var loadError: String?
     @ObservationIgnored private var queryToken = 0
+    @ObservationIgnored private var searchTask: Task<Void, Never>?
     @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
     @ObservationIgnored private var lastDispatchedQuery = ""
 
@@ -44,10 +45,7 @@ final class SearchViewModel {
             guard text != lastDispatchedQuery else { return }
             lastDispatchedQuery = text
             if text.isEmpty {
-                queryToken += 1
-                results = []
-                isLoading = false
-                loadError = nil
+                clearSearch()
             } else {
                 performSearch(query: text)
             }
@@ -55,26 +53,46 @@ final class SearchViewModel {
     }
 
     func performSearch(query: String) {
-        queryToken += 1
+        searchTask?.cancel()
+        queryToken &+= 1
         let token = queryToken
         isLoading = true
         loadError = nil
-        Task { [weak self] in
-            guard let self else { return }
-            defer {
-                // Only the latest query clears the spinner; a stale completion
-                // must not hide the loader while a newer search is in flight.
-                if queryToken == token { isLoading = false }
-            }
+        searchTask = Task { [weak self] in
             do {
                 let items = try await KaraokeAPIClient.searchSongItems(query: query, pageSize: 20)
-                guard queryToken == token else { return }
-                results = items
+                try Task.checkCancellation()
+                guard let self, self.queryToken == token else { return }
+                self.results = items
+                self.finishSearch(token: token)
+            } catch is CancellationError {
+                return
             } catch {
-                guard queryToken == token else { return }
-                results = []
-                loadError = "Check your connection and try again."
+                guard let self, self.queryToken == token else { return }
+                self.results = []
+                self.loadError = "Check your connection and try again."
+                self.finishSearch(token: token)
             }
         }
+    }
+
+    private func clearSearch() {
+        searchTask?.cancel()
+        searchTask = nil
+        queryToken &+= 1
+        results = []
+        isLoading = false
+        loadError = nil
+    }
+
+    private func finishSearch(token: Int) {
+        guard queryToken == token else { return }
+        searchTask = nil
+        isLoading = false
+    }
+
+    deinit {
+        searchDebounceTask?.cancel()
+        searchTask?.cancel()
     }
 }

--- a/TwinskaraokeWatchAppTests/WatchAccountViewModelTests.swift
+++ b/TwinskaraokeWatchAppTests/WatchAccountViewModelTests.swift
@@ -1,0 +1,98 @@
+import Testing
+@testable import Twinskaraoke_Watch_App
+
+@MainActor
+@Suite("Watch account view models")
+struct WatchAccountViewModelTests {
+    @Test("A late favorites response cannot restore signed-out data")
+    func favoritesResetRejectsLateResponse() async {
+        let loader = SuspendedLoader<[Song]>()
+        let viewModel = FavoritesViewModel(
+            isAuthenticated: { true },
+            loadSongs: { await loader.value() }
+        )
+
+        viewModel.fetch(force: true)
+        await loader.waitUntilStarted()
+        #expect(viewModel.isLoading)
+
+        viewModel.reset()
+        #expect(!viewModel.isLoading)
+        #expect(viewModel.songs.isEmpty)
+
+        await loader.resume(returning: [makeSong(id: "previous-account-favorite")])
+        await settleTasks()
+
+        #expect(viewModel.songs.isEmpty)
+        #expect(viewModel.loadError == nil)
+        #expect(!viewModel.isLoading)
+    }
+
+    @Test("A late playlist response cannot restore signed-out data")
+    func playlistsResetRejectsLateResponse() async {
+        let loader = SuspendedLoader<[Playlist]>()
+        let viewModel = UserPlaylistsViewModel(
+            isAuthenticated: { true },
+            loadPlaylists: { await loader.value() }
+        )
+
+        viewModel.fetch(force: true)
+        await loader.waitUntilStarted()
+        #expect(viewModel.isLoading)
+
+        viewModel.reset()
+        #expect(!viewModel.isLoading)
+        #expect(viewModel.playlists.isEmpty)
+
+        await loader.resume(returning: [makePlaylist(id: "previous-account-playlist")])
+        await settleTasks()
+
+        #expect(viewModel.playlists.isEmpty)
+        #expect(viewModel.loadError == nil)
+        #expect(!viewModel.isLoading)
+    }
+
+    private func makeSong(id: String) -> Song {
+        UITestFixtures.song(id: id, title: id, artist: "Artist")
+    }
+
+    private func makePlaylist(id: String) -> Playlist {
+        Playlist(
+            id: id,
+            name: id,
+            songCount: 0,
+            mosaicMedia: nil,
+            songListDTOs: [],
+            isPersonal: true
+        )
+    }
+
+    private func settleTasks() async {
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+    }
+}
+
+private actor SuspendedLoader<Value: Sendable> {
+    private var continuation: CheckedContinuation<Value, Never>?
+    private var started = false
+
+    func value() async -> Value {
+        started = true
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        while !started {
+            await Task.yield()
+        }
+    }
+
+    func resume(returning value: Value) {
+        continuation?.resume(returning: value)
+        continuation = nil
+    }
+}


### PR DESCRIPTION
## Summary

- prevent late watchOS Favorites and personal-playlist responses from restoring the previous account's data after sign-out
- cancel superseded watchOS and tvOS search requests instead of only discarding their eventual results
- make shared user-playlist wire models explicitly nonisolated and `Sendable` for Swift 6 task boundaries
- remove the tvOS account manager's block-observer leak and cancel its owned QR task during teardown
- add watchOS regressions for late account-scoped responses

## Testing

- Xcode static analysis passed for the iOS scheme
- full iOS unit suite passed
- full watchOS unit suite passed
- Debug builds passed for watchOS, tvOS, and macOS
- optimized Release build passed for iOS with the embedded watch app

## Summary by Sourcery

Harden companion-app asynchronous task lifecycles against stale responses, leaked observers, and teardown-related work.

Bug Fixes:
- Prevent late watchOS Favorites and personal-playlist responses from repopulating data after account reset or sign-out.
- Cancel superseded watchOS and tvOS search requests so stale asynchronous work cannot affect current results.

Enhancements:
- Make shared user-playlist models explicitly nonisolated and Sendable for Swift concurrency task boundaries.
- Ensure watchOS and tvOS view models cancel owned tasks during reset or deinitialization.
- Clean up the tvOS session-expiration observer and cancel its QR task during teardown.

Tests:
- Add watchOS regressions verifying that late Favorites and playlist responses cannot restore previous-account data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search reliability by canceling outdated requests and preventing stale results from replacing newer searches.
  * Clearing a search now consistently resets results and loading state.
  * Favorites and playlists no longer reappear after sign-out or reset when delayed responses arrive.
  * Improved handling of interrupted playlist and favorites loading.
  * Session and background tasks now clean up more reliably when leaving the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->