### PR TITLE
Show the active queue mode on the Playing Next button

### DIFF
--- a/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
+++ b/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
@@ -135,7 +135,7 @@ struct PlayerBottomToolbar: View {
             .font(.system(size: 9, weight: .bold))
             .foregroundStyle(.primary)
             .frame(width: 16, height: 16)
-            .background(Color.appControlInactiveFill, in: Circle())
+            .background(Color.appPlayerActionFill, in: Circle())
             .offset(x: 2, y: -2)
             .transition(badgeTransition)
             .accessibilityHidden(true)

--- a/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
+++ b/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
@@ -4,13 +4,65 @@ import SwiftUI
     import UIKit
 #endif
 
+/// The active queue mode, drawn as a small glyph on the corner of the Playing
+/// Next button the way Apple Music does. Autoplay is deliberately absent: it is
+/// on by default, so badging it would mean a permanent glyph that says nothing —
+/// Apple Music leaves it out for the same reason. Only one glyph fits, so
+/// repeat outranks shuffle: repeat changes where the queue ends, which is the
+/// less obvious of the two once playback is under way.
+enum PlayerQueueModeBadge {
+    case shuffle, repeatAll, repeatOne
+
+    var symbol: String {
+        switch self {
+        case .shuffle: "shuffle"
+        case .repeatAll: "repeat"
+        case .repeatOne: "repeat.1"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .shuffle: "Shuffle on"
+        case .repeatAll: "Repeat all"
+        case .repeatOne: "Repeat one"
+        }
+    }
+
+    static func resolve(isShuffled: Bool, repeatMode: RepeatMode) -> PlayerQueueModeBadge? {
+        switch repeatMode {
+        case .one: return .repeatOne
+        case .all: return .repeatAll
+        case .off: return isShuffled ? .shuffle : nil
+        }
+    }
+}
+
 struct PlayerBottomToolbar: View {
     @Environment(AudioPlayerManager.self) var audioManager
+    @Environment(\.appReduceMotion) private var reduceMotion
     @Binding var showingQueue: Bool
     let song: Song
     let onLyricsToggle: () -> Void
     let showLyrics: Bool
     var horizontalPadding: CGFloat = 48
+
+    /// Radio has no queue to shuffle or repeat, so the badge stays off there.
+    private var queueModeBadge: PlayerQueueModeBadge? {
+        guard !audioManager.isRadioMode else { return nil }
+        return PlayerQueueModeBadge.resolve(
+            isShuffled: audioManager.isShuffled,
+            repeatMode: audioManager.repeatMode
+        )
+    }
+
+    private var badgeAnimation: Animation? {
+        reduceMotion ? nil : AppMotion.snap
+    }
+
+    private var badgeTransition: AnyTransition {
+        reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.6))
+    }
 
     var body: some View {
         HStack(spacing: audioManager.isRadioMode ? 56 : 0) {
@@ -50,17 +102,39 @@ struct PlayerBottomToolbar: View {
                 Image(systemName: "list.bullet")
                     .font(.title3)
                     .foregroundStyle(.primary)
+                    .overlay(alignment: .topTrailing) { queueModeBadgeView }
                     .frame(width: 44, height: 44)
                     .frame(maxWidth: audioManager.isRadioMode ? nil : .infinity)
             }
             .buttonStyle(PressableButtonStyle(scale: 0.85, dim: 0.55))
             .accessibilityLabel("Playing Next")
+            .accessibilityValue(queueModeBadge?.label ?? "")
             .accessibilityHint("Show the queue for \(song.title)")
             .accessibilityIdentifier("PlayerToolbar.PlayingNext")
+            .animation(badgeAnimation, value: queueModeBadge?.symbol)
         }
         .padding(.horizontal, audioManager.isRadioMode ? 0 : horizontalPadding)
         .padding(.top, 16)
         .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var queueModeBadgeView: some View {
+        if let badge = queueModeBadge {
+            Group {
+                if reduceMotion {
+                    Image(systemName: badge.symbol)
+                } else {
+                    Image(systemName: badge.symbol)
+                        .contentTransition(.symbolEffect(.replace))
+                }
+            }
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(Color.appAccent)
+            .offset(x: 9, y: -8)
+            .transition(badgeTransition)
+            .accessibilityHidden(true)
+        }
     }
 
     private func routeSymbolName(_ name: String) -> String {

--- a/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
+++ b/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
@@ -102,8 +102,11 @@ struct PlayerBottomToolbar: View {
                 Image(systemName: "list.bullet")
                     .font(.title3)
                     .foregroundStyle(.primary)
-                    .overlay(alignment: .topTrailing) { queueModeBadgeView }
                     .frame(width: 44, height: 44)
+                    // Cornered on the button's frame rather than on the glyph:
+                    // the badge clears the list icon's top rule that way, so
+                    // the two never overlap at any Dynamic Type size.
+                    .overlay(alignment: .topTrailing) { queueModeBadgeView }
                     .frame(maxWidth: audioManager.isRadioMode ? nil : .infinity)
             }
             .buttonStyle(PressableButtonStyle(scale: 0.85, dim: 0.55))
@@ -130,8 +133,10 @@ struct PlayerBottomToolbar: View {
                 }
             }
             .font(.system(size: 9, weight: .bold))
-            .foregroundStyle(Color.appAccent)
-            .offset(x: 9, y: -8)
+            .foregroundStyle(.primary)
+            .frame(width: 16, height: 16)
+            .background(Color.appControlInactiveFill, in: Circle())
+            .offset(x: 2, y: -2)
             .transition(badgeTransition)
             .accessibilityHidden(true)
         }

