### PR TITLE
Polish playback architecture, adaptive UI, and release performance

### DIFF
--- a/Twinskaraoke.xcodeproj/project.pbxproj
+++ b/Twinskaraoke.xcodeproj/project.pbxproj
@@ -534,7 +534,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2640;
-				LastUpgradeCheck = 2640;
+				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					D0AA0000000000000000E003 = {
 						CreatedOnToolsVersion = 26.4.1;
@@ -969,6 +969,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -998,6 +999,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1021,6 +1023,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1031,6 +1034,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1060,6 +1064,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -1076,6 +1081,7 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 			};
 			name = Release;
@@ -1178,7 +1184,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1222,7 +1228,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1252,7 +1258,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1280,7 +1286,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1307,7 +1313,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1333,7 +1339,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GQCU59RKTN;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Twinskaraoke/App/ContentView.swift
+++ b/Twinskaraoke/App/ContentView.swift
@@ -84,7 +84,7 @@ private struct PopupHostView: View {
     }
 
     private func usesSidebarShell(availableWidth: CGFloat) -> Bool {
-        guard AM.Layout.usesWideCanvas(
+        guard AM.Layout.usesSidebarCanvas(
             horizontalSizeClass: horizontalSizeClass,
             availableWidth: availableWidth
         ) else { return false }

--- a/Twinskaraoke/App/TwinskaraokeApp.swift
+++ b/Twinskaraoke/App/TwinskaraokeApp.swift
@@ -11,6 +11,7 @@ struct TwinskaraokeApp: App {
     @AppStorage(AppLanguage.storageKey) private var languageMode: String = AppLanguage.system.rawValue
 
     init() {
+        AppPerformance.event("App Initialization")
         if AppRuntime.isUITestMode,
            ProcessInfo.processInfo.arguments.contains("-UITestResetRecentlyPlayed")
         {

--- a/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
+++ b/Twinskaraoke/Components/Media/RemoteArtworkImage.swift
@@ -352,7 +352,7 @@ struct CenteredLoadingView: View {
 
 struct MusicSkeletonShimmer: ViewModifier {
     var isActive: Bool
-    @Environment(\.appReduceMotion) private var reduceMotion
+    @Environment(\.appReduceEffects) private var reduceEffects
     private let scrollState = ScrollPerformanceState.shared
     @State private var phase: CGFloat = -0.8
 
@@ -378,7 +378,7 @@ struct MusicSkeletonShimmer: ViewModifier {
     private var effectiveActive: Bool {
         isActive
             && !scrollState.isScrolling
-            && !reduceMotion
+            && !reduceEffects
     }
 
     private func restartIfNeeded(active: Bool) {

--- a/Twinskaraoke/Components/Player/EqualizerBars.swift
+++ b/Twinskaraoke/Components/Player/EqualizerBars.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct EqualizerBars: View {
     let isAnimating: Bool
-    @Environment(\.appReduceMotion) private var reduceMotion
+    @Environment(\.appReduceEffects) private var reduceEffects
     private let scrollState = ScrollPerformanceState.shared
     @State private var startDate = Date()
     @State private var isVisible: Bool = false
@@ -49,6 +49,6 @@ struct EqualizerBars: View {
     }
 
     private var shouldAnimateBars: Bool {
-        isAnimating && isVisible && !reduceMotion && !scrollState.isScrolling
+        isAnimating && isVisible && !reduceEffects && !scrollState.isScrolling
     }
 }

--- a/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
+++ b/Twinskaraoke/Components/Player/PlayerAmbientBackground.swift
@@ -9,6 +9,7 @@ struct PlayerAmbientBackground: View {
     let artworkURL: URL?
     var isPlaying: Bool = true
     @Environment(\.appReduceMotion) private var reduceMotion
+    @Environment(\.appReduceEffects) private var reduceEffects
     @State private var palette: ArtworkPalette = .placeholder
     @State private var paletteSourceURL: URL?
     /// Breath time already run before the current stretch of playback.
@@ -17,7 +18,7 @@ struct PlayerAmbientBackground: View {
     @State private var breathResumedAt = Date()
 
     private var shouldAnimateAmbient: Bool {
-        isPlaying && !reduceMotion
+        isPlaying && !reduceEffects
     }
 
     /// Seconds for one full out-and-back breath.

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -247,6 +247,12 @@ enum AM {
         static let wideContentMaxWidth: CGFloat = 1180
         static let wideRailMaxWidth: CGFloat = 740
         static let wideInspectorWidth: CGFloat = 340
+        /// A 13-inch iPad is 1376pt wide in landscape. Its balanced sidebar
+        /// consumes 330pt, leaving a 1046pt detail canvas; using the former
+        /// 1050pt threshold for both shell and content meant the largest iPad
+        /// opened a sidebar and then missed every wide content layout by 4pt.
+        static let wideCanvasMinimumWidth: CGFloat = 980
+        static let sidebarMinimumWidth: CGFloat = 1050
 
         static func usesWideCanvas(
             horizontalSizeClass: UserInterfaceSizeClass?,
@@ -259,7 +265,14 @@ enum AM {
                 }
             #endif
             guard let availableWidth else { return false }
-            return availableWidth >= 1050
+            return availableWidth >= wideCanvasMinimumWidth
+        }
+
+        static func usesSidebarCanvas(
+            horizontalSizeClass: UserInterfaceSizeClass?,
+            availableWidth: CGFloat
+        ) -> Bool {
+            horizontalSizeClass == .regular && availableWidth >= sidebarMinimumWidth
         }
 
         static func shelfTileWidth(for availableWidth: CGFloat, compact: Bool = false) -> CGFloat {

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -272,7 +272,16 @@ enum AM {
             horizontalSizeClass: UserInterfaceSizeClass?,
             availableWidth: CGFloat
         ) -> Bool {
-            horizontalSizeClass == .regular && availableWidth >= sidebarMinimumWidth
+            guard horizontalSizeClass == .regular else { return false }
+            #if canImport(UIKit)
+                // Mac idiom windows keep desktop navigation even when resized
+                // below the iPad sidebar threshold. Falling back to a tab bar
+                // here is a platform regression, not an adaptive layout.
+                if UIDevice.current.userInterfaceIdiom == .mac {
+                    return true
+                }
+            #endif
+            return availableWidth >= sidebarMinimumWidth
         }
 
         static func shelfTileWidth(for availableWidth: CGFloat, compact: Bool = false) -> CGFloat {

--- a/Twinskaraoke/Components/Shared/MarqueeText.swift
+++ b/Twinskaraoke/Components/Shared/MarqueeText.swift
@@ -34,7 +34,7 @@ struct MarqueeText: View {
     /// display link alive to scroll text nobody can see.
     var isPaused: Bool = false
 
-    @Environment(\.appReduceMotion) private var reduceMotion
+    @Environment(\.appReduceEffects) private var reduceEffects
     @State private var textSize: CGSize = .zero
     @State private var containerWidth: CGFloat = 0
 
@@ -54,7 +54,7 @@ struct MarqueeText: View {
     @State private var startDate = Date()
 
     private var needsScroll: Bool {
-        !reduceMotion && containerWidth > 0 && textSize.width > containerWidth + 0.5
+        !reduceEffects && containerWidth > 0 && textSize.width > containerWidth + 0.5
     }
 
     private var isScrolling: Bool {

--- a/Twinskaraoke/Components/Shared/MarqueeText.swift
+++ b/Twinskaraoke/Components/Shared/MarqueeText.swift
@@ -153,6 +153,12 @@ struct MarqueeText: View {
             .onChange(of: text) {
                 restartCycle()
             }
+            // The timeline is removed while decorative effects are reduced.
+            // Start from a fresh dwell when it returns instead of including
+            // the paused interval in the elapsed phase.
+            .onChange(of: reduceEffects) { _, shouldReduce in
+                if !shouldReduce { restartCycle() }
+            }
             // Resuming starts a fresh dwell rather than picking the pass up
             // where it left off. A host only pauses this when it is covered, so
             // there is no jump to see, and coming back to a title that starts

--- a/Twinskaraoke/Features/CarPlay/CarPlaySceneDelegate.swift
+++ b/Twinskaraoke/Features/CarPlay/CarPlaySceneDelegate.swift
@@ -449,10 +449,17 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     }
 
     private func playlistListItem(_ playlist: Playlist) -> CPListItem {
-        let item = CPListItem(text: playlist.name, detailText: playlistDetailText(playlist))
+        let item = CPListItem(
+            text: playlist.name,
+            detailText: playlistDetailText(playlist),
+            image: fallbackPlaylistImage(for: playlist),
+            accessoryImage: nil,
+            accessoryType: .disclosureIndicator
+        )
         item.handler = { [weak self] _, completion in
             self?.showPlaylist(playlist, completion: completion)
         }
+        loadPlaylistArtwork(for: playlist, into: item)
         return item
     }
 
@@ -806,9 +813,22 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         }
     }
 
+    private func loadPlaylistArtwork(for playlist: Playlist, into item: CPListItem) {
+        guard !playlist.isFavorites else { return }
+        guard let sourceURL = playlist.explicitCoverThumbnailURL
+            ?? playlist.initialMosaicArtworkURLs.first
+        else { return }
+        let url = ArtworkURLBuilder.variantURL(from: sourceURL, variant: .row) ?? sourceURL
+        loadArtwork(from: url, into: item)
+    }
+
     private func loadRadioArtwork(for song: RadioNowPlaying.SongInfo, into item: CPListItem) {
         guard let artworkURL = song.artworkURL else { return }
         let url = ArtworkURLBuilder.variantURL(from: artworkURL, variant: .row) ?? artworkURL
+        loadArtwork(from: url, into: item)
+    }
+
+    private func loadArtwork(from url: URL, into item: CPListItem) {
         let targetSize = carPlayListArtworkSize()
         let displayScale = interfaceController?.carTraitCollection.displayScale ?? 2
         artworkLoader.loadImage(from: url, targetSize: targetSize, displayScale: displayScale) { [weak item] image in
@@ -832,6 +852,12 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     private func fallbackRadioImage() -> UIImage {
         let configuration = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
         return UIImage(systemName: "dot.radiowaves.left.and.right", withConfiguration: configuration) ?? fallbackSongImage()
+    }
+
+    private func fallbackPlaylistImage(for playlist: Playlist) -> UIImage {
+        let symbol = playlist.isFavorites ? "star.fill" : "music.note.list"
+        let configuration = UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold)
+        return UIImage(systemName: symbol, withConfiguration: configuration) ?? fallbackSongImage()
     }
 
     private func play(_ song: Song, in context: [Song], playlist: Playlist? = nil) {
@@ -884,9 +910,15 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
 
 @MainActor
 private final class CarPlayArtworkLoader {
-    private let cache = NSCache<NSURL, UIImage>()
-    private var operations: [NSURL: any SDWebImageOperation] = [:]
-    private var completions: [NSURL: [@MainActor (UIImage) -> Void]] = [:]
+    private let cache = NSCache<NSString, UIImage>()
+    private var operations: [NSString: any SDWebImageOperation] = [:]
+    private var completions: [NSString: [@MainActor (UIImage) -> Void]] = [:]
+    private var generation = 0
+
+    init() {
+        cache.countLimit = 96
+        cache.totalCostLimit = 12 * 1_024 * 1_024
+    }
 
     func loadImage(
         from url: URL,
@@ -894,7 +926,8 @@ private final class CarPlayArtworkLoader {
         displayScale: CGFloat,
         completion: @escaping @MainActor (UIImage) -> Void
     ) {
-        let cacheKey = url as NSURL
+        let maxPixel = max(targetSize.width, targetSize.height) * max(displayScale, 1)
+        let cacheKey = NSString(string: "\(url.absoluteString)#\(Int(maxPixel.rounded(.up)))")
         if let cached = cache.object(forKey: cacheKey) {
             completion(cached)
             return
@@ -903,23 +936,17 @@ private final class CarPlayArtworkLoader {
         completions[cacheKey, default: []].append(completion)
         guard operations[cacheKey] == nil else { return }
 
+        let requestGeneration = generation
         operations[cacheKey] = SDWebImageManager.shared.loadImage(
             with: url,
             options: [],
             context: ImageCacheConfig.memoryAndDiskCacheContext,
             progress: nil
         ) { [weak self] image, _, _, _, _, _ in
-            guard let image else {
-                Task { @MainActor [weak self] in
-                    self?.finishLoading(cacheKey, image: nil)
-                }
-                return
-            }
-
-            let maxPixel = max(targetSize.width, targetSize.height) * max(displayScale, 1)
-            let processedImage = image.croppedToSquare().downscaled(maxPixel: maxPixel)
             Task { @MainActor [weak self] in
-                self?.finishLoading(cacheKey, image: processedImage)
+                guard let self, self.generation == requestGeneration else { return }
+                let processedImage = image?.croppedToSquare().downscaled(maxPixel: maxPixel)
+                self.finishLoading(cacheKey, image: processedImage)
             }
         }
     }
@@ -928,13 +955,15 @@ private final class CarPlayArtworkLoader {
         operations.values.forEach { $0.cancel() }
         operations.removeAll()
         completions.removeAll()
+        generation &+= 1
     }
 
-    private func finishLoading(_ cacheKey: NSURL, image: UIImage?) {
+    private func finishLoading(_ cacheKey: NSString, image: UIImage?) {
         operations[cacheKey] = nil
         let handlers = completions.removeValue(forKey: cacheKey) ?? []
         guard let image else { return }
-        cache.setObject(image, forKey: cacheKey)
+        let cost = image.cgImage.map { $0.bytesPerRow * $0.height } ?? 0
+        cache.setObject(image, forKey: cacheKey, cost: cost)
         handlers.forEach { $0(image) }
     }
 }

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -296,12 +296,6 @@ struct PlaylistDetailView: View {
                 .id(Self.contentAnchor)
             }
                 .padding(.bottom, 16)
-                .onGeometryChange(for: CGFloat.self) { proxy in
-                    proxy.size.width
-                } action: { width in
-                    guard width > 0, abs(width - contentWidth) > 0.5 else { return }
-                    contentWidth = width
-                }
                 // Row changes (e.g. unfavouriting) used to animate via the
                 // `filteredSongs` swap; now that the list is derived, the
                 // animation attaches to the value instead. Same 300-row
@@ -313,6 +307,18 @@ struct PlaylistDetailView: View {
                         : AppMotion.quick,
                     value: displayedSongs
                 )
+        }
+        // Measure the viewport, not the laid-out content. The former
+        // `onGeometryChange` lived on the content VStack; because its first
+        // pass used the 390pt compact fallback, the VStack reported that same
+        // intrinsic width and could never promote itself to the wide layout on
+        // iPad. Scroll geometry exposes the actual detail-column width without
+        // inserting the GeometryReader that breaks navigation-bar edge tracking.
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.containerSize.width
+        } action: { _, width in
+            guard width > 0, abs(width - contentWidth) > 0.5 else { return }
+            contentWidth = width
         }
         .smoothScrolling()
         .scrollEdgeHaptic()

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -8,13 +8,14 @@ private struct PlayerLayoutMetrics {
     let containerSize: CGSize
     let safeTop: CGFloat
     let safeBottom: CGFloat
+    let usesAccessibilityText: Bool
 
     private var contentHeight: CGFloat {
         max(1, containerSize.height - safeTop - safeBottom)
     }
 
     private var isCompactHeight: Bool {
-        contentHeight < 760
+        contentHeight < 760 || usesAccessibilityText
     }
 
     private var isWidePhone: Bool {
@@ -41,17 +42,19 @@ private struct PlayerLayoutMetrics {
 
     var horizontalPadding: CGFloat {
         if usesPadLayout { return 0 }
+        if usesAccessibilityText { return 20 }
         if isWidePhone { return 34 }
         return isCompactHeight ? 24 : 28
     }
 
     var toolbarHorizontalPadding: CGFloat {
-        isCompactHeight ? 38 : 48
+        if usesAccessibilityText { return 28 }
+        return isCompactHeight ? 38 : 48
     }
 
     var artSize: CGFloat {
         let widthBound = containerSize.width - (horizontalPadding * 2)
-        let heightFraction = contentHeight * (isCompactHeight ? 0.43 : 0.48)
+        let heightFraction = contentHeight * (usesAccessibilityText ? 0.34 : (isCompactHeight ? 0.43 : 0.48))
         let maxSize: CGFloat = isWidePhone ? 390 : 360
         return min(widthBound, heightFraction, maxSize)
     }
@@ -126,11 +129,13 @@ private struct PlayerLayoutMetrics {
     }
 
     var artworkTopSpacer: CGFloat {
-        isCompactHeight ? 10 : 20
+        if usesAccessibilityText { return 4 }
+        return isCompactHeight ? 10 : 20
     }
 
     var artworkBottomSpacer: CGFloat {
-        isCompactHeight ? 18 : 28
+        if usesAccessibilityText { return 10 }
+        return isCompactHeight ? 18 : 28
     }
 
     var lyricsTopSpacer: CGFloat {
@@ -142,15 +147,18 @@ private struct PlayerLayoutMetrics {
     }
 
     var progressTopPadding: CGFloat {
-        isCompactHeight ? 10 : 16
+        if usesAccessibilityText { return 6 }
+        return isCompactHeight ? 10 : 16
     }
 
     var controlsTopPadding: CGFloat {
-        isCompactHeight ? 40 : 54
+        if usesAccessibilityText { return 24 }
+        return isCompactHeight ? 40 : 54
     }
 
     var controlsBottomSpacer: CGFloat {
-        isCompactHeight ? 30 : 46
+        if usesAccessibilityText { return 18 }
+        return isCompactHeight ? 30 : 46
     }
 
     var transportControlHeight: CGFloat {
@@ -310,6 +318,7 @@ struct FullScreenPlayerView: View {
     private let favorites = FavoritesManager.shared
     @Environment(\.playerSafeAreaInsets) private var injectedSafeAreaInsets
     @Environment(\.appReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showingQueue = false
     @State private var showLyrics = false
     @State private var didSetInitialSurface = false
@@ -343,7 +352,8 @@ struct FullScreenPlayerView: View {
                     let metrics = PlayerLayoutMetrics(
                         containerSize: geo.size,
                         safeTop: safeTop,
-                        safeBottom: safeBottom
+                        safeBottom: safeBottom,
+                        usesAccessibilityText: dynamicTypeSize.isAccessibilitySize
                     )
                     ZStack(alignment: .top) {
                         Group {

--- a/Twinskaraoke/Features/Player/NowPlaying/NowPlayingPresentation.swift
+++ b/Twinskaraoke/Features/Player/NowPlaying/NowPlayingPresentation.swift
@@ -98,6 +98,7 @@ final class NowPlayingPresentation {
 
     func expand() {
         guard !isExpanded else { return }
+        AppPerformance.event("Player Expand")
         AppHaptic.commit.play()
         isExpanded = true
         animate(to: 1)
@@ -105,6 +106,7 @@ final class NowPlayingPresentation {
 
     func collapse() {
         guard isExpanded else { return }
+        AppPerformance.event("Player Collapse")
         AppHaptic.dismiss.play()
         isExpanded = false
         animate(to: 0)
@@ -147,6 +149,7 @@ final class NowPlayingPresentation {
     /// where an animated close would be animating a player that has nothing
     /// left to show.
     func dismissImmediately() {
+        AppPerformance.event("Player Immediate Dismiss")
         settleTask?.cancel()
         settleTask = nil
         isAnimatingTransition = false

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -16,7 +16,7 @@ private final class TimerStepCounter: @unchecked Sendable {
     var step = 0
 }
 
-enum RepeatMode {
+nonisolated enum RepeatMode: Equatable, Sendable {
     case off, all, one
     var symbol: String {
         switch self {
@@ -69,7 +69,8 @@ final class AudioPlayerManager {
         set { PlaybackClock.shared.progress = newValue }
     }
 
-    var queue: [Song] = []
+    private var queueState = PlaybackQueueState()
+    var queue: [Song] { queueState.items }
     var isEditingProgress = false
     var volume: Double = 1.0
     var isUserScrubbingVolume: Bool = false
@@ -80,7 +81,7 @@ final class AudioPlayerManager {
     var routeIcon: String = "airplayaudio"
     var routeName: String = ""
     var repeatMode: RepeatMode = .off
-    var isShuffled: Bool = false
+    var isShuffled: Bool { queueState.isShuffled }
     var autoplayEnabled: Bool = true
     var isRadioMode: Bool = false
     var radioArtworkURL: URL?
@@ -375,7 +376,6 @@ final class AudioPlayerManager {
     private var streamStartedAt: Date?
 
     private var _suppressModeSwitch = false
-    private var originalQueue: [Song] = []
     private var cancellables = Set<AnyCancellable>()
     private var artworkURL: URL?
     private var artworkTask: (any SDWebImageOperation)?
@@ -405,9 +405,11 @@ final class AudioPlayerManager {
     private var activeCrossfadePlan: TransitionCoordinator.TransitionPlan?
     private var suppressPlaybackEndedUntil: Date = .distantPast
     private var wasPlayingBeforeInterruption = false
-    private var audioSessionCategoryConfigured = false
-    private var audioSessionIsActive = false
     private var handlingAudioSessionInterruption = false
+    @ObservationIgnored private let audioSessionController: any AudioSessionManaging =
+        AudioSessionController()
+    @ObservationIgnored private let nowPlayingPublisher: any NowPlayingPublishing =
+        SystemNowPlayingPublisher()
 
     private let easterEggSongID = "73376790-47d2-4c17-a7fc-88d11dccd2f0"
     private var easterEggQueuedForCurrentSong = false
@@ -485,6 +487,11 @@ final class AudioPlayerManager {
         isPlaying = playing
         isBuffering = buffering
         if changed {
+            if playing, !buffering {
+                AppPerformance.event("Playback Ready")
+            } else if !playing, !buffering {
+                AppPerformance.event("Playback Stopped")
+            }
             DebugLogger.log(
                 "Playback state changed: playing=\(playing), buffering=\(buffering), reason=\(reason)",
                 category: .playback
@@ -1348,6 +1355,7 @@ final class AudioPlayerManager {
             cacheRecoverySongID = nil
         }
         DebugLogger.log("Play requested: \(song.title) (id: \(song.id))", category: .playback)
+        AppPerformance.event("Playback Request")
         let previousSongID = currentSong?.id
         let effectToResume = currentActiveEffect ?? deferredAIEffect
         suppressPlaybackEndedCallbacks()
@@ -1388,17 +1396,7 @@ final class AudioPlayerManager {
         progress = 0
         currentSong = song
         warmPlayerArtwork(for: song)
-        if !context.isEmpty {
-            queue = context
-            if isShuffled {
-                originalQueue = context
-                var rest = queue.filter { $0.id != song.id }
-                rest.shuffle()
-                queue = [song] + rest
-            } else {
-                originalQueue = []
-            }
-        }
+        queueState.replaceContext(context, current: song)
         checkEasterEgg(for: song)
         // Songs with a remote source use the non-decompressing lookup; a
         // compressed-only cache falls through to startStreamPlayback, whose
@@ -1475,23 +1473,7 @@ final class AudioPlayerManager {
             return
         }
 
-        func inserting(_ song: Song, into source: [Song], after current: Song) -> [Song] {
-            var updated = source
-            updated.removeAll { $0.id == song.id && $0.id != current.id }
-            if updated.contains(where: { $0.id == current.id }) == false {
-                updated.insert(current, at: 0)
-            }
-            guard song.id != current.id else { return updated }
-            let currentIndex = updated.firstIndex(where: { $0.id == current.id }) ?? 0
-            let insertIndex = min(currentIndex + 1, updated.count)
-            updated.insert(song, at: insertIndex)
-            return updated
-        }
-
-        queue = inserting(song, into: queue, after: current)
-        if !originalQueue.isEmpty {
-            originalQueue = inserting(song, into: originalQueue, after: current)
-        }
+        queueState.insertNext(song, after: current)
         transitionCoordinator.reset()
         upcomingSong = nil
     }
@@ -1913,21 +1895,20 @@ final class AudioPlayerManager {
         #endif
         configureAudioSessionCategory()
         activateAudioSession()
-        if repeatMode == .one, let current = currentSong {
+        switch queueState.advance(
+            after: currentSong,
+            repeatMode: repeatMode,
+            autoplayEnabled: autoplayEnabled
+        ) {
+        case .replayCurrent:
+            guard let current = currentSong else { return }
             // Repeat-one replay: not a new listen, so don't count it again.
             play(song: current, context: [], resetTransitionVolume: true, reportsPlayCount: false)
-            return
-        }
-        if let current = currentSong, !queue.isEmpty,
-           let idx = queue.firstIndex(where: { $0.id == current.id }),
-           idx + 1 < queue.count
-        {
-            play(song: queue[idx + 1])
-        } else if repeatMode == .all, let first = queue.first {
-            play(song: first)
-        } else if autoplayEnabled {
+        case .play(let song):
+            play(song: song)
+        case .autoplay:
             fetchRandomTrending()
-        } else {
+        case .stop:
             avEngine.pause()
             setPlaybackState(
                 playing: false,
@@ -1942,14 +1923,11 @@ final class AudioPlayerManager {
 
     func playPrevious() {
         if isRadioMode { return }
-        guard let current = currentSong, !queue.isEmpty,
-              let idx = queue.firstIndex(where: { $0.id == current.id }),
-              idx - 1 >= 0
-        else {
+        guard let previous = queueState.previous(before: currentSong) else {
             seek(to: 0)
             return
         }
-        play(song: queue[idx - 1])
+        play(song: previous)
     }
 
     func toggleRepeat() {
@@ -1957,31 +1935,20 @@ final class AudioPlayerManager {
     }
 
     func toggleShuffle() {
-        isShuffled.toggle()
-        if isShuffled {
-            originalQueue = queue
-            guard let current = currentSong else { return }
-            var rest = queue.filter { $0.id != current.id }
-            rest.shuffle()
-            queue = [current] + rest
-        } else if !originalQueue.isEmpty {
-            queue = originalQueue
-            originalQueue = []
-        }
+        queueState.toggleShuffle(current: currentSong)
     }
 
     func playInOrder(song: Song, context: [Song]) {
-        isShuffled = false
-        originalQueue = []
+        queueState.beginInOrder(context: context)
         play(song: song, context: context)
     }
 
     func playShuffled(from songs: [Song]) {
-        guard let pick = songs.randomElement() else { return }
-        let shuffled = [pick] + songs.filter { $0.id != pick.id }.shuffled()
-        isShuffled = true
-        play(song: pick, context: shuffled)
-        originalQueue = songs
+        guard let pick = queueState.beginShuffled(songs: songs) else { return }
+        // The state already contains the shuffled queue and its original
+        // ordering. Passing that queue back as a context would shuffle it a
+        // second time and overwrite the restoration order.
+        play(song: pick)
     }
 
     func toggleAutoplay() {
@@ -1989,25 +1956,11 @@ final class AudioPlayerManager {
     }
 
     func moveInUpNext(from source: IndexSet, to destination: Int) {
-        guard let current = currentSong,
-              let baseIdx = queue.firstIndex(where: { $0.id == current.id })
-        else { return }
-        let upNextStart = baseIdx + 1
-        guard upNextStart < queue.count else { return }
-        var upNext = Array(queue[upNextStart...])
-        upNext.move(fromOffsets: source, toOffset: destination)
-        queue = Array(queue[..<upNextStart]) + upNext
+        queueState.moveUpNext(after: currentSong, from: source, to: destination)
     }
 
     func removeFromUpNext(at offsets: IndexSet) {
-        guard let current = currentSong,
-              let baseIdx = queue.firstIndex(where: { $0.id == current.id })
-        else { return }
-        let upNextStart = baseIdx + 1
-        guard upNextStart < queue.count else { return }
-        var upNext = Array(queue[upNextStart...])
-        upNext.remove(atOffsets: offsets)
-        queue = Array(queue[..<upNextStart]) + upNext
+        queueState.removeUpNext(after: currentSong, at: offsets)
     }
 
     private func observeManagedPlayer(
@@ -2144,6 +2097,7 @@ final class AudioPlayerManager {
     }
 
     func playRadio(streamURL: URL, song: Song, artworkURL: URL?) {
+        AppPerformance.event("Radio Playback Request")
         resetEasterEggWork()
         let alreadyOnSameStation = isRadioMode && currentSong?.id == song.id
         if alreadyOnSameStation {
@@ -2168,8 +2122,7 @@ final class AudioPlayerManager {
         isRadioMode = true
         radioArtworkURL = artworkURL
         progress = 0
-        queue = []
-        originalQueue = []
+        queueState.clear()
         currentSong = song
         startRadio(url: streamURL)
     }
@@ -2716,30 +2669,19 @@ final class AudioPlayerManager {
     }
 
     private func configureAudioSessionCategory() {
-        guard !audioSessionCategoryConfigured else { return }
-        do {
-            try AVAudioSession.sharedInstance().setCategory(
-                .playback, mode: .default, policy: .longFormAudio, options: []
-            )
-            audioSessionCategoryConfigured = true
-        } catch {
-            DebugLogger.log("Audio session category configuration failed: \(error)", category: .playback)
-        }
+        audioSessionController.prepareForPlayback()
     }
 
     private func activateAudioSession() {
-        guard !audioSessionIsActive else { return }
-        do {
-            try AVAudioSession.sharedInstance().setActive(true)
-            audioSessionIsActive = true
-        } catch {
-            DebugLogger.log("Audio session activation failed: \(error)", category: .playback)
-        }
+        // Kept as a compatibility seam while call sites are migrated from the
+        // former configure/activate pair. The controller makes this idempotent.
+        audioSessionController.prepareForPlayback()
     }
 
     private func syncSystemVolume(
-        _ systemVolume: Float = AVAudioSession.sharedInstance().outputVolume
+        _ systemVolume: Float? = nil
     ) {
+        let systemVolume = systemVolume ?? audioSessionController.outputVolume
         let reconciledVolume = SystemVolumeReconciliation.value(
             currentVolume: volume,
             systemVolume: systemVolume,
@@ -2765,10 +2707,7 @@ final class AudioPlayerManager {
 
     private func handleMediaServicesReset() {
         DebugLogger.log("Media services were reset — reconfiguring audio", category: .playback)
-        audioSessionCategoryConfigured = false
-        audioSessionIsActive = false
-        configureAudioSessionCategory()
-        activateAudioSession()
+        audioSessionController.resetAfterMediaServicesLoss()
         if isPlaying, !isRadioMode, !isStreamMode {
             let position = lastKnownPlaybackTime
             avEngine.startEngineIfNeeded()
@@ -2783,7 +2722,7 @@ final class AudioPlayerManager {
         else { return }
         switch type {
         case .began:
-            audioSessionIsActive = false
+            audioSessionController.markInterrupted()
             wasPlayingBeforeInterruption = isPlaybackRequested
             DebugLogger.log(
                 "Audio session interruption began; should resume later=\(wasPlayingBeforeInterruption)",
@@ -2825,46 +2764,9 @@ final class AudioPlayerManager {
     }
 
     func updateRouteIcon() {
-        let outputs = AVAudioSession.sharedInstance().currentRoute.outputs
-        guard let primary = outputs.first else {
-            routeIcon = "airplayaudio"
-            routeName = ""
-            return
-        }
-        routeName = primary.portName
-        let nameLower = primary.portName.lowercased()
-        switch primary.portType {
-        case .builtInSpeaker, .builtInReceiver:
-            routeIcon = "airplayaudio"
-        case .headphones:
-            routeIcon = "headphones"
-        case .HDMI:
-            routeIcon = "tv.fill"
-        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP:
-            if nameLower.contains("airpods max") {
-                routeIcon = "airpodsmax"
-            } else if nameLower.contains("airpods pro") {
-                routeIcon = "airpodspro"
-            } else if nameLower.contains("airpods") {
-                routeIcon = "airpods"
-            } else if nameLower.contains("beats") {
-                routeIcon = "beats.headphones"
-            } else {
-                routeIcon = "hifispeaker.fill"
-            }
-        case .airPlay:
-            if nameLower.contains("homepod mini") {
-                routeIcon = "homepodmini"
-            } else if nameLower.contains("homepod") {
-                routeIcon = "homepod"
-            } else if nameLower.contains("apple tv") {
-                routeIcon = "appletv"
-            } else {
-                routeIcon = "airplayaudio"
-            }
-        default:
-            routeIcon = "airplayaudio"
-        }
+        let route = audioSessionController.currentRoute
+        routeName = route.name
+        routeIcon = route.symbol
     }
 
     private func setupRemoteCommands() {
@@ -2999,7 +2901,7 @@ final class AudioPlayerManager {
 
     private func updateNowPlayingInfo(reloadArtwork: Bool) {
         guard let song = currentSong else {
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            nowPlayingPublisher.info = nil
             lastNowPlayingElapsedSecond = nil
             lastNowPlayingPlaybackRate = nil
             lastLoggedNowPlayingElapsedSecond = nil
@@ -3024,9 +2926,9 @@ final class AudioPlayerManager {
             }
         }
         if shouldResetNowPlayingIdentity {
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            nowPlayingPublisher.info = nil
         }
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        nowPlayingPublisher.info = info
         updateRemoteCommandAvailability()
         DebugLogger.log(
             "Now Playing updated: rate=\(nowPlayingPlaybackRate), playing=\(isPlaying), buffering=\(isBuffering)",
@@ -3061,7 +2963,7 @@ final class AudioPlayerManager {
             elapsed: isRadioMode ? nil : elapsed,
             includeExistingArtwork: true
         )
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        nowPlayingPublisher.info = info
         if lastLoggedNowPlayingElapsedSecond == nil
             || roundedSecond - (lastLoggedNowPlayingElapsedSecond ?? 0) >= 15
         {
@@ -3080,39 +2982,16 @@ final class AudioPlayerManager {
         elapsed: TimeInterval?,
         includeExistingArtwork: Bool
     ) -> [String: Any] {
-        let currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
-        // Keep system surfaces driven by the public Now Playing contract:
-        // metadata, elapsed time, duration, and playback rate.
-        let originalArtists = song.originalArtists?
-            .filter { !$0.isEmpty }
-            .joined(separator: ", ")
-        let artist: String
-        if let originalArtists, !originalArtists.isEmpty {
-            artist = originalArtists
-        } else {
-            artist = song.artistName
-        }
-        var info: [String: Any] = [
-            MPMediaItemPropertyTitle: song.title,
-            MPMediaItemPropertyArtist: artist,
-            MPMediaItemPropertyMediaType: MPMediaType.music.rawValue,
-            MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.audio.rawValue,
-            MPNowPlayingInfoPropertyPlaybackRate: nowPlayingPlaybackRate,
-            MPNowPlayingInfoPropertyDefaultPlaybackRate: 1.0,
-        ]
-        if includeExistingArtwork,
-           let artwork = currentInfo?[MPMediaItemPropertyArtwork]
-        {
-            info[MPMediaItemPropertyArtwork] = artwork
-        }
-        if isRadioMode {
-            info[MPNowPlayingInfoPropertyIsLiveStream] = true
-        } else {
-            info[MPNowPlayingInfoPropertyIsLiveStream] = false
-            info[MPMediaItemPropertyPlaybackDuration] = playbackDuration
-            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed ?? playbackTime
-        }
-        return info
+        return NowPlayingInfoBuilder.make(
+            song: song,
+            playbackRate: nowPlayingPlaybackRate,
+            isLiveStream: isRadioMode,
+            duration: playbackDuration,
+            elapsed: elapsed ?? playbackTime,
+            existingArtwork: includeExistingArtwork
+                ? nowPlayingPublisher.info?[MPMediaItemPropertyArtwork]
+                : nil
+        )
     }
 
     private func loadArtworkAsync(from url: URL) {
@@ -3174,7 +3053,7 @@ final class AudioPlayerManager {
                     includeExistingArtwork: false
                 )
                 info[MPMediaItemPropertyArtwork] = artwork
-                MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+                self.nowPlayingPublisher.info = info
                 self.updateRemoteCommandAvailability()
                 if self.isRadioMode {
                     self.lastNowPlayingElapsedSecond = nil

--- a/Twinskaraoke/Services/Audio/AudioSessionController.swift
+++ b/Twinskaraoke/Services/Audio/AudioSessionController.swift
@@ -1,0 +1,117 @@
+import AVFoundation
+import Foundation
+
+nonisolated struct AudioRouteDescriptor: Equatable, Sendable {
+    let name: String
+    let symbol: String
+
+    static let unavailable = AudioRouteDescriptor(name: "", symbol: "airplayaudio")
+
+    static func resolve(portType: AVAudioSession.Port, name: String) -> AudioRouteDescriptor {
+        let normalizedName = name.lowercased()
+        let symbol: String
+        switch portType {
+        case .builtInSpeaker, .builtInReceiver:
+            symbol = "airplayaudio"
+        case .headphones:
+            symbol = "headphones"
+        case .HDMI:
+            symbol = "tv.fill"
+        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP:
+            if normalizedName.contains("airpods max") {
+                symbol = "airpodsmax"
+            } else if normalizedName.contains("airpods pro") {
+                symbol = "airpodspro"
+            } else if normalizedName.contains("airpods") {
+                symbol = "airpods"
+            } else if normalizedName.contains("beats") {
+                symbol = "beats.headphones"
+            } else {
+                symbol = "hifispeaker.fill"
+            }
+        case .airPlay:
+            if normalizedName.contains("homepod mini") {
+                symbol = "homepodmini"
+            } else if normalizedName.contains("homepod") {
+                symbol = "homepod"
+            } else if normalizedName.contains("apple tv") {
+                symbol = "appletv"
+            } else {
+                symbol = "airplayaudio"
+            }
+        default:
+            symbol = "airplayaudio"
+        }
+        return AudioRouteDescriptor(name: name, symbol: symbol)
+    }
+}
+
+@MainActor
+protocol AudioSessionManaging: AnyObject {
+    var outputVolume: Float { get }
+    var currentRoute: AudioRouteDescriptor { get }
+
+    func prepareForPlayback()
+    func markInterrupted()
+    func resetAfterMediaServicesLoss()
+}
+
+/// Owns the process-wide AVAudioSession configuration state.
+///
+/// Playback code can ask for a prepared session without duplicating the
+/// category/activation guards or reaching into AVAudioSession directly.
+@MainActor
+final class AudioSessionController: AudioSessionManaging {
+    private let session: AVAudioSession
+    private var categoryConfigured = false
+    private var isActive = false
+
+    init(session: AVAudioSession = .sharedInstance()) {
+        self.session = session
+    }
+
+    var outputVolume: Float { session.outputVolume }
+
+    var currentRoute: AudioRouteDescriptor {
+        guard let output = session.currentRoute.outputs.first else { return .unavailable }
+        return .resolve(portType: output.portType, name: output.portName)
+    }
+
+    func prepareForPlayback() {
+        configureCategoryIfNeeded()
+        activateIfNeeded()
+    }
+
+    func markInterrupted() {
+        isActive = false
+    }
+
+    func resetAfterMediaServicesLoss() {
+        categoryConfigured = false
+        isActive = false
+        prepareForPlayback()
+    }
+
+    private func configureCategoryIfNeeded() {
+        guard !categoryConfigured else { return }
+        do {
+            try session.setCategory(.playback, mode: .default, policy: .longFormAudio, options: [])
+            categoryConfigured = true
+        } catch {
+            DebugLogger.log(
+                "Audio session category configuration failed: \(error)",
+                category: .playback
+            )
+        }
+    }
+
+    private func activateIfNeeded() {
+        guard !isActive else { return }
+        do {
+            try session.setActive(true)
+            isActive = true
+        } catch {
+            DebugLogger.log("Audio session activation failed: \(error)", category: .playback)
+        }
+    }
+}

--- a/Twinskaraoke/Services/Audio/NowPlayingPublisher.swift
+++ b/Twinskaraoke/Services/Audio/NowPlayingPublisher.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MediaPlayer
+
+@MainActor
+protocol NowPlayingPublishing: AnyObject {
+    var info: [String: Any]? { get set }
+}
+
+@MainActor
+final class SystemNowPlayingPublisher: NowPlayingPublishing {
+    var info: [String: Any]? {
+        get { MPNowPlayingInfoCenter.default().nowPlayingInfo }
+        set { MPNowPlayingInfoCenter.default().nowPlayingInfo = newValue }
+    }
+}
+
+@MainActor
+enum NowPlayingInfoBuilder {
+    static func make(
+        song: Song,
+        playbackRate: Double,
+        isLiveStream: Bool,
+        duration: TimeInterval,
+        elapsed: TimeInterval,
+        existingArtwork: Any?
+    ) -> [String: Any] {
+        let originalArtists = song.originalArtists?
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+        let artist: String
+        if let originalArtists, !originalArtists.isEmpty {
+            artist = originalArtists
+        } else {
+            artist = song.artistName
+        }
+
+        var info: [String: Any] = [
+            MPMediaItemPropertyTitle: song.title,
+            MPMediaItemPropertyArtist: artist,
+            MPMediaItemPropertyMediaType: MPMediaType.music.rawValue,
+            MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.audio.rawValue,
+            MPNowPlayingInfoPropertyPlaybackRate: playbackRate,
+            MPNowPlayingInfoPropertyDefaultPlaybackRate: 1.0,
+            MPNowPlayingInfoPropertyIsLiveStream: isLiveStream,
+        ]
+        if let existingArtwork {
+            info[MPMediaItemPropertyArtwork] = existingArtwork
+        }
+        if !isLiveStream {
+            info[MPMediaItemPropertyPlaybackDuration] = max(0, duration)
+            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = min(
+                max(0, elapsed),
+                max(0, duration)
+            )
+        }
+        return info
+    }
+}

--- a/Twinskaraoke/Services/Audio/PlaybackQueueState.swift
+++ b/Twinskaraoke/Services/Audio/PlaybackQueueState.swift
@@ -128,10 +128,14 @@ nonisolated struct PlaybackQueueState: Equatable, Sendable {
         guard let start = upNextStart(after: current) else { return }
         var upNext = Array(items[start...])
         guard offsets.allSatisfy(upNext.indices.contains) else { return }
+        let removedIDs = Set(offsets.map { upNext[$0].id })
         for index in offsets.sorted(by: >) {
             upNext.remove(at: index)
         }
         items = Array(items[..<start]) + upNext
+        if !originalItems.isEmpty {
+            originalItems.removeAll { removedIDs.contains($0.id) }
+        }
     }
 
     private func upNextStart(after current: Song?) -> Int? {

--- a/Twinskaraoke/Services/Audio/PlaybackQueueState.swift
+++ b/Twinskaraoke/Services/Audio/PlaybackQueueState.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Pure queue state kept separate from audio-engine and UI concerns.
+///
+/// Keeping every mutation here makes shuffle restoration and Up Next editing
+/// deterministic and independently testable. `AudioPlayerManager` remains the
+/// observable facade used by views.
+nonisolated struct PlaybackQueueState: Equatable, Sendable {
+    enum Advance: Equatable, Sendable {
+        case replayCurrent
+        case play(Song)
+        case autoplay
+        case stop
+    }
+
+    private(set) var items: [Song] = []
+    private(set) var originalItems: [Song] = []
+    private(set) var isShuffled = false
+
+    mutating func replaceContext(
+        _ context: [Song],
+        current: Song,
+        shuffling: ([Song]) -> [Song] = { $0.shuffled() }
+    ) {
+        guard !context.isEmpty else { return }
+        if isShuffled {
+            originalItems = context
+            items = [current] + shuffling(context.filter { $0.id != current.id })
+        } else {
+            items = context
+            originalItems = []
+        }
+    }
+
+    mutating func clear() {
+        items = []
+        originalItems = []
+        isShuffled = false
+    }
+
+    mutating func insertNext(_ song: Song, after current: Song) {
+        items = Self.inserting(song, into: items, after: current)
+        if !originalItems.isEmpty {
+            originalItems = Self.inserting(song, into: originalItems, after: current)
+        }
+    }
+
+    func advance(
+        after current: Song?,
+        repeatMode: RepeatMode,
+        autoplayEnabled: Bool
+    ) -> Advance {
+        if repeatMode == .one, current != nil {
+            return .replayCurrent
+        }
+        if let current,
+           let index = items.firstIndex(where: { $0.id == current.id }),
+           items.indices.contains(index + 1)
+        {
+            return .play(items[index + 1])
+        }
+        if repeatMode == .all, let first = items.first {
+            return .play(first)
+        }
+        return autoplayEnabled ? .autoplay : .stop
+    }
+
+    func previous(before current: Song?) -> Song? {
+        guard let current,
+              let index = items.firstIndex(where: { $0.id == current.id }),
+              items.indices.contains(index - 1)
+        else { return nil }
+        return items[index - 1]
+    }
+
+    mutating func toggleShuffle(
+        current: Song?,
+        shuffling: ([Song]) -> [Song] = { $0.shuffled() }
+    ) {
+        isShuffled.toggle()
+        if isShuffled {
+            originalItems = items
+            guard let current else { return }
+            items = [current] + shuffling(items.filter { $0.id != current.id })
+        } else if !originalItems.isEmpty {
+            items = originalItems
+            originalItems = []
+        }
+    }
+
+    mutating func beginInOrder(context: [Song]) {
+        isShuffled = false
+        originalItems = []
+        items = context
+    }
+
+    mutating func beginShuffled(
+        songs: [Song],
+        selecting: ([Song]) -> Song? = { $0.randomElement() },
+        shuffling: ([Song]) -> [Song] = { $0.shuffled() }
+    ) -> Song? {
+        guard let selected = selecting(songs) else { return nil }
+        isShuffled = true
+        originalItems = songs
+        items = [selected] + shuffling(songs.filter { $0.id != selected.id })
+        return selected
+    }
+
+    mutating func moveUpNext(
+        after current: Song?,
+        from source: IndexSet,
+        to destination: Int
+    ) {
+        guard let start = upNextStart(after: current) else { return }
+        var upNext = Array(items[start...])
+        guard source.allSatisfy(upNext.indices.contains), destination <= upNext.count else { return }
+        let moving = source.map { upNext[$0] }
+        for index in source.sorted(by: >) {
+            upNext.remove(at: index)
+        }
+        let removedBeforeDestination = source.lazy.filter { $0 < destination }.count
+        let insertionIndex = min(max(0, destination - removedBeforeDestination), upNext.count)
+        upNext.insert(contentsOf: moving, at: insertionIndex)
+        items = Array(items[..<start]) + upNext
+    }
+
+    mutating func removeUpNext(after current: Song?, at offsets: IndexSet) {
+        guard let start = upNextStart(after: current) else { return }
+        var upNext = Array(items[start...])
+        guard offsets.allSatisfy(upNext.indices.contains) else { return }
+        for index in offsets.sorted(by: >) {
+            upNext.remove(at: index)
+        }
+        items = Array(items[..<start]) + upNext
+    }
+
+    private func upNextStart(after current: Song?) -> Int? {
+        guard let current,
+              let index = items.firstIndex(where: { $0.id == current.id })
+        else { return nil }
+        let start = index + 1
+        return items.indices.contains(start) ? start : nil
+    }
+
+    private static func inserting(_ song: Song, into source: [Song], after current: Song) -> [Song] {
+        var updated = source
+        updated.removeAll { $0.id == song.id && $0.id != current.id }
+        if !updated.contains(where: { $0.id == current.id }) {
+            updated.insert(current, at: 0)
+        }
+        guard song.id != current.id else { return updated }
+        let currentIndex = updated.firstIndex(where: { $0.id == current.id }) ?? 0
+        updated.insert(song, at: min(currentIndex + 1, updated.count))
+        return updated
+    }
+}

--- a/Twinskaraoke/Services/Debug/AppPerformance.swift
+++ b/Twinskaraoke/Services/Debug/AppPerformance.swift
@@ -1,0 +1,14 @@
+import OSLog
+
+/// Local-only signposts for Instruments and XCTest performance diagnostics.
+/// No metric or user data leaves the device.
+nonisolated enum AppPerformance {
+    private static let signposter = OSSignposter(
+        subsystem: Bundle.main.bundleIdentifier ?? "org.evilneuro.Twinskaraoke",
+        category: "ReleasePerformance"
+    )
+
+    static func event(_ name: StaticString) {
+        signposter.emitEvent(name)
+    }
+}

--- a/Twinskaraoke/Theme/AuroraBackgroundViews.swift
+++ b/Twinskaraoke/Theme/AuroraBackgroundViews.swift
@@ -16,9 +16,8 @@ class CloudProvider {
 }
 
 struct Cloud: View {
-    // Fixed: Marked StateObject private and added appReduceMotion environment key
     @State private var provider = CloudProvider()
-    @Environment(\.appReduceMotion) private var reduceMotion
+    @Environment(\.appReduceEffects) private var reduceEffects
     @State private var move = false
 
     let proxy: GeometryProxy
@@ -32,30 +31,36 @@ struct Cloud: View {
             .fill(color)
             .frame(height: proxy.size.height / provider.frameHeightRatio)
             .offset(provider.offset)
-            // Fixed: Only apply rotation shift if user allows motion animations
-            .rotationEffect(.init(degrees: (move && !reduceMotion) ? rotationStart : rotationStart + 360))
+            .rotationEffect(.init(degrees: (move && !reduceEffects) ? rotationStart : rotationStart + 360))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
             .opacity(0.8)
             .onAppear {
-                // Fixed: Respect reduceMotion settings by blocking the infinite animation loop
-                guard !reduceMotion else { return }
-                
-                withOptionalAnimation(Animation.linear(duration: duration).repeatForever(autoreverses: false)) {
-                    move.toggle()
-                }
+                updateAnimation(shouldReduce: reduceEffects)
             }
+            .onChange(of: reduceEffects) { _, shouldReduce in
+                updateAnimation(shouldReduce: shouldReduce)
+            }
+    }
+
+    private func updateAnimation(shouldReduce: Bool) {
+        if shouldReduce {
+            withOptionalAnimation(nil) { move = false }
+        } else {
+            move = false
+            withOptionalAnimation(Animation.linear(duration: duration).repeatForever(autoreverses: false)) {
+                move = true
+            }
+        }
     }
 }
 
 struct FloatingClouds: View {
-    @Environment(\.appReduceMotion) private var reduceMotion
     let blur: CGFloat = 64
     private let scheme: ColorScheme = .dark
 
     var body: some View {
         GeometryReader { proxy in
             ZStack {
-                // Clouds will automatically inherit and respect reduceMotion via Environment
                 Cloud(proxy: proxy, color: Theme.ellipsesTopLeading(forScheme: scheme), rotationStart: 0, duration: 60, alignment: .topLeading)
                 Cloud(proxy: proxy, color: Theme.ellipsesBottomTrailing(forScheme: scheme), rotationStart: 90, duration: 90, alignment: .bottomTrailing)
                 Cloud(proxy: proxy, color: Theme.ellipsesTopTrailing(forScheme: scheme), rotationStart: 180, duration: 75, alignment: .topTrailing)
@@ -70,6 +75,7 @@ struct FloatingClouds: View {
 /// what pushes the wash from "blurry colored blobs" to something that reads
 /// as an actual aurora — a faint band of light drifting across the sky.
 private struct AuroraShimmerOverlay: View {
+    @Environment(\.appReduceEffects) private var reduceEffects
     @State private var animate = false
 
     var body: some View {
@@ -84,10 +90,22 @@ private struct AuroraShimmerOverlay: View {
         )
         .blendMode(.plusLighter)
         .onAppear {
+            guard !reduceEffects else { return }
             withOptionalAnimation(
                 Animation.easeInOut(duration: 13).repeatForever(autoreverses: true)
             ) {
                 animate = true
+            }
+        }
+        .onChange(of: reduceEffects) { _, shouldReduce in
+            if shouldReduce {
+                withOptionalAnimation(nil) { animate = false }
+            } else {
+                withOptionalAnimation(
+                    Animation.easeInOut(duration: 13).repeatForever(autoreverses: true)
+                ) {
+                    animate = true
+                }
             }
         }
     }

--- a/TwinskaraokeShared/Components/AppMotion.swift
+++ b/TwinskaraokeShared/Components/AppMotion.swift
@@ -36,12 +36,25 @@ struct AppReduceMotionKey: EnvironmentKey {
     static let defaultValue: Bool = false
 }
 
+struct AppReduceEffectsKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
 extension EnvironmentValues {
     /// Whether reduce-motion should be respected, combining the system
     /// accessibility setting with the user's in-app preference.
     var appReduceMotion: Bool {
         get { self[AppReduceMotionKey.self] }
         set { self[AppReduceMotionKey.self] = newValue }
+    }
+
+    /// Pauses perpetual, decorative effects when either Reduce Motion or Low
+    /// Power Mode is active. Interaction transitions still use
+    /// `appReduceMotion`, so Low Power Mode does not make the interface feel
+    /// abruptly unanimated.
+    var appReduceEffects: Bool {
+        get { self[AppReduceEffectsKey.self] }
+        set { self[AppReduceEffectsKey.self] = newValue }
     }
 }
 
@@ -62,12 +75,27 @@ private struct ReduceMotionInjector<Content: View>: View {
     let content: Content
     @AppStorage("nk.respectReducedMotion") private var respectReducedMotion: Bool = true
     @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
+    @State private var lowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
 
     var body: some View {
-        content.environment(\.appReduceMotion, AppMotion.reduceMotion(
+        let reduceMotion = AppMotion.reduceMotion(
             systemReduceMotion: systemReduceMotion,
             respectPreference: respectReducedMotion
-        ))
+        )
+        content
+            .environment(\.appReduceMotion, reduceMotion)
+            .environment(
+                \.appReduceEffects,
+                AppMotion.reduceDecorativeEffects(
+                    reduceMotion: reduceMotion,
+                    lowPowerModeEnabled: lowPowerModeEnabled
+                )
+            )
+            .onReceive(
+                NotificationCenter.default.publisher(for: .NSProcessInfoPowerStateDidChange)
+            ) { _ in
+                lowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+            }
     }
 }
 
@@ -76,6 +104,13 @@ private struct ReduceMotionInjector<Content: View>: View {
 enum AppMotion {
   static func reduceMotion(systemReduceMotion: Bool, respectPreference: Bool) -> Bool {
     respectPreference && systemReduceMotion
+  }
+
+  static func reduceDecorativeEffects(
+    reduceMotion: Bool,
+    lowPowerModeEnabled: Bool
+  ) -> Bool {
+    reduceMotion || lowPowerModeEnabled
   }
 
   static func duration(_ seconds: TimeInterval) -> TimeInterval {

--- a/TwinskaraokeTests/AppLayoutTests.swift
+++ b/TwinskaraokeTests/AppLayoutTests.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Adaptive layout breakpoints")
+struct AppLayoutTests {
+    @Test("A 13-inch iPad detail column keeps the wide content layout")
+    func wideDetailCanvas() {
+        #expect(AM.Layout.usesWideCanvas(horizontalSizeClass: .regular, availableWidth: 1_046))
+        #expect(!AM.Layout.usesWideCanvas(horizontalSizeClass: .regular, availableWidth: 900))
+        #expect(!AM.Layout.usesWideCanvas(horizontalSizeClass: .compact, availableWidth: 1_376))
+    }
+
+    @Test("The sidebar retains a wider activation threshold than content")
+    func sidebarCanvas() {
+        #expect(AM.Layout.usesSidebarCanvas(horizontalSizeClass: .regular, availableWidth: 1_376))
+        #expect(!AM.Layout.usesSidebarCanvas(horizontalSizeClass: .regular, availableWidth: 1_046))
+        #expect(!AM.Layout.usesSidebarCanvas(horizontalSizeClass: .compact, availableWidth: 1_376))
+    }
+}

--- a/TwinskaraokeTests/AppMotionTests.swift
+++ b/TwinskaraokeTests/AppMotionTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Application motion policy")
+struct AppMotionTests {
+    @Test("Reduce Motion follows the system setting only when enabled in-app")
+    func reducedMotionPreference() {
+        #expect(AppMotion.reduceMotion(systemReduceMotion: true, respectPreference: true))
+        #expect(!AppMotion.reduceMotion(systemReduceMotion: true, respectPreference: false))
+        #expect(!AppMotion.reduceMotion(systemReduceMotion: false, respectPreference: true))
+    }
+
+    @Test("Decorative effects pause for accessibility or Low Power Mode")
+    func decorativeEffectsPolicy() {
+        #expect(AppMotion.reduceDecorativeEffects(reduceMotion: true, lowPowerModeEnabled: false))
+        #expect(AppMotion.reduceDecorativeEffects(reduceMotion: false, lowPowerModeEnabled: true))
+        #expect(!AppMotion.reduceDecorativeEffects(reduceMotion: false, lowPowerModeEnabled: false))
+    }
+}

--- a/TwinskaraokeTests/AudioRouteDescriptorTests.swift
+++ b/TwinskaraokeTests/AudioRouteDescriptorTests.swift
@@ -1,0 +1,29 @@
+import AVFoundation
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Audio route presentation")
+struct AudioRouteDescriptorTests {
+    @Test("Known Apple audio routes use specific system symbols", arguments: [
+        (AVAudioSession.Port.bluetoothA2DP, "AirPods Pro", "airpodspro"),
+        (AVAudioSession.Port.bluetoothA2DP, "AirPods Max", "airpodsmax"),
+        (AVAudioSession.Port.bluetoothLE, "Beats Studio", "beats.headphones"),
+        (AVAudioSession.Port.airPlay, "Living Room Apple TV", "appletv"),
+        (AVAudioSession.Port.airPlay, "Kitchen HomePod mini", "homepodmini"),
+        (AVAudioSession.Port.HDMI, "Receiver", "tv.fill"),
+    ])
+    func systemSymbol(port: AVAudioSession.Port, name: String, expected: String) {
+        let descriptor = AudioRouteDescriptor.resolve(portType: port, name: name)
+        #expect(descriptor.name == name)
+        #expect(descriptor.symbol == expected)
+    }
+
+    @Test("Unknown Bluetooth devices use a stable speaker fallback")
+    func genericBluetoothFallback() {
+        let descriptor = AudioRouteDescriptor.resolve(
+            portType: .bluetoothA2DP,
+            name: "Conference Speaker"
+        )
+        #expect(descriptor.symbol == "hifispeaker.fill")
+    }
+}

--- a/TwinskaraokeTests/NowPlayingInfoBuilderTests.swift
+++ b/TwinskaraokeTests/NowPlayingInfoBuilderTests.swift
@@ -1,0 +1,57 @@
+import MediaPlayer
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Now Playing metadata")
+@MainActor
+struct NowPlayingInfoBuilderTests {
+    @Test("On-demand playback publishes bounded timing and preferred artists")
+    func onDemandMetadata() {
+        let song = fixture(originalArtists: [" Artist A ", "", "Artist B"])
+        let info = NowPlayingInfoBuilder.make(
+            song: song,
+            playbackRate: 1,
+            isLiveStream: false,
+            duration: 180,
+            elapsed: 250,
+            existingArtwork: nil
+        )
+
+        #expect(info[MPMediaItemPropertyTitle] as? String == "A Song")
+        #expect(info[MPMediaItemPropertyArtist] as? String == "Artist A, Artist B")
+        #expect(info[MPNowPlayingInfoPropertyIsLiveStream] as? Bool == false)
+        #expect(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double == 180)
+        #expect(info[MPMediaItemPropertyPlaybackDuration] as? Double == 180)
+    }
+
+    @Test("Live radio omits seekable timing metadata")
+    func liveMetadata() {
+        let info = NowPlayingInfoBuilder.make(
+            song: fixture(originalArtists: nil),
+            playbackRate: 1,
+            isLiveStream: true,
+            duration: 180,
+            elapsed: 30,
+            existingArtwork: nil
+        )
+
+        #expect(info[MPNowPlayingInfoPropertyIsLiveStream] as? Bool == true)
+        #expect(info[MPNowPlayingInfoPropertyElapsedPlaybackTime] == nil)
+        #expect(info[MPMediaItemPropertyPlaybackDuration] == nil)
+        #expect(info[MPMediaItemPropertyArtist] as? String == "Cover Artist")
+    }
+
+    private func fixture(originalArtists: [String]?) -> Song {
+        Song(
+            id: "song",
+            title: "A Song",
+            duration: 180,
+            absolutePath: nil,
+            cloudflareID: nil,
+            coverArt: nil,
+            originalArtists: originalArtists,
+            coverArtists: ["Cover Artist"],
+            userUploaded: false
+        )
+    }
+}

--- a/TwinskaraokeTests/PlaybackQueueStateTests.swift
+++ b/TwinskaraokeTests/PlaybackQueueStateTests.swift
@@ -59,6 +59,25 @@ struct PlaybackQueueStateTests {
         #expect(state.items.map(\.id) == ["0", "1", "4", "3"])
     }
 
+    @Test("Removing shuffled Up Next songs also removes them from restored order")
+    func shuffledRemovalPersistsWhenShuffleIsDisabled() throws {
+        let songs = fixtures(4)
+        var state = PlaybackQueueState()
+        let selection = state.beginShuffled(
+            songs: songs,
+            selecting: { $0[1] },
+            shuffling: { Array($0.reversed()) }
+        )
+        let current = try #require(selection)
+
+        #expect(state.items.map(\.id) == ["1", "3", "2", "0"])
+        state.removeUpNext(after: current, at: IndexSet(integer: 0))
+        #expect(state.items.map(\.id) == ["1", "2", "0"])
+
+        state.toggleShuffle(current: current)
+        #expect(state.items.map(\.id) == ["0", "1", "2"])
+    }
+
     @Test("Starting a shuffled session retains the source ordering")
     func beginShuffledRetainsSource() throws {
         let songs = fixtures(4)

--- a/TwinskaraokeTests/PlaybackQueueStateTests.swift
+++ b/TwinskaraokeTests/PlaybackQueueStateTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Playback queue state")
+struct PlaybackQueueStateTests {
+    @Test("Play Next inserts once immediately after the current song")
+    func insertNextIsStableAndDeduplicated() {
+        let songs = fixtures(4)
+        var state = PlaybackQueueState()
+        state.beginInOrder(context: songs)
+
+        state.insertNext(songs[3], after: songs[1])
+        #expect(state.items.map(\.id) == ["0", "1", "3", "2"])
+
+        state.insertNext(songs[3], after: songs[1])
+        #expect(state.items.map(\.id) == ["0", "1", "3", "2"])
+    }
+
+    @Test("Disabling shuffle restores the exact original order")
+    func shuffleRestoresOriginalOrder() {
+        let songs = fixtures(4)
+        var state = PlaybackQueueState()
+        state.beginInOrder(context: songs)
+
+        state.toggleShuffle(current: songs[1], shuffling: { Array($0.reversed()) })
+        #expect(state.isShuffled)
+        #expect(state.items.map(\.id) == ["1", "3", "2", "0"])
+
+        state.toggleShuffle(current: songs[1])
+        #expect(!state.isShuffled)
+        #expect(state.items == songs)
+        #expect(state.originalItems.isEmpty)
+    }
+
+    @Test("Repeat and autoplay decisions are explicit queue outcomes")
+    func advanceMatrix() {
+        let songs = fixtures(2)
+        var state = PlaybackQueueState()
+        state.beginInOrder(context: songs)
+
+        #expect(state.advance(after: songs[0], repeatMode: .off, autoplayEnabled: false) == .play(songs[1]))
+        #expect(state.advance(after: songs[1], repeatMode: .one, autoplayEnabled: false) == .replayCurrent)
+        #expect(state.advance(after: songs[1], repeatMode: .all, autoplayEnabled: false) == .play(songs[0]))
+        #expect(state.advance(after: songs[1], repeatMode: .off, autoplayEnabled: true) == .autoplay)
+        #expect(state.advance(after: songs[1], repeatMode: .off, autoplayEnabled: false) == .stop)
+    }
+
+    @Test("Up Next edits cannot alter played queue entries")
+    func upNextEditingPreservesHistory() {
+        let songs = fixtures(5)
+        var state = PlaybackQueueState()
+        state.beginInOrder(context: songs)
+
+        state.moveUpNext(after: songs[1], from: IndexSet(integer: 2), to: 0)
+        #expect(state.items.map(\.id) == ["0", "1", "4", "2", "3"])
+
+        state.removeUpNext(after: songs[1], at: IndexSet(integer: 1))
+        #expect(state.items.map(\.id) == ["0", "1", "4", "3"])
+    }
+
+    @Test("Starting a shuffled session retains the source ordering")
+    func beginShuffledRetainsSource() throws {
+        let songs = fixtures(4)
+        var state = PlaybackQueueState()
+
+        let shuffledSelection = state.beginShuffled(
+            songs: songs,
+            selecting: { $0[2] },
+            shuffling: { Array($0.reversed()) }
+        )
+        let selected = try #require(shuffledSelection)
+
+        #expect(selected == songs[2])
+        #expect(state.originalItems == songs)
+        #expect(state.items.map(\.id) == ["2", "3", "1", "0"])
+    }
+
+    private func fixtures(_ count: Int) -> [Song] {
+        (0..<count).map { index in
+            Song(
+                id: String(index),
+                title: "Song \(index)",
+                duration: 180,
+                absolutePath: nil,
+                cloudflareID: nil,
+                coverArt: nil,
+                originalArtists: ["Artist"],
+                coverArtists: nil,
+                userUploaded: false
+            )
+        }
+    }
+}

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -160,7 +160,7 @@ final class TwinskaraokeUITests: XCTestCase {
     )
     if isRunningOnPad {
       XCTAssertTrue(
-        accessibleElementExists(identifier: "PlaylistDetail.WideOverview", in: app, timeout: 8),
+        playlistDetailUsesWideOverview(in: app, timeout: 8),
         "Expected playlist detail to use a wide Apple Music-style overview on iPad."
       )
     }
@@ -203,12 +203,24 @@ final class TwinskaraokeUITests: XCTestCase {
     )
 
     openRootSection("Search", in: app)
+    let firstSongIdentifier = "PlaylistDetail.song.0.ui-search-song-1"
+    if !element(identifier: firstSongIdentifier, in: app).waitForExistence(timeout: 2) {
+      // A split-view section switch may restore Search at its root instead of
+      // preserving the pushed playlist. Reopen it explicitly so this test
+      // measures history semantics, not NavigationSplitView path retention.
+      openVisibleItem("Public Playlists", identifier: "SearchCategory.PublicPlaylists", in: app)
+      openVisibleItem(
+        "Karaoke Essentials",
+        identifier: "PlaylistList.ui-search-playlist-essentials",
+        in: app
+      )
+    }
     scrollToVisibleItem(
       "Wake Me Up Before You Go-Go",
-      identifier: "PlaylistDetail.song.0.ui-search-song-1",
+      identifier: firstSongIdentifier,
       in: app
     )
-    let firstSong = element(identifier: "PlaylistDetail.song.0.ui-search-song-1", in: app)
+    let firstSong = element(identifier: firstSongIdentifier, in: app)
     XCTAssertTrue(
       waitUntil(timeout: 5) { firstSong.isHittable && self.tapStartsPlayback(firstSong, in: app) },
       "Expected deliberate playlist playback to start."
@@ -606,7 +618,8 @@ final class TwinskaraokeUITests: XCTestCase {
     let artwork = playerArtwork(in: app)
     XCTAssertTrue(artwork.waitForExistence(timeout: 8), "Missing the player artwork.")
 
-    // Both ends inside the artwork, so the touch never leaves the old button.
+    // Keep both ends inside the artwork: that is the exact gesture the former
+    // Button misread as a tap.
     let start = artwork.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12))
     let end = artwork.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.92))
     start.press(forDuration: 0.05, thenDragTo: end, withVelocity: 400, thenHoldForDuration: 0.1)
@@ -618,10 +631,17 @@ final class TwinskaraokeUITests: XCTestCase {
     // Both halves, because either one alone can be satisfied by a broken
     // player: a gesture that swallowed the drag outright would open no cover
     // art and dismiss nothing, and pass the assertion above on its own.
-    XCTAssertTrue(
-      waitUntil(timeout: 5) { self.miniPlayerIsHittable(in: app) },
-      "Dragging down from the artwork did not dismiss the full-screen player."
-    )
+    // Compact artwork is tall enough for this contained drag to cross the
+    // player's 25% commit threshold. The iPad landscape bottom bar uses a 64pt
+    // thumbnail only ~90pt above the screen edge, so dismissal is physically
+    // impossible without a fast flick; `testDraggingDownDismisses...` covers
+    // the full-surface dismissal path on every layout.
+    if !isRunningOnPad {
+      XCTAssertTrue(
+        waitUntil(timeout: 5) { self.miniPlayerIsHittable(in: app) },
+        "Dragging down from the artwork did not dismiss the full-screen player."
+      )
+    }
   }
 
   /// The other half of the bargain: a deliberate tap must still open it.
@@ -727,6 +747,36 @@ final class TwinskaraokeUITests: XCTestCase {
         "Expected the player to switch into lyrics mode."
       )
     }
+  }
+
+  func testAccessibilityDynamicTypeKeepsPlayerControlsReachable() throws {
+    let app = launchApp(
+      initialSection: "home",
+      preferredContentSizeCategory: "UICTContentSizeCategoryAccessibilityXL"
+    )
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))
+
+    openVisibleItem(
+      "Wake Me Up Before You Go-Go",
+      identifier: "HomeSongSection.Made for You.ui-home-song-1",
+      in: app
+    )
+    openMiniPlayer(in: app)
+
+    XCTAssertTrue(
+      app.buttons["Play"].waitForExistence(timeout: 8)
+        || app.buttons["Pause"].waitForExistence(timeout: 8),
+      "The primary transport control disappeared at an accessibility text size."
+    )
+    XCTAssertTrue(
+      app.buttons["Playing Next"].waitForExistence(timeout: 8),
+      "The queue control disappeared at an accessibility text size."
+    )
+    XCTAssertTrue(
+      app.buttons["Show Lyrics"].waitForExistence(timeout: 8)
+        || app.buttons["Hide Lyrics"].waitForExistence(timeout: 8),
+      "The lyrics control disappeared at an accessibility text size."
+    )
   }
 
   func testAccountToolbarOpensAccountAndSettings() throws {
@@ -842,7 +892,8 @@ final class TwinskaraokeUITests: XCTestCase {
 
   private func launchApp(
     initialSection: String? = nil,
-    resetRecentlyPlayed: Bool = false
+    resetRecentlyPlayed: Bool = false,
+    preferredContentSizeCategory: String? = nil
   ) -> XCUIApplication {
     let app = XCUIApplication()
     app.launchArguments += ["-UITestMode", "1"]
@@ -852,17 +903,30 @@ final class TwinskaraokeUITests: XCTestCase {
     if let initialSection {
       app.launchArguments += ["-UITestInitialSection", initialSection]
     }
+    if let preferredContentSizeCategory {
+      app.launchArguments += [
+        "-UIPreferredContentSizeCategoryName",
+        preferredContentSizeCategory,
+      ]
+    }
     app.launch()
     return app
   }
 
   private func openRootSection(_ title: String, in app: XCUIApplication) {
-    if app.tabBars.buttons[title].waitForExistence(timeout: 3) {
-      app.tabBars.buttons[title].tap()
+    let tabButton = app.tabBars.buttons[title].firstMatch
+    if tabButton.waitForExistence(timeout: 3) {
+      tabButton.tap()
       return
     }
 
     let identifier = "RootSection.\(title.lowercased())"
+    let identifiedSidebarCell = app.cells.containing(.staticText, identifier: identifier).firstMatch
+    if identifiedSidebarCell.waitForExistence(timeout: 3) {
+      identifiedSidebarCell.tap()
+      return
+    }
+
     if app.staticTexts[identifier].waitForExistence(timeout: 3) {
       app.staticTexts[identifier].tap()
       return
@@ -891,8 +955,9 @@ final class TwinskaraokeUITests: XCTestCase {
       return
     }
 
-    if app.buttons[title].waitForExistence(timeout: 3) {
-      app.buttons[title].tap()
+    let fallbackButton = app.buttons[title].firstMatch
+    if fallbackButton.waitForExistence(timeout: 3) {
+      fallbackButton.tap()
       return
     }
 
@@ -1030,6 +1095,29 @@ final class TwinskaraokeUITests: XCTestCase {
     timeout: TimeInterval
   ) -> Bool {
     element(identifier: identifier, in: app).waitForExistence(timeout: timeout)
+  }
+
+  private func playlistDetailUsesWideOverview(
+    in app: XCUIApplication,
+    timeout: TimeInterval
+  ) -> Bool {
+    if accessibleElementExists(
+      identifier: "PlaylistDetail.WideOverview",
+      in: app,
+      timeout: timeout
+    ) {
+      return true
+    }
+
+    // iOS 26 can omit identifier-only `.contain` accessibility containers.
+    // Verify the actual two-column layout instead: the artwork/title rail must
+    // sit meaningfully to the left of the first song column.
+    let title = app.staticTexts["Karaoke Essentials"].firstMatch
+    let firstSong = element(identifier: "PlaylistDetail.song.0.ui-search-song-1", in: app)
+    guard title.waitForExistence(timeout: timeout),
+          firstSong.waitForExistence(timeout: timeout)
+    else { return false }
+    return firstSong.frame.minX - title.frame.minX >= 280
   }
 
   private var isRunningOnPad: Bool {

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -204,7 +204,8 @@ final class TwinskaraokeUITests: XCTestCase {
 
     openRootSection("Search", in: app)
     let firstSongIdentifier = "PlaylistDetail.song.0.ui-search-song-1"
-    if !element(identifier: firstSongIdentifier, in: app).waitForExistence(timeout: 2) {
+    let firstSong = element(identifier: firstSongIdentifier, in: app)
+    if !waitUntil(timeout: 2, { firstSong.isHittable }) {
       // A split-view section switch may restore Search at its root instead of
       // preserving the pushed playlist. Reopen it explicitly so this test
       // measures history semantics, not NavigationSplitView path retention.
@@ -220,7 +221,6 @@ final class TwinskaraokeUITests: XCTestCase {
       identifier: firstSongIdentifier,
       in: app
     )
-    let firstSong = element(identifier: firstSongIdentifier, in: app)
     XCTAssertTrue(
       waitUntil(timeout: 5) { firstSong.isHittable && self.tapStartsPlayback(firstSong, in: app) },
       "Expected deliberate playlist playback to start."
@@ -787,17 +787,21 @@ final class TwinskaraokeUITests: XCTestCase {
     openMiniPlayer(in: app)
 
     XCTAssertTrue(
-      app.buttons["Play"].waitForExistence(timeout: 8)
-        || app.buttons["Pause"].waitForExistence(timeout: 8),
+      waitUntil(timeout: 8) {
+        app.buttons["Play"].firstMatch.isHittable
+          || app.buttons["Pause"].firstMatch.isHittable
+      },
       "The primary transport control disappeared at an accessibility text size."
     )
     XCTAssertTrue(
-      app.buttons["Playing Next"].waitForExistence(timeout: 8),
+      waitUntil(timeout: 8) { app.buttons["Playing Next"].firstMatch.isHittable },
       "The queue control disappeared at an accessibility text size."
     )
     XCTAssertTrue(
-      app.buttons["Show Lyrics"].waitForExistence(timeout: 8)
-        || app.buttons["Hide Lyrics"].waitForExistence(timeout: 8),
+      waitUntil(timeout: 8) {
+        app.buttons["Show Lyrics"].firstMatch.isHittable
+          || app.buttons["Hide Lyrics"].firstMatch.isHittable
+      },
       "The lyrics control disappeared at an accessibility text size."
     )
   }
@@ -1094,20 +1098,22 @@ final class TwinskaraokeUITests: XCTestCase {
     for _ in 0..<6 {
       if let identifier {
         let identifiedElement = element(identifier: identifier, in: app)
-        if identifiedElement.exists {
+        if identifiedElement.isHittable {
           return
         }
       }
-      if app.staticTexts[title].exists || app.buttons[title].exists {
+      if app.staticTexts[title].firstMatch.isHittable
+        || app.buttons[title].firstMatch.isHittable
+      {
         return
       }
       app.swipeUp()
     }
 
     XCTAssertTrue(
-      (identifier.map { element(identifier: $0, in: app).exists } ?? false)
-        || app.staticTexts[title].exists
-        || app.buttons[title].exists,
+      (identifier.map { element(identifier: $0, in: app).isHittable } ?? false)
+        || app.staticTexts[title].firstMatch.isHittable
+        || app.buttons[title].firstMatch.isHittable,
       "Missing visible item \(title) after scrolling."
     )
   }

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -631,12 +631,35 @@ final class TwinskaraokeUITests: XCTestCase {
     // Both halves, because either one alone can be satisfied by a broken
     // player: a gesture that swallowed the drag outright would open no cover
     // art and dismiss nothing, and pass the assertion above on its own.
-    // Compact artwork is tall enough for this contained drag to cross the
-    // player's 25% commit threshold. The iPad landscape bottom bar uses a 64pt
-    // thumbnail only ~90pt above the screen edge, so dismissal is physically
-    // impossible without a fast flick; `testDraggingDownDismisses...` covers
-    // the full-surface dismissal path on every layout.
-    if !isRunningOnPad {
+    if isRunningOnPad {
+      // The landscape bottom bar uses a 64pt thumbnail only ~90pt above the
+      // screen edge. A contained drag cannot cross the player's 25% commit
+      // threshold, so first assert that it correctly springs back rather than
+      // silently treating a missing dismissal assertion as success.
+      XCTAssertFalse(
+        waitUntil(timeout: 1) { self.miniPlayerIsHittable(in: app) },
+        "A short contained iPad artwork drag unexpectedly dismissed the player."
+      )
+
+      // Then prove the artwork drag did not leave the shared gesture state
+      // stuck: a deliberate full-surface pull must still dismiss normally.
+      let dismissStart = player.coordinate(
+        withNormalizedOffset: CGVector(dx: 0.5, dy: 0.18)
+      )
+      let dismissEnd = player.coordinate(
+        withNormalizedOffset: CGVector(dx: 0.5, dy: 0.85)
+      )
+      dismissStart.press(
+        forDuration: 0.05,
+        thenDragTo: dismissEnd,
+        withVelocity: 400,
+        thenHoldForDuration: 0.1
+      )
+      XCTAssertTrue(
+        waitUntil(timeout: 5) { self.miniPlayerIsHittable(in: app) },
+        "The iPad player could not dismiss after a contained artwork drag."
+      )
+    } else {
       XCTAssertTrue(
         waitUntil(timeout: 5) { self.miniPlayerIsHittable(in: app) },
         "Dragging down from the artwork did not dismiss the full-screen player."


### PR DESCRIPTION
## Summary

- isolate playback queue, audio-session, routing, and Now Playing coordination behind testable boundaries
- improve adaptive iPhone and iPad player layouts, Dynamic Type behavior, gestures, and navigation regressions
- pause decorative motion for Reduce Motion and Low Power Mode while retaining responsive interaction transitions
- improve CarPlay playlist artwork loading with bounded caching and stale-request protection
- add local Instruments signposts for launch, playback readiness, and player presentation
- align Swift 6 and Xcode release settings

## Verification

- Swift unit test suite passed
- iPhone UI suite passed: 19/19
- iPad UI matrix passed: 18/19 in the complete run, with the corrected navigation-fixture case passing independently
- Xcode static analyzer passed
- unsigned Release builds passed for iOS, macOS, tvOS, watchOS, and watch widgets
- `git diff --check` passed

## Review notes

The commits are split into playback architecture, adaptive experience polish, and release settings to keep review focused.

## Summary by Sourcery

Polish playback coordination, adaptive player experiences, motion behavior, CarPlay artwork handling, and release performance diagnostics.

New Features:
- Add adaptive iPhone and iPad player layouts that preserve usable controls across wider screens and accessibility text sizes.
- Pause decorative animations when Reduce Motion or Low Power Mode is active while retaining interactive transitions.
- Load playlist artwork in CarPlay with bounded, size-aware caching and protection against stale requests.

Bug Fixes:
- Fix iPad playlist detail layouts and navigation test behavior across adaptive split-view configurations.
- Prevent queue, shuffle, Up Next, and playback progression state from becoming inconsistent.
- Improve Now Playing timing metadata and audio-route handling through centralized coordination.

Enhancements:
- Separate playback queue state, audio-session management, and Now Playing metadata behind testable boundaries.
- Add local performance signposts for app initialization, playback requests and readiness, and player presentation changes.

Build:
- Align project release settings with the supported Swift 6 and Xcode configuration.

Tests:
- Add unit coverage for adaptive layout breakpoints, motion policy, audio-route presentation, Now Playing metadata, and playback queue behavior.
- Expand UI coverage for accessibility-sized player controls, iPad gestures, wide playlist layouts, and navigation recovery.