--- a/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
+++ b/Twinskaraoke/Components/Player/PlayerBottomToolbar.swift
@@ -56,6 +56,16 @@ struct PlayerBottomToolbar: View {
         )
     }
 
+    /// Never blank: an empty string is still a value as far as VoiceOver is
+    /// concerned, and the plain case is worth hearing. A conditional
+    /// `accessibilityValue` would say nothing at all, but branching the
+    /// modifier changes the button's identity, which kills the badge's
+    /// transition every time a mode goes on or off.
+    private var queueModeAccessibilityValue: String {
+        if audioManager.isRadioMode { return "Live radio" }
+        return queueModeBadge?.label ?? "Playing in order"
+    }
+
     private var badgeAnimation: Animation? {
         reduceMotion ? nil : AppMotion.snap
     }
@@ -111,7 +121,7 @@ struct PlayerBottomToolbar: View {
             }
             .buttonStyle(PressableButtonStyle(scale: 0.85, dim: 0.55))
             .accessibilityLabel("Playing Next")
-            .accessibilityValue(queueModeBadge?.label ?? "")
+            .accessibilityValue(queueModeAccessibilityValue)
             .accessibilityHint("Show the queue for \(song.title)")
             .accessibilityIdentifier("PlayerToolbar.PlayingNext")
             .animation(badgeAnimation, value: queueModeBadge?.symbol)
@@ -124,21 +134,15 @@ struct PlayerBottomToolbar: View {
     @ViewBuilder
     private var queueModeBadgeView: some View {
         if let badge = queueModeBadge {
-            Group {
-                if reduceMotion {
-                    Image(systemName: badge.symbol)
-                } else {
-                    Image(systemName: badge.symbol)
-                        .contentTransition(.symbolEffect(.replace))
-                }
-            }
-            .font(.system(size: 9, weight: .bold))
-            .foregroundStyle(.primary)
-            .frame(width: 16, height: 16)
-            .background(Color.appPlayerActionFill, in: Circle())
-            .offset(x: 2, y: -2)
-            .transition(badgeTransition)
-            .accessibilityHidden(true)
+            Image(systemName: badge.symbol)
+                .contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(.primary)
+                .frame(width: 16, height: 16)
+                .background(Color.appPlayerActionFill, in: Circle())
+                .offset(x: 2, y: -2)
+                .transition(badgeTransition)
+                .accessibilityHidden(true)
         }
     }
 

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -132,6 +132,15 @@ nonisolated extension Color {
             light: UIColor.black.withAlphaComponent(0.08),
             dark: UIColor.white.withAlphaComponent(0.16)
         )
+        /// The circle under the player's round actions — favorite, more, the
+        /// lyrics-header chevron and the queue-mode badge. A shade deeper than
+        /// `appControlInactiveFill`, which washed out against the artwork
+        /// ambience; Apple Music's reads as a darker grey than the surface it
+        /// sits on rather than a light film over it.
+        static let appPlayerActionFill = adaptive(
+            light: UIColor.black.withAlphaComponent(0.12),
+            dark: UIColor.white.withAlphaComponent(0.10)
+        )
         static let appArtworkOverlay = adaptive(
             light: UIColor.white.withAlphaComponent(0.45),
             dark: UIColor.black.withAlphaComponent(0.40)

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -201,24 +201,37 @@ private struct PlayerLayoutMetrics {
 }
 
 /// The soft filled circle the player's actions sit on, Apple Music's treatment
-/// for favorite, more and the queue-mode badge on Playing Next. It is the
-/// shared control fill rather than a player-local grey so the three surfaces
-/// and the badge in ``PlayerBottomToolbar`` cannot drift apart.
-private let playerTitleButtonBackground = Color.appControlInactiveFill
+/// for favorite, more and the queue-mode badge on Playing Next. It is a theme
+/// token rather than a literal grey here so the three title surfaces and the
+/// badge in ``PlayerBottomToolbar`` cannot drift apart.
+private let playerTitleButtonBackground = Color.appPlayerActionFill
 
 private func playerTitleIconColor(isActive _: Bool = false) -> Color {
     Color.primary
 }
 
+/// How far the filled circle sits inside the button's hit target. The tap area
+/// stays a full 44pt; only the circle shrinks, so it hugs the glyph the way
+/// Apple Music's does instead of filling the whole target.
+private let playerTitleButtonChromeInset: CGFloat = 10
+
 private extension View {
-    /// The circular background worn by the player's title-surface buttons.
-    /// The iPad control bar sits on its own glass and skips it.
+    /// The circular background worn by the player's title-surface buttons, and
+    /// the hit target underneath it. The iPad control bar sits on its own glass
+    /// and skips the circle, but keeps the target.
     @ViewBuilder
-    func playerTitleButtonChrome(_ isVisible: Bool) -> some View {
+    func playerTitleButtonChrome(_ isVisible: Bool, size: CGFloat) -> some View {
         if isVisible {
-            background(playerTitleButtonBackground, in: Circle())
+            frame(
+                width: size - playerTitleButtonChromeInset,
+                height: size - playerTitleButtonChromeInset
+            )
+            .background(playerTitleButtonBackground, in: Circle())
+            .frame(width: size, height: size)
+            .contentShape(Rectangle())
         } else {
-            self
+            frame(width: size, height: size)
+                .contentShape(Rectangle())
         }
     }
 }
@@ -258,9 +271,7 @@ private struct PlayerFavoriteButton: View {
             }
             .font(font)
             .foregroundStyle(playerTitleIconColor(isActive: isFavorite))
-            .frame(width: size, height: size)
-            .contentShape(Rectangle())
-            .playerTitleButtonChrome(showsChrome)
+            .playerTitleButtonChrome(showsChrome, size: size)
         }
         .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6))
         .accessibilityLabel(isFavorite ? "Remove from Favorites" : "Add to Favorites")
@@ -285,9 +296,7 @@ private struct PlayerMoreMenu: View {
             Image(systemName: "ellipsis")
                 .font(font)
                 .foregroundStyle(playerTitleIconColor())
-                .frame(width: size, height: size)
-                .contentShape(Rectangle())
-                .playerTitleButtonChrome(showsChrome)
+                .playerTitleButtonChrome(showsChrome, size: size)
         }
         .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .selection))
         .accessibilityLabel("More")
@@ -891,8 +900,7 @@ struct FullScreenPlayerView: View {
                 Image(systemName: "chevron.down")
                     .font(.headline.bold())
                     .foregroundStyle(playerTitleIconColor())
-                    .frame(width: 44, height: 44)
-                    .playerTitleButtonChrome(true)
+                    .playerTitleButtonChrome(true, size: 44)
             }
             .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .selection))
             .accessibilityLabel("Hide lyrics")

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -200,25 +200,23 @@ private struct PlayerLayoutMetrics {
     }
 }
 
-private let playerTitleButtonBackground = Color.clear
-
-private var playerTitleButtonBorder: some View {
-    Circle()
-        .stroke(Color.primary.opacity(0.08), lineWidth: 0.6)
-}
+/// The soft filled circle the player's actions sit on, Apple Music's treatment
+/// for favorite, more and the queue-mode badge on Playing Next. It is the
+/// shared control fill rather than a player-local grey so the three surfaces
+/// and the badge in ``PlayerBottomToolbar`` cannot drift apart.
+private let playerTitleButtonBackground = Color.appControlInactiveFill
 
 private func playerTitleIconColor(isActive _: Bool = false) -> Color {
     Color.primary
 }
 
 private extension View {
-    /// The circular background/border worn by the player's title-surface
-    /// buttons. The iPad control bar sits on its own glass and skips it.
+    /// The circular background worn by the player's title-surface buttons.
+    /// The iPad control bar sits on its own glass and skips it.
     @ViewBuilder
     func playerTitleButtonChrome(_ isVisible: Bool) -> some View {
         if isVisible {
             background(playerTitleButtonBackground, in: Circle())
-                .overlay(playerTitleButtonBorder)
         } else {
             self
         }
@@ -894,8 +892,7 @@ struct FullScreenPlayerView: View {
                     .font(.headline.bold())
                     .foregroundStyle(playerTitleIconColor())
                     .frame(width: 44, height: 44)
-                    .background(playerTitleButtonBackground, in: Circle())
-                    .overlay(playerTitleButtonBorder)
+                    .playerTitleButtonChrome(true)
             }
             .buttonStyle(PressableButtonStyle(scale: 0.88, dim: 0.6, haptic: .selection))
             .accessibilityLabel("Hide lyrics")


### PR DESCRIPTION
The player's bottom toolbar gave no sign of the queue modes set inside the queue sheet, so a shuffled or repeating queue looked identical to a plain one until the sheet was opened again. Apple Music badges its Playing Next button with the active mode; this does the same.

**The badge.** A small glyph on the top-right corner of the Playing Next button: `shuffle`, `repeat` or `repeat.1`. Only one glyph fits, so repeat outranks shuffle — repeat changes where the queue ends, which is the less obvious of the two once playback is under way. Autoplay is deliberately left out: it is on by default, so badging it would mean a permanent glyph that carries no information, and Apple Music omits it for the same reason. Radio has no queue to shuffle or repeat, so the badge stays off there.

The glyph swaps with a symbol replace effect and scales in and out on the shared snap spring, both dropped under reduce motion. It is cornered on the button's frame rather than on the list glyph, which keeps it clear of the icon's top rule at every Dynamic Type size, and the button now carries an accessibility value naming the active mode.

**The round actions.** The favorite toggle, the overflow menu and the lyrics-header chevron wore a transparent circle with a hairline border, which read as bare glyphs floating on the artwork, and the circle took up the whole 44pt hit target. They now sit on a filled circle inset 10pt inside the target, so the fill hugs the glyph while the frame that draws it stays separate from the frame that catches the tap — the buttons are still a full 44pt to hit. The iPad landscape control bar already sits on its own glass and still skips the circle.

The fill is a new `appPlayerActionFill` token rather than the shared `appControlInactiveFill`, which washed out against the artwork ambience: a shade deeper in light appearance, and less milky in dark so it reads as a darker grey than the surface instead of a film over it. The badge tracks the same token, so all four circles stay in step.

Verified with a clean iOS build; the styling was checked on device.

## Summary by Sourcery

Expose queue modes in the player toolbar and unify the visual treatment of round player actions.

New Features:
- Show the active shuffle or repeat mode on the Playing Next button, with corresponding accessibility values and motion-aware transitions.

Enhancements:
- Refresh player action controls with inset filled circular styling while preserving full-size tap targets and platform-specific control-bar behavior.
- Add a dedicated adaptive theme color for player action surfaces and queue-mode badges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible shuffle and repeat status badges to the Playing Next button, with accessible labels and motion-sensitive animations.
* **Style**
  * Updated player action buttons with adaptive circular backgrounds for improved contrast in light and dark appearances.
  * Refined button sizing and visual insets while preserving full tap areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->