### PR TITLE
Align the interface with Apple Music

### DIFF
--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -13,7 +13,7 @@ struct PlaylistCarousel: View {
     var body: some View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
-            VStack(alignment: .leading, spacing: AM.Spacing.s) {
+            VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
                 AMSectionHeader(
                     title, destination: PlaylistListView(title: title, playlists: playlists, apiURL: apiURL)
                 )
@@ -67,7 +67,7 @@ struct HomeSongSection: View {
     var body: some View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
-            VStack(alignment: .leading, spacing: AM.Spacing.s) {
+            VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
                 AMSectionHeader(title, destination: BrowseSongCollectionView(title: title, songs: songs))
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
@@ -104,21 +104,13 @@ struct WideSongListPanel: View {
     let songs: [Song]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AM.Spacing.s) {
-            NavigationLink(destination: BrowseSongCollectionView(title: title, songs: songs)) {
-                HStack(alignment: .firstTextBaseline, spacing: AM.Spacing.s) {
-                    Text(title)
-                        .font(AM.Font.sectionHeader)
-                        .foregroundStyle(.primary)
-                    Image(systemName: "chevron.right")
-                        .font(AM.Font.chevron)
-                        .foregroundStyle(.tertiary)
-                        .frame(width: 44, height: 44)
-                        .accessibilityHidden(true)
-                    Spacer()
-                }
-            }
-            .buttonStyle(.plain)
+        VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+            // The panel supplies its own margins, so the header adds none.
+            AMSectionHeader(
+                title,
+                destination: BrowseSongCollectionView(title: title, songs: songs),
+                horizontalPadding: 0
+            )
             LazyVStack(spacing: 0) {
                 ForEach(songs) { song in
                     Button {
@@ -145,7 +137,7 @@ struct LatestSingleSection: View {
     @State private var showAddToPlaylist = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AM.Spacing.m) {
+        VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
             AMSectionHeader("Latest Single")
             Button {
                 play()

--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -15,7 +15,8 @@ struct PlaylistCarousel: View {
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
             VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
                 AMSectionHeader(
-                    title, destination: PlaylistListView(title: title, playlists: playlists, apiURL: apiURL)
+                    verbatim: title,
+                    destination: PlaylistListView(title: title, playlists: playlists, apiURL: apiURL)
                 )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
@@ -68,7 +69,7 @@ struct HomeSongSection: View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
             VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
-                AMSectionHeader(title, destination: BrowseSongCollectionView(title: title, songs: songs))
+                AMSectionHeader(verbatim: title, destination: BrowseSongCollectionView(title: title, songs: songs))
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(songs) { song in
@@ -107,7 +108,7 @@ struct WideSongListPanel: View {
         VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
             // The panel supplies its own margins, so the header adds none.
             AMSectionHeader(
-                title,
+                verbatim: title,
                 destination: BrowseSongCollectionView(title: title, songs: songs),
                 horizontalPadding: 0
             )

--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct PlaylistCarousel: View {
     @Namespace private var zoomNamespace
+    /// Localizable: every caller passes a literal. The destination needs a
+    /// resolved `String` for its navigation title, which `String(localized:)`
+    /// gives us from the same value.
     let title: String
     let playlists: [Playlist]
     var isLoadingMore: Bool = false
@@ -9,14 +12,21 @@ struct PlaylistCarousel: View {
     var apiURL: ((Int, Int) -> String)?
     var horizontalPadding: CGFloat = AM.Spacing.screenMargin
     @State private var availableWidth: CGFloat = 390
+    /// Grows the shelf with the text size; see AM.Layout.shelfLabelAllowance.
+    @ScaledMetric(relativeTo: .subheadline) private var labelAllowance: CGFloat =
+        AM.Layout.shelfLabelAllowance
 
     var body: some View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
             VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
                 AMSectionHeader(
-                    verbatim: title,
-                    destination: PlaylistListView(title: title, playlists: playlists, apiURL: apiURL)
+                    title,
+                    destination: PlaylistListView(
+                        title: title,
+                        playlists: playlists,
+                        apiURL: apiURL
+                    )
                 )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
@@ -50,7 +60,10 @@ struct PlaylistCarousel: View {
                 updateAvailableWidth(width)
             }
         }
-        .frame(height: AM.Layout.mediaShelfHeight(tileWidth: AM.Layout.shelfTileWidth(for: availableWidth)))
+        .frame(height: AM.Layout.mediaShelfHeight(
+            tileWidth: AM.Layout.shelfTileWidth(for: availableWidth),
+            labelAllowance: labelAllowance
+        ))
     }
 
     private func updateAvailableWidth(_ width: CGFloat) {
@@ -64,12 +77,28 @@ struct HomeSongSection: View {
     let songs: [Song]
     var horizontalPadding: CGFloat = AM.Spacing.screenMargin
     @State private var availableWidth: CGFloat = 390
+    /// Grows the shelf with the text size; see AM.Layout.shelfLabelAllowance.
+    @ScaledMetric(relativeTo: .subheadline) private var labelAllowance: CGFloat =
+        AM.Layout.shelfLabelAllowance
+
+    init(
+        title: String,
+        songs: [Song],
+        horizontalPadding: CGFloat = AM.Spacing.screenMargin
+    ) {
+        self.title = title
+        self.songs = songs
+        self.horizontalPadding = horizontalPadding
+    }
 
     var body: some View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
             VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
-                AMSectionHeader(verbatim: title, destination: BrowseSongCollectionView(title: title, songs: songs))
+                AMSectionHeader(
+                    title,
+                    destination: BrowseSongCollectionView(title: title, songs: songs)
+                )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(songs) { song in
@@ -91,7 +120,10 @@ struct HomeSongSection: View {
                 updateAvailableWidth(width)
             }
         }
-        .frame(height: AM.Layout.mediaShelfHeight(tileWidth: AM.Layout.shelfTileWidth(for: availableWidth)))
+        .frame(height: AM.Layout.mediaShelfHeight(
+            tileWidth: AM.Layout.shelfTileWidth(for: availableWidth),
+            labelAllowance: labelAllowance
+        ))
     }
 
     private func updateAvailableWidth(_ width: CGFloat) {
@@ -108,7 +140,7 @@ struct WideSongListPanel: View {
         VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
             // The panel supplies its own margins, so the header adds none.
             AMSectionHeader(
-                verbatim: title,
+                title,
                 destination: BrowseSongCollectionView(title: title, songs: songs),
                 horizontalPadding: 0
             )
@@ -139,7 +171,7 @@ struct LatestSingleSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
-            AMSectionHeader("Latest Single")
+            AMSectionHeader(String(localized: "Latest Single"))
             Button {
                 play()
             } label: {

--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -26,7 +26,8 @@ struct PlaylistCarousel: View {
                         title: title,
                         playlists: playlists,
                         apiURL: apiURL
-                    )
+                    ),
+                    horizontalPadding: horizontalPadding
                 )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
@@ -53,23 +54,14 @@ struct PlaylistCarousel: View {
                     .padding(.horizontal, horizontalPadding)
                 }
             }
-            .onAppear {
-                updateAvailableWidth(proxy.size.width)
-            }
-            .onChange(of: proxy.size.width) { _, width in
-                updateAvailableWidth(width)
-            }
         }
+        .trackingWidth(into: $availableWidth)
         .frame(height: AM.Layout.mediaShelfHeight(
             tileWidth: AM.Layout.shelfTileWidth(for: availableWidth),
             labelAllowance: labelAllowance
         ))
     }
 
-    private func updateAvailableWidth(_ width: CGFloat) {
-        guard width > 0, abs(width - availableWidth) > 0.5 else { return }
-        availableWidth = width
-    }
 }
 
 struct HomeSongSection: View {
@@ -97,7 +89,8 @@ struct HomeSongSection: View {
             VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
                 AMSectionHeader(
                     title,
-                    destination: BrowseSongCollectionView(title: title, songs: songs)
+                    destination: BrowseSongCollectionView(title: title, songs: songs),
+                    horizontalPadding: horizontalPadding
                 )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
@@ -113,23 +106,14 @@ struct HomeSongSection: View {
                     .padding(.horizontal, horizontalPadding)
                 }
             }
-            .onAppear {
-                updateAvailableWidth(proxy.size.width)
-            }
-            .onChange(of: proxy.size.width) { _, width in
-                updateAvailableWidth(width)
-            }
         }
+        .trackingWidth(into: $availableWidth)
         .frame(height: AM.Layout.mediaShelfHeight(
             tileWidth: AM.Layout.shelfTileWidth(for: availableWidth),
             labelAllowance: labelAllowance
         ))
     }
 
-    private func updateAvailableWidth(_ width: CGFloat) {
-        guard width > 0, abs(width - availableWidth) > 0.5 else { return }
-        availableWidth = width
-    }
 }
 
 struct WideSongListPanel: View {
@@ -171,7 +155,7 @@ struct LatestSingleSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
-            AMSectionHeader(String(localized: "Latest Single"))
+            AMSectionHeader(String(localized: "Latest Single"), horizontalPadding: horizontalPadding)
             Button {
                 play()
             } label: {

--- a/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
+++ b/Twinskaraoke/Components/Library/AddToPlaylistSheet.swift
@@ -182,9 +182,9 @@ private struct AddToPlaylistSongPreview: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            RemoteArtworkImage(url: song.thumbnailURL ?? song.imageURL, cornerRadius: 10)
+            RemoteArtworkImage(url: song.thumbnailURL ?? song.imageURL, cornerRadius: AM.Radius.card)
                 .frame(width: 74, height: 74)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
                 .shadow(color: Color.appShadow, radius: 10, y: 6)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -217,9 +217,9 @@ private struct AddToPlaylistRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            PlaylistArtwork(playlist: playlist.asPlaylist(), cornerRadius: 7)
+            PlaylistArtwork(playlist: playlist.asPlaylist(), cornerRadius: AM.Radius.thumb)
                 .frame(width: 50, height: 50)
-                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(playlist.name)
@@ -332,9 +332,9 @@ private struct AddToPlaylistPreview: View {
 
     var body: some View {
         ContextPreviewCard {
-            PlaylistArtwork(playlist: playlist.asPlaylist(), cornerRadius: 10)
+            PlaylistArtwork(playlist: playlist.asPlaylist(), cornerRadius: AM.Radius.card)
                 .frame(width: 220, height: 220)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
         } label: {
             VStack(alignment: .leading, spacing: 3) {
                 Text(playlist.isPublic ? "Public Playlist" : "Private Playlist")

--- a/Twinskaraoke/Components/Media/ArtThumbnail.swift
+++ b/Twinskaraoke/Components/Media/ArtThumbnail.swift
@@ -6,16 +6,16 @@ struct ArtThumbnail: View {
         Group {
             if let url = art.imageURL {
                 RemoteArtworkImage(
-                    url: url, cornerRadius: 8, lowResURL: art.blurPreviewURL,
+                    url: url, cornerRadius: AM.Radius.card, lowResURL: art.blurPreviewURL,
                     transparentBackground: true
                 )
             } else {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous)
                     .fill(Color(.tertiarySystemFill))
             }
         }
         .aspectRatio(1, contentMode: .fill)
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
         .overlay(alignment: .bottomTrailing) {
             if let upvotes = art.upvotes, upvotes > 0 {
                 Label("\(upvotes)", systemImage: "heart.fill")

--- a/Twinskaraoke/Components/Player/QueueComponents.swift
+++ b/Twinskaraoke/Components/Player/QueueComponents.swift
@@ -23,7 +23,7 @@ struct QueueRow: View {
                             .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
                         if isPlayingNext {
                             Text("NEXT")
-                                .font(.caption2.weight(.heavy))
+                                .font(AM.Font.badge)
                                 .foregroundStyle(.white)
                                 .padding(.horizontal, 5)
                                 .padding(.vertical, 2)
@@ -33,11 +33,11 @@ struct QueueRow: View {
                     }
                     VStack(alignment: .leading, spacing: 3) {
                         Text(song.title)
-                            .font(.body.weight(.medium))
+                            .font(AM.Font.rowTitle.weight(.medium))
                             .foregroundStyle(.primary)
                             .lineLimit(1)
                         Text(song.displayArtist)
-                            .font(.subheadline)
+                            .font(AM.Font.rowSubtitle)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
@@ -75,7 +75,7 @@ struct QueueRow: View {
                 }
             } label: {
                 Label("More actions", systemImage: "ellipsis")
-                    .font(.headline.weight(.semibold))
+                    .font(AM.Font.groupHeader)
                     .foregroundStyle(.secondary)
                     .labelStyle(.iconOnly)
                     .frame(width: 44, height: 44)
@@ -120,7 +120,7 @@ struct QueueModeButton: View {
                     Image(systemName: symbol)
                 }
             }
-            .font(.headline.weight(.semibold))
+            .font(AM.Font.groupHeader)
             .foregroundStyle(isActive ? Color.appControlActiveForeground : .primary)
             .frame(maxWidth: .infinity)
             .frame(minHeight: 44)

--- a/Twinskaraoke/Components/Player/QueueComponents.swift
+++ b/Twinskaraoke/Components/Player/QueueComponents.swift
@@ -16,11 +16,11 @@ struct QueueRow: View {
                     ZStack(alignment: .topLeading) {
                         RemoteArtworkImage(
                             url: audioManager.displayImageURL(for: song, variant: .row),
-                            cornerRadius: 7,
+                            cornerRadius: AM.Radius.thumb,
                             lowResURL: song.thumbnailURL
                         )
                             .frame(width: 50, height: 50)
-                            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
                         if isPlayingNext {
                             Text("NEXT")
                                 .font(AM.Font.badge)

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -577,25 +577,53 @@ private struct ToolbarIconLabel: View {
 /// 17pt glyph would only inflate the header's height without widening
 /// anything you can actually tap.
 struct AMSectionHeader<Destination: View>: View {
-    let title: String
+    /// Held as a `Text` so the two entry points can differ in *how* the title
+    /// resolves. `Text(LocalizedStringKey)` is looked up in the string catalog;
+    /// `Text(verbatim:)` is not, and neither is the `Text(String)` this
+    /// component used to build — which is how "Recently Added" quietly lost its
+    /// translations the moment it moved out of a literal `Text` and into here.
+    private let title: Text
     let destination: Destination?
     var horizontalPadding: CGFloat = AM.Spacing.screenMargin
 
+    /// For literal titles, which is most of them. Extracted for localization.
     init(
-        _ title: String,
+        _ titleKey: LocalizedStringKey,
         destination: Destination,
         horizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) {
-        self.title = title
+        title = Text(titleKey)
         self.destination = destination
         self.horizontalPadding = horizontalPadding
     }
 
     init(
-        _ title: String,
+        _ titleKey: LocalizedStringKey,
         horizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) where Destination == EmptyView {
-        self.title = title
+        title = Text(titleKey)
+        destination = nil
+        self.horizontalPadding = horizontalPadding
+    }
+
+    /// For titles that arrive as a runtime `String` — a shelf whose name came
+    /// from a view model. Nothing to look up, so say so at the call site
+    /// instead of silently getting the non-localizing overload.
+    init(
+        verbatim title: String,
+        destination: Destination,
+        horizontalPadding: CGFloat = AM.Spacing.screenMargin
+    ) {
+        self.title = Text(verbatim: title)
+        self.destination = destination
+        self.horizontalPadding = horizontalPadding
+    }
+
+    init(
+        verbatim title: String,
+        horizontalPadding: CGFloat = AM.Spacing.screenMargin
+    ) where Destination == EmptyView {
+        self.title = Text(verbatim: title)
         destination = nil
         self.horizontalPadding = horizontalPadding
     }
@@ -616,7 +644,7 @@ struct AMSectionHeader<Destination: View>: View {
 
     private func headerRow(showChevron: Bool) -> some View {
         HStack(spacing: AM.Spacing.xs) {
-            Text(title)
+            title
                 .font(AM.Font.sectionHeader)
                 .foregroundStyle(.primary)
             if showChevron {

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -337,13 +337,22 @@ enum AM {
         static let songGridColumns = adaptiveGridColumns(minimum: 154)
         static let categoryGridColumns = adaptiveGridColumns(minimum: 160, spacing: Spacing.m)
 
-        /// Tile plus its caption block plus the section header above it.
-        /// Retuned from +100 when the type ramp moved: the header dropped from
-        /// 28pt to 22pt and the tile labels from headline+caption to a matched
-        /// subheadline pair, so the old constant left ~14pt of dead air under
-        /// every shelf.
-        static func mediaShelfHeight(tileWidth: CGFloat) -> CGFloat {
-            tileWidth + 90
+        /// Everything a shelf needs above and below its artwork: the section
+        /// header, the gap under it, and the tile's two label lines.
+        ///
+        /// At the default text size this is 90 — retuned from 100 when the type
+        /// ramp moved, since the header dropped 28pt to 22pt and the tile labels
+        /// from headline+caption to a matched subheadline pair.
+        ///
+        /// Shelves scale it with `@ScaledMetric`. A shelf's height is fixed
+        /// because it lives in a `GeometryReader`, so nothing else can grow it,
+        /// and at Accessibility L the labels need roughly half again this much —
+        /// a bare constant clipped tile titles through the baseline and dropped
+        /// the caption line entirely.
+        static let shelfLabelAllowance: CGFloat = 90
+
+        static func mediaShelfHeight(tileWidth: CGFloat, labelAllowance: CGFloat = shelfLabelAllowance) -> CGFloat {
+            tileWidth + labelAllowance
         }
 
         static func compactMediaShelfHeight(tileWidth: CGFloat) -> CGFloat {
@@ -576,54 +585,43 @@ private struct ToolbarIconLabel: View {
 /// the `NavigationLink`'s target via `contentShape`, so a 44x44 box around a
 /// 17pt glyph would only inflate the header's height without widening
 /// anything you can actually tap.
+/// The one section header. Every shelf, grid and panel heading goes through
+/// this — there used to be three hand-rolled variants that disagreed on the
+/// chevron's size, weight and colour.
+///
+/// The title is an **already-localized** `String`: callers pass
+/// `String(localized: "…")`. That is deliberate. This component cannot take a
+/// `LocalizedStringKey` (shelves must hand the same text to a destination's
+/// `navigationTitle`, and a key cannot be read back out) and
+/// `LocalizedStringResource` was worse — verified on a clean build, literals
+/// reaching a custom initializer that way are never extracted into the string
+/// catalog at all, so the headings silently shipped as English. Resolving at
+/// the call site is the form Xcode does extract.
+///
+/// The chevron carries no hit frame of its own on purpose. The whole row is
+/// the `NavigationLink`'s target via `contentShape`, so a 44x44 box around a
+/// 17pt glyph would only inflate the header's height without widening
+/// anything you can actually tap.
 struct AMSectionHeader<Destination: View>: View {
-    /// Held as a `Text` so the two entry points can differ in *how* the title
-    /// resolves. `Text(LocalizedStringKey)` is looked up in the string catalog;
-    /// `Text(verbatim:)` is not, and neither is the `Text(String)` this
-    /// component used to build — which is how "Recently Added" quietly lost its
-    /// translations the moment it moved out of a literal `Text` and into here.
-    private let title: Text
+    let title: String
     let destination: Destination?
     var horizontalPadding: CGFloat = AM.Spacing.screenMargin
 
-    /// For literal titles, which is most of them. Extracted for localization.
     init(
-        _ titleKey: LocalizedStringKey,
+        _ title: String,
         destination: Destination,
         horizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) {
-        title = Text(titleKey)
+        self.title = title
         self.destination = destination
         self.horizontalPadding = horizontalPadding
     }
 
     init(
-        _ titleKey: LocalizedStringKey,
+        _ title: String,
         horizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) where Destination == EmptyView {
-        title = Text(titleKey)
-        destination = nil
-        self.horizontalPadding = horizontalPadding
-    }
-
-    /// For titles that arrive as a runtime `String` — a shelf whose name came
-    /// from a view model. Nothing to look up, so say so at the call site
-    /// instead of silently getting the non-localizing overload.
-    init(
-        verbatim title: String,
-        destination: Destination,
-        horizontalPadding: CGFloat = AM.Spacing.screenMargin
-    ) {
-        self.title = Text(verbatim: title)
-        self.destination = destination
-        self.horizontalPadding = horizontalPadding
-    }
-
-    init(
-        verbatim title: String,
-        horizontalPadding: CGFloat = AM.Spacing.screenMargin
-    ) where Destination == EmptyView {
-        self.title = Text(verbatim: title)
+        self.title = title
         destination = nil
         self.horizontalPadding = horizontalPadding
     }
@@ -644,7 +642,9 @@ struct AMSectionHeader<Destination: View>: View {
 
     private func headerRow(showChevron: Bool) -> some View {
         HStack(spacing: AM.Spacing.xs) {
-            title
+            // `verbatim`: the string arrived translated, or is server data.
+            // Either way there is nothing left to look up.
+            Text(verbatim: title)
                 .font(AM.Font.sectionHeader)
                 .foregroundStyle(.primary)
             if showChevron {

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -253,8 +253,6 @@ enum AM {
         /// A section header to the content it labels. One value for every
         /// shelf and grid, so the rhythm does not drift per section.
         static let sectionHeaderGap: CGFloat = 10
-        /// One section to the next.
-        static let sectionGap: CGFloat = 28
         static let shelfTile: CGFloat = 162
         static let compactShelfTile: CGFloat = 132
     }
@@ -398,8 +396,6 @@ enum AM {
         /// the lyrics chevron, the translation globe.
         static let playerGlyph = SwiftUI.Font.headline.weight(.semibold)
 
-        /// Labels under round player controls and on action strips.
-        static let controlLabel = SwiftUI.Font.footnote.weight(.semibold)
         /// Counts and status pills.
         static let badge = SwiftUI.Font.caption2.weight(.semibold)
         static let timecode = SwiftUI.Font.caption.monospacedDigit()

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -444,6 +444,24 @@ extension View {
     }
 }
 
+extension View {
+    /// Reports this view's width into `width`, ignoring sub-point jitter.
+    ///
+    /// Shelves need their own width in two places at once: inside a
+    /// `GeometryReader` to size tiles, and outside it to size the fixed frame
+    /// the `GeometryReader` sits in. The proxy only reaches the first, so the
+    /// width has to be carried out in state. Five shelves were each about to
+    /// grow their own copy of that.
+    func trackingWidth(into width: Binding<CGFloat>) -> some View {
+        onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { newWidth in
+            guard newWidth > 0, abs(newWidth - width.wrappedValue) > 0.5 else { return }
+            width.wrappedValue = newWidth
+        }
+    }
+}
+
 @MainActor
 @discardableResult
 func withOptionalAnimation<Result>(

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -383,6 +383,14 @@ enum AM {
 
         static let nowPlayingTitle = SwiftUI.Font.title2.bold()
         static let nowPlayingArtist = SwiftUI.Font.title3
+        /// The player's title pair where the layout is tight — the iPad control
+        /// bar, the lyrics header, and any phone geometry short enough that the
+        /// full pair would crowd the transport.
+        static let nowPlayingTitleCompact = SwiftUI.Font.headline.bold()
+        static let nowPlayingArtistCompact = SwiftUI.Font.subheadline
+        /// Glyphs on the player's round chrome buttons — favourite, more,
+        /// the lyrics chevron, the translation globe.
+        static let playerGlyph = SwiftUI.Font.headline.weight(.semibold)
 
         /// Labels under round player controls and on action strips.
         static let controlLabel = SwiftUI.Font.footnote.weight(.semibold)

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -221,13 +221,24 @@ nonisolated extension Color {
 }
 
 enum AM {
+    /// Continuous corner radii, ramped by element size the way Apple Music's
+    /// are. A 44pt row thumbnail and a 340pt player hero should not share a
+    /// corner, which is what the old flat 7/8/10 ramp gave them.
     enum Radius {
-        static let thumb: CGFloat = 7
-        static let card: CGFloat = 8
-        static let hero: CGFloat = 10
-        static let tile: CGFloat = 8
+        static let thumb: CGFloat = 6
+        static let card: CGFloat = 10
+        static let tile: CGFloat = 10
+        /// Large artwork surfaces: the full-screen player, the radio and wide
+        /// heroes, playlist and browse headers.
+        ///
+        /// `ArtworkMorphLayer` lerps `thumb -> hero` while `PlayerArtworkView`
+        /// draws at `hero`, so the flying artwork lands on exactly the corner
+        /// it turns into. Those two must keep reading the same token — split
+        /// this in half and the morph ends on a different shape than the
+        /// artwork underneath it.
+        static let hero: CGFloat = 16
         static let popup: CGFloat = 6
-        static let sheet: CGFloat = 16
+        static let sheet: CGFloat = 20
     }
 
     enum Spacing {
@@ -239,6 +250,11 @@ enum AM {
         static let xxl: CGFloat = 28
         static let screenMargin: CGFloat = 16
         static let shelfSpacing: CGFloat = 20
+        /// A section header to the content it labels. One value for every
+        /// shelf and grid, so the rhythm does not drift per section.
+        static let sectionHeaderGap: CGFloat = 10
+        /// One section to the next.
+        static let sectionGap: CGFloat = 28
         static let shelfTile: CGFloat = 162
         static let compactShelfTile: CGFloat = 132
     }
@@ -323,8 +339,13 @@ enum AM {
         static let songGridColumns = adaptiveGridColumns(minimum: 154)
         static let categoryGridColumns = adaptiveGridColumns(minimum: 160, spacing: Spacing.m)
 
+        /// Tile plus its caption block plus the section header above it.
+        /// Retuned from +100 when the type ramp moved: the header dropped from
+        /// 28pt to 22pt and the tile labels from headline+caption to a matched
+        /// subheadline pair, so the old constant left ~14pt of dead air under
+        /// every shelf.
         static func mediaShelfHeight(tileWidth: CGFloat) -> CGFloat {
-            tileWidth + 100
+            tileWidth + 90
         }
 
         static func compactMediaShelfHeight(tileWidth: CGFloat) -> CGFloat {
@@ -335,17 +356,40 @@ enum AM {
         static let compactMediaShelfHeight = compactMediaShelfHeight(tileWidth: 152)
     }
 
+    /// The type ramp, calibrated against Apple Music rather than assembled a
+    /// call site at a time. Pick by role — the sizes and weights *are* the
+    /// design, and a raw `.font(.headline)` next to one of these is how the
+    /// interface drifts.
     enum Font {
-        static let sectionHeader = SwiftUI.Font.title.bold()
-        static let groupHeader = SwiftUI.Font.headline.bold()
-        static let tileTitle = SwiftUI.Font.headline
-        static let tileCaption = SwiftUI.Font.caption
+        /// A heading that carries a whole screen, below the navigation title.
+        static let screenTitle = SwiftUI.Font.largeTitle.bold()
+        /// Shelf and section headings: "Recently Added", "Made For You".
+        /// 22pt, not the 28pt `.title` this used to be — Apple Music's shelf
+        /// headers sit close to the content they label.
+        static let sectionHeader = SwiftUI.Font.title2.bold()
+        /// One level under `sectionHeader`.
+        static let groupHeader = SwiftUI.Font.title3.weight(.semibold)
+
+        /// Tile title and caption are the *same size* and separate on colour
+        /// alone. That is what makes an Apple Music shelf read as a grid of
+        /// items rather than a grid of headlines with footnotes under them.
+        static let tileTitle = SwiftUI.Font.subheadline
+        static let tileCaption = SwiftUI.Font.subheadline
+
         static let rowTitle = SwiftUI.Font.body
         static let rowSubtitle = SwiftUI.Font.subheadline
-        static let nowPlayingTitle = SwiftUI.Font.title.bold()
-        static let nowPlayingArtist = SwiftUI.Font.headline
+        static let rowCompactTitle = SwiftUI.Font.subheadline
+        static let rowCompactSubtitle = SwiftUI.Font.footnote
+
+        static let nowPlayingTitle = SwiftUI.Font.title2.bold()
+        static let nowPlayingArtist = SwiftUI.Font.title3
+
+        /// Labels under round player controls and on action strips.
+        static let controlLabel = SwiftUI.Font.footnote.weight(.semibold)
+        /// Counts and status pills.
+        static let badge = SwiftUI.Font.caption2.weight(.semibold)
         static let timecode = SwiftUI.Font.caption.monospacedDigit()
-        static let chevron = SwiftUI.Font.headline.bold()
+        static let chevron = SwiftUI.Font.subheadline.weight(.semibold)
     }
 
     enum Shadow {
@@ -514,17 +558,36 @@ private struct ToolbarIconLabel: View {
     }
 }
 
+/// The one section header. Every shelf, grid and panel heading goes through
+/// this — there used to be three hand-rolled variants that disagreed on the
+/// chevron's size, weight and colour.
+///
+/// The chevron carries no hit frame of its own on purpose. The whole row is
+/// the `NavigationLink`'s target via `contentShape`, so a 44x44 box around a
+/// 17pt glyph would only inflate the header's height without widening
+/// anything you can actually tap.
 struct AMSectionHeader<Destination: View>: View {
     let title: String
     let destination: Destination?
-    init(_ title: String, destination: Destination) {
+    var horizontalPadding: CGFloat = AM.Spacing.screenMargin
+
+    init(
+        _ title: String,
+        destination: Destination,
+        horizontalPadding: CGFloat = AM.Spacing.screenMargin
+    ) {
         self.title = title
         self.destination = destination
+        self.horizontalPadding = horizontalPadding
     }
 
-    init(_ title: String) where Destination == EmptyView {
+    init(
+        _ title: String,
+        horizontalPadding: CGFloat = AM.Spacing.screenMargin
+    ) where Destination == EmptyView {
         self.title = title
         destination = nil
+        self.horizontalPadding = horizontalPadding
     }
 
     var body: some View {
@@ -538,22 +601,23 @@ struct AMSectionHeader<Destination: View>: View {
                 headerRow(showChevron: false)
             }
         }
-        .padding(.horizontal, AM.Spacing.screenMargin)
+        .padding(.horizontal, horizontalPadding)
     }
 
     private func headerRow(showChevron: Bool) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: AM.Spacing.s) {
+        HStack(spacing: AM.Spacing.xs) {
             Text(title)
                 .font(AM.Font.sectionHeader)
                 .foregroundStyle(.primary)
             if showChevron {
                 Image(systemName: "chevron.right")
-                    .font(.headline.bold())
-                    .foregroundStyle(.secondary)
+                    .font(AM.Font.chevron)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
             }
-            Spacer()
+            Spacer(minLength: 0)
         }
-        .padding(.top, 2)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
     }
 }

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -367,6 +367,12 @@ enum AM {
         /// 22pt, not the 28pt `.title` this used to be — Apple Music's shelf
         /// headers sit close to the content they label.
         static let sectionHeader = SwiftUI.Font.title2.bold()
+        /// The title on a featured card that is smaller than the full-width
+        /// hero — the radio's featured episode, a promoted playlist.
+        static let heroTitle = SwiftUI.Font.title.bold()
+        /// The small uppercase kicker over a hero or featured title.
+        /// Always paired with `.textCase(.uppercase)` and a secondary colour.
+        static let eyebrow = SwiftUI.Font.caption.weight(.semibold)
         /// One level under `sectionHeader`.
         static let groupHeader = SwiftUI.Font.title3.weight(.semibold)
 

--- a/Twinskaraoke/Components/Shared/AppTheme.swift
+++ b/Twinskaraoke/Components/Shared/AppTheme.swift
@@ -354,13 +354,6 @@ enum AM {
         static func mediaShelfHeight(tileWidth: CGFloat, labelAllowance: CGFloat = shelfLabelAllowance) -> CGFloat {
             tileWidth + labelAllowance
         }
-
-        static func compactMediaShelfHeight(tileWidth: CGFloat) -> CGFloat {
-            tileWidth + 86
-        }
-
-        static let mediaShelfHeight = mediaShelfHeight(tileWidth: 190)
-        static let compactMediaShelfHeight = compactMediaShelfHeight(tileWidth: 152)
     }
 
     /// The type ramp, calibrated against Apple Music rather than assembled a
@@ -577,14 +570,6 @@ private struct ToolbarIconLabel: View {
     }
 }
 
-/// The one section header. Every shelf, grid and panel heading goes through
-/// this — there used to be three hand-rolled variants that disagreed on the
-/// chevron's size, weight and colour.
-///
-/// The chevron carries no hit frame of its own on purpose. The whole row is
-/// the `NavigationLink`'s target via `contentShape`, so a 44x44 box around a
-/// 17pt glyph would only inflate the header's height without widening
-/// anything you can actually tap.
 /// The one section header. Every shelf, grid and panel heading goes through
 /// this — there used to be three hand-rolled variants that disagreed on the
 /// chevron's size, weight and colour.

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -40,14 +40,14 @@ enum SongRowSize {
 
     var titleFont: Font {
         switch self {
-        case .compact: .subheadline
+        case .compact: AM.Font.rowCompactTitle
         case .regular: AM.Font.rowTitle
         }
     }
 
     var subtitleFont: Font {
         switch self {
-        case .compact: .caption
+        case .compact: AM.Font.rowCompactSubtitle
         case .regular: AM.Font.rowSubtitle
         }
     }
@@ -125,6 +125,12 @@ struct SongRow: View {
                     .lineLimit(1)
             }
             Spacer()
+            // One trailing accessory, then the menu. Apple Music's rows show a
+            // single status glyph; this used to stack a download badge, a
+            // duration and an ellipsis side by side, which read busier than the
+            // artwork it sat next to. Download state outranks the duration
+            // because it is the transient, actionable one — the duration is
+            // still on the row's accessibility value either way.
             Group {
                 if downloadState.status.isDownloaded {
                     Image(systemName: "arrow.down.circle.fill")
@@ -136,15 +142,14 @@ struct SongRow: View {
                     ProgressView()
                         .controlSize(.small)
                         .transition(statusTransition)
+                } else if !song.durationText.isEmpty {
+                    Text(song.durationText)
+                        .font(AM.Font.timecode)
+                        .foregroundStyle(.secondary)
+                        .transition(statusTransition)
                 }
             }
             .animation(statusAnimation, value: downloadState.status)
-            if !song.durationText.isEmpty {
-                Text(song.durationText)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-            }
             if let trailing {
                 trailing
             } else {
@@ -203,18 +208,22 @@ enum MusicGridCardSize: Equatable {
     var titleFont: Font {
         switch self {
         case .regular: AM.Font.tileTitle
-        case .compact: .subheadline
+        case .compact: AM.Font.rowCompactTitle
         }
     }
 
     var artistFont: Font {
         switch self {
         case .regular: AM.Font.tileCaption
-        case .compact: .caption
+        case .compact: AM.Font.rowCompactSubtitle
         }
     }
 
-    var textSpacing: CGFloat {
+    /// Artwork to the label block. Distinct from the gap *inside* the label
+    /// block: on an Apple Music tile the two lines sit almost touching and the
+    /// whole pair is set away from the image, which is what groups them as one
+    /// caption rather than two stacked rows.
+    var artworkTextGap: CGFloat {
         switch self {
         case .regular: AM.Spacing.s
         case .compact: 6
@@ -255,16 +264,18 @@ struct MusicGridCard: View {
             AppHaptic.selection.play()
             AudioPlayerManager.shared.play(song: song, context: context)
         } label: {
-            VStack(alignment: .leading, spacing: size.textSpacing) {
+            VStack(alignment: .leading, spacing: size.artworkTextGap) {
                 artwork
-                Text(song.title)
-                    .font(size.titleFont)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                Text(artistText)
-                    .font(size.artistFont)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(song.title)
+                        .font(size.titleFont)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text(artistText)
+                        .font(size.artistFont)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
             .frame(width: width, alignment: .leading)
             .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
@@ -408,13 +419,13 @@ struct SongContextPreview: View {
         ContextPreviewCard {
             RemoteArtworkImage(
                 url: song.imageURL,
-                cornerRadius: 10,
+                cornerRadius: AM.Radius.hero,
                 lowResURL: song.thumbnailURL,
                 fixedDisplaySize: CGSize(width: 220, height: 220)
             )
             .aspectRatio(1, contentMode: .fill)
             .frame(width: 220, height: 220)
-            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: AM.Radius.hero, style: .continuous))
         } label: {
             VStack(alignment: .leading, spacing: 3) {
                 Text(song.title)

--- a/Twinskaraoke/Components/Shared/SongRow.swift
+++ b/Twinskaraoke/Components/Shared/SongRow.swift
@@ -136,11 +136,12 @@ struct SongRow: View {
                     Image(systemName: "arrow.down.circle.fill")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        .accessibilityLabel("Downloaded")
+                        .accessibilityLabel(statusLabel("Downloaded"))
                         .transition(statusTransition)
                 } else if downloadState.status.isDownloading {
                     ProgressView()
                         .controlSize(.small)
+                        .accessibilityLabel(statusLabel("Downloading"))
                         .transition(statusTransition)
                 } else if !song.durationText.isEmpty {
                     Text(song.durationText)
@@ -183,6 +184,15 @@ struct SongRow: View {
         SongActionsMenuItems(song: song) {
             showAddToPlaylist = true
         }
+    }
+
+    /// The status glyph replaces the duration rather than sitting beside it, so
+    /// it has to carry the duration itself. `songRowAccessibility` also puts the
+    /// duration on the row, but six of the screens that draw a SongRow never
+    /// apply that modifier — without this the time is simply gone for VoiceOver
+    /// on any downloaded row there.
+    private func statusLabel(_ status: String) -> String {
+        song.durationText.isEmpty ? status : "\(status), \(song.durationText)"
     }
 
     private var statusAnimation: Animation? {

--- a/Twinskaraoke/Features/Account/iOSAppDevelopmentView.swift
+++ b/Twinskaraoke/Features/Account/iOSAppDevelopmentView.swift
@@ -47,7 +47,7 @@ struct iOSAppDevelopmentView: View {
                             .foregroundStyle(.white)
                             .frame(width: 28, height: 28)
                             .background(Color.black)
-                            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
                         VStack(alignment: .leading, spacing: 2) {
                             Text("github.com/Evil-Project/Twinskaraoke")
                                 .font(.body)

--- a/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
+++ b/Twinskaraoke/Features/Home/BrowseSongCollectionView.swift
@@ -195,7 +195,7 @@ struct BrowseSongCollectionView: View {
                     .padding(.vertical, 10)
                     .background(Color.primary.opacity(0.08))
                     .foregroundStyle(Color.appAccent)
-                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
             }
             .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.82))
             .accessibilityLabel("Play \(title)")
@@ -210,7 +210,7 @@ struct BrowseSongCollectionView: View {
                     .padding(.vertical, 10)
                     .background(Color.primary.opacity(0.08))
                     .foregroundStyle(Color.appAccent)
-                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
             }
             .buttonStyle(PressableButtonStyle(scale: 0.96, dim: 0.82))
             .accessibilityLabel("Shuffle \(title)")

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -79,13 +79,13 @@ struct HomeView: View {
                 
 
             if !recentlyPlayed.playlists.isEmpty {
-                PlaylistCarousel(title: "Recently Played", playlists: recentlyPlayed.playlists)
+                PlaylistCarousel(title: String(localized: "Recently Played"), playlists: recentlyPlayed.playlists)
                     .accessibilityIdentifier("Home.RecentlyPlayed")
                     .shelfEntrance(index: 1)
             }
 
             if !viewModel.suggestions.isEmpty {
-                HomeSongSection(title: "Made for You", songs: viewModel.suggestions)
+                HomeSongSection(title: String(localized: "Made for You"), songs: viewModel.suggestions)
                     .shelfEntrance(index: 2)
             }
 
@@ -93,12 +93,12 @@ struct HomeView: View {
                 .shelfEntrance(index: 3)
             
             if !viewModel.newReleases.isEmpty {
-                HomeSongSection(title: "New Releases", songs: viewModel.newReleases)
+                HomeSongSection(title: String(localized: "New Releases"), songs: viewModel.newReleases)
                     .shelfEntrance(index: 4)
             }
 
             if !viewModel.trending.isEmpty {
-                HomeSongSection(title: "More to Explore", songs: viewModel.trending)
+                HomeSongSection(title: String(localized: "More to Explore"), songs: viewModel.trending)
                     .shelfEntrance(index: 5)
             }
         }
@@ -121,7 +121,7 @@ struct HomeView: View {
 
                     if !recentlyPlayed.playlists.isEmpty {
                         PlaylistCarousel(
-                            title: "Recently Played",
+                            title: String(localized: "Recently Played"),
                             playlists: recentlyPlayed.playlists,
                             horizontalPadding: 0
                         )
@@ -129,7 +129,7 @@ struct HomeView: View {
                     }
 
                     if !viewModel.suggestions.isEmpty {
-                        HomeSongSection(title: "Made for You", songs: viewModel.suggestions, horizontalPadding: 0)
+                        HomeSongSection(title: String(localized: "Made for You"), songs: viewModel.suggestions, horizontalPadding: 0)
                     }
                 }
                 .frame(minWidth: 520, maxWidth: .infinity, alignment: .topLeading)
@@ -140,11 +140,11 @@ struct HomeView: View {
                     latestSingleSection(horizontalPadding: 0)
 
                     if !viewModel.newReleases.isEmpty {
-                        WideSongListPanel(title: "New Releases", songs: Array(viewModel.newReleases.prefix(6)))
+                        WideSongListPanel(title: String(localized: "New Releases"), songs: Array(viewModel.newReleases.prefix(6)))
                     }
 
                     if !viewModel.trending.isEmpty {
-                        WideSongListPanel(title: "More to Explore", songs: Array(viewModel.trending.prefix(6)))
+                        WideSongListPanel(title: String(localized: "More to Explore"), songs: Array(viewModel.trending.prefix(6)))
                     }
                 }
                 .frame(
@@ -210,7 +210,7 @@ struct HomeView: View {
     private func topPicksShelf(horizontalPadding: CGFloat = AM.Spacing.screenMargin) -> some View {
         if !viewModel.recentPlaylists.isEmpty {
             PlaylistCarousel(
-                title: "Top Picks for You",
+                title: String(localized: "Top Picks for You"),
                 playlists: viewModel.recentPlaylists,
                 isLoadingMore: viewModel.isLoadingMoreTopPicks,
                 onAppearItem: { viewModel.loadMoreTopPicksIfNeeded(current: $0) },

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -73,7 +73,7 @@ struct HomeView: View {
     }
 
     private var compactHomeOverview: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: AM.Spacing.xxl) {
             topPicksShelf()
                 .shelfEntrance(index: 0)
                 

--- a/Twinskaraoke/Features/Home/HomeWideHero.swift
+++ b/Twinskaraoke/Features/Home/HomeWideHero.swift
@@ -133,22 +133,22 @@ private struct WideSongHeroCard: View {
                 HStack(alignment: .bottom, spacing: AM.Spacing.xl) {
                     VStack(alignment: .leading, spacing: 7) {
                         Text(eyebrow)
-                            .font(.caption.bold())
+                            .font(AM.Font.eyebrow)
                             .foregroundStyle(.white.opacity(0.72))
                             .textCase(.uppercase)
                         Text(title)
-                            .font(.largeTitle.bold())
+                            .font(AM.Font.screenTitle)
                             .foregroundStyle(.white)
                             .lineLimit(2)
                             .minimumScaleFactor(0.72)
                         Text(subtitle)
-                            .font(.subheadline)
+                            .font(AM.Font.rowSubtitle)
                             .foregroundStyle(.white.opacity(0.82))
                             .lineLimit(2)
                     }
                     Spacer(minLength: AM.Spacing.l)
                     Image(systemName: "play.fill")
-                        .font(.title3.bold())
+                        .font(AM.Font.groupHeader)
                         .foregroundStyle(.black)
                         .frame(width: 54, height: 54)
                         .background(.white, in: Circle())
@@ -206,10 +206,10 @@ private struct WideHeroModuleTitle: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(title)
-                .font(.title3.bold())
+                .font(AM.Font.groupHeader)
                 .foregroundStyle(.primary)
             Text(subtitle)
-                .font(.subheadline)
+                .font(AM.Font.rowSubtitle)
                 .foregroundStyle(.secondary)
         }
         .padding(.bottom, 2)
@@ -260,11 +260,11 @@ private struct WideHeroActionRowContent: View {
             .frame(width: 44, height: 44)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.headline)
+                    .font(AM.Font.rowTitle.weight(.semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                 Text(subtitle)
-                    .font(.subheadline)
+                    .font(AM.Font.rowSubtitle)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }

--- a/Twinskaraoke/Features/Home/NewSections.swift
+++ b/Twinskaraoke/Features/Home/NewSections.swift
@@ -106,14 +106,20 @@ private struct NewFeatureCard: View {
 }
 
 struct NewSongRail: View {
+    /// Grows the shelf with the text size; see AM.Layout.shelfLabelAllowance.
+    @ScaledMetric(relativeTo: .subheadline) private var labelAllowance: CGFloat =
+        AM.Layout.shelfLabelAllowance
     let title: String
     let songs: [Song]
 
     var body: some View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
-            VStack(alignment: .leading, spacing: AM.Spacing.m) {
-                AMSectionHeader(verbatim: title, destination: BrowseSongCollectionView(title: title, songs: songs))
+            VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+                AMSectionHeader(
+                    title,
+                    destination: BrowseSongCollectionView(title: title, songs: songs)
+                )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(songs) { song in
@@ -128,7 +134,7 @@ struct NewSongRail: View {
                 }
             }
         }
-        .frame(height: AM.Layout.mediaShelfHeight)
+        .frame(height: AM.Layout.mediaShelfHeight(tileWidth: 190, labelAllowance: labelAllowance))
     }
 }
 
@@ -138,8 +144,11 @@ struct NewSongListPreview: View {
     var horizontalPadding: CGFloat = AM.Spacing.screenMargin
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AM.Spacing.s) {
-            AMSectionHeader(verbatim: title, destination: BrowseSongCollectionView(title: title, songs: songs))
+        VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+            AMSectionHeader(
+                    title,
+                    destination: BrowseSongCollectionView(title: title, songs: songs)
+                )
             LazyVStack(spacing: 0) {
                 ForEach(songs) { song in
                     Button {
@@ -160,14 +169,20 @@ struct NewSongListPreview: View {
 
 struct NewPlaylistRail: View {
     @Namespace private var zoomNamespace
+    /// Grows the shelf with the text size; see AM.Layout.shelfLabelAllowance.
+    @ScaledMetric(relativeTo: .subheadline) private var labelAllowance: CGFloat =
+        AM.Layout.shelfLabelAllowance
     let title: String
     let playlists: [Playlist]
 
     var body: some View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
-            VStack(alignment: .leading, spacing: AM.Spacing.m) {
-                AMSectionHeader(verbatim: title, destination: PlaylistListView(title: title, playlists: playlists))
+            VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+                AMSectionHeader(
+                    title,
+                    destination: PlaylistListView(title: title, playlists: playlists)
+                )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(playlists) { playlist in
@@ -188,6 +203,6 @@ struct NewPlaylistRail: View {
                 }
             }
         }
-        .frame(height: AM.Layout.mediaShelfHeight)
+        .frame(height: AM.Layout.mediaShelfHeight(tileWidth: 190, labelAllowance: labelAllowance))
     }
 }

--- a/Twinskaraoke/Features/Home/NewSections.swift
+++ b/Twinskaraoke/Features/Home/NewSections.swift
@@ -5,6 +5,14 @@ struct NewFeaturedRail: View {
     let secondary: Song?
     let songs: [Song]
 
+    /// The kicker/title/subtitle block above each card's artwork. Split out of
+    /// the old flat 316 so it can scale: the artwork half is sized from the
+    /// card width and does not grow with the text, but this half does, and a
+    /// fixed total clipped the subtitle at the larger accessibility sizes.
+    /// 243 + 73 reproduces 316 exactly at the default text size.
+    @ScaledMetric(relativeTo: .subheadline) private var cardTextAllowance: CGFloat = 73
+    private let cardArtworkAllowance: CGFloat = 243
+
     var body: some View {
         GeometryReader { proxy in
             let cardWidth = featureCardWidth(for: proxy.size.width)
@@ -36,7 +44,7 @@ struct NewFeaturedRail: View {
                 .padding(.horizontal, AM.Spacing.screenMargin)
             }
         }
-        .frame(height: 316)
+        .frame(height: cardArtworkAllowance + cardTextAllowance)
     }
 
     private func featureCardWidth(for availableWidth: CGFloat) -> CGFloat {

--- a/Twinskaraoke/Features/Home/NewSections.swift
+++ b/Twinskaraoke/Features/Home/NewSections.swift
@@ -6,12 +6,17 @@ struct NewFeaturedRail: View {
     let songs: [Song]
 
     /// The kicker/title/subtitle block above each card's artwork. Split out of
-    /// the old flat 316 so it can scale: the artwork half is sized from the
-    /// card width and does not grow with the text, but this half does, and a
-    /// fixed total clipped the subtitle at the larger accessibility sizes.
-    /// 243 + 73 reproduces 316 exactly at the default text size.
+    /// the old flat 316 so it can scale with the text, which a fixed total
+    /// could not — it clipped the subtitle at the larger accessibility sizes.
     @ScaledMetric(relativeTo: .subheadline) private var cardTextAllowance: CGFloat = 73
-    private let cardArtworkAllowance: CGFloat = 243
+    @State private var availableWidth: CGFloat = 390
+
+    /// The artwork half is measured, not assumed. Pinning it to 243 — the
+    /// widest card's 420 * 0.56 — left ~40pt of dead space under every card on
+    /// a phone, where the card clamps far below that.
+    private var cardArtworkHeight: CGFloat {
+        featureCardWidth(for: availableWidth) * NewFeatureCard.artworkWidthRatio
+    }
 
     var body: some View {
         GeometryReader { proxy in
@@ -26,7 +31,7 @@ struct NewFeaturedRail: View {
                             song: primary,
                             context: songs,
                             width: cardWidth,
-                            artworkSize: cardWidth * 0.56
+                            artworkSize: cardWidth * NewFeatureCard.artworkWidthRatio
                         )
                     }
                     if let secondary {
@@ -37,14 +42,15 @@ struct NewFeaturedRail: View {
                             song: secondary,
                             context: songs,
                             width: cardWidth,
-                            artworkSize: cardWidth * 0.56
+                            artworkSize: cardWidth * NewFeatureCard.artworkWidthRatio
                         )
                     }
                 }
                 .padding(.horizontal, AM.Spacing.screenMargin)
             }
         }
-        .frame(height: cardArtworkAllowance + cardTextAllowance)
+        .trackingWidth(into: $availableWidth)
+        .frame(height: cardArtworkHeight + AM.Spacing.s + cardTextAllowance)
     }
 
     private func featureCardWidth(for availableWidth: CGFloat) -> CGFloat {
@@ -53,6 +59,10 @@ struct NewFeaturedRail: View {
 }
 
 private struct NewFeatureCard: View {
+    /// The artwork's height as a fraction of the card's width. Read by
+    /// NewFeaturedRail too, so the rail's frame matches what the card draws.
+    static let artworkWidthRatio: CGFloat = 0.56
+
     let kicker: String
     let title: String
     let subtitle: String
@@ -117,6 +127,7 @@ struct NewSongRail: View {
     /// Grows the shelf with the text size; see AM.Layout.shelfLabelAllowance.
     @ScaledMetric(relativeTo: .subheadline) private var labelAllowance: CGFloat =
         AM.Layout.shelfLabelAllowance
+    @State private var availableWidth: CGFloat = 390
     let title: String
     let songs: [Song]
 
@@ -142,7 +153,11 @@ struct NewSongRail: View {
                 }
             }
         }
-        .frame(height: AM.Layout.mediaShelfHeight(tileWidth: 190, labelAllowance: labelAllowance))
+        .trackingWidth(into: $availableWidth)
+        .frame(height: AM.Layout.mediaShelfHeight(
+            tileWidth: AM.Layout.shelfTileWidth(for: availableWidth),
+            labelAllowance: labelAllowance
+        ))
     }
 }
 
@@ -154,9 +169,10 @@ struct NewSongListPreview: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
             AMSectionHeader(
-                    title,
-                    destination: BrowseSongCollectionView(title: title, songs: songs)
-                )
+                title,
+                destination: BrowseSongCollectionView(title: title, songs: songs),
+                horizontalPadding: horizontalPadding
+            )
             LazyVStack(spacing: 0) {
                 ForEach(songs) { song in
                     Button {
@@ -180,6 +196,7 @@ struct NewPlaylistRail: View {
     /// Grows the shelf with the text size; see AM.Layout.shelfLabelAllowance.
     @ScaledMetric(relativeTo: .subheadline) private var labelAllowance: CGFloat =
         AM.Layout.shelfLabelAllowance
+    @State private var availableWidth: CGFloat = 390
     let title: String
     let playlists: [Playlist]
 
@@ -211,6 +228,10 @@ struct NewPlaylistRail: View {
                 }
             }
         }
-        .frame(height: AM.Layout.mediaShelfHeight(tileWidth: 190, labelAllowance: labelAllowance))
+        .trackingWidth(into: $availableWidth)
+        .frame(height: AM.Layout.mediaShelfHeight(
+            tileWidth: AM.Layout.shelfTileWidth(for: availableWidth),
+            labelAllowance: labelAllowance
+        ))
     }
 }

--- a/Twinskaraoke/Features/Home/NewSections.swift
+++ b/Twinskaraoke/Features/Home/NewSections.swift
@@ -113,7 +113,7 @@ struct NewSongRail: View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
             VStack(alignment: .leading, spacing: AM.Spacing.m) {
-                AMSectionHeader(title, destination: BrowseSongCollectionView(title: title, songs: songs))
+                AMSectionHeader(verbatim: title, destination: BrowseSongCollectionView(title: title, songs: songs))
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(songs) { song in
@@ -139,7 +139,7 @@ struct NewSongListPreview: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.s) {
-            AMSectionHeader(title, destination: BrowseSongCollectionView(title: title, songs: songs))
+            AMSectionHeader(verbatim: title, destination: BrowseSongCollectionView(title: title, songs: songs))
             LazyVStack(spacing: 0) {
                 ForEach(songs) { song in
                     Button {
@@ -167,7 +167,7 @@ struct NewPlaylistRail: View {
         GeometryReader { proxy in
             let tileWidth = AM.Layout.shelfTileWidth(for: proxy.size.width)
             VStack(alignment: .leading, spacing: AM.Spacing.m) {
-                AMSectionHeader(title, destination: PlaylistListView(title: title, playlists: playlists))
+                AMSectionHeader(verbatim: title, destination: PlaylistListView(title: title, playlists: playlists))
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(alignment: .top, spacing: AM.Spacing.l) {
                         ForEach(playlists) { playlist in

--- a/Twinskaraoke/Features/Home/NewView.swift
+++ b/Twinskaraoke/Features/Home/NewView.swift
@@ -67,7 +67,7 @@ struct NewView: View {
     }
 
     private var compactNewOverview: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: AM.Spacing.xxl) {
             if !viewModel.newReleases.isEmpty {
                 NewFeaturedRail(
                     primary: viewModel.newReleases.first,

--- a/Twinskaraoke/Features/Home/NewView.swift
+++ b/Twinskaraoke/Features/Home/NewView.swift
@@ -77,27 +77,27 @@ struct NewView: View {
             }
 
             if !viewModel.newReleases.isEmpty {
-                NewSongRail(title: "Up Next", songs: Array(viewModel.newReleases.prefix(8)))
+                NewSongRail(title: String(localized: "Up Next"), songs: Array(viewModel.newReleases.prefix(8)))
             }
 
             if !viewModel.trending.isEmpty {
-                NewSongListPreview(title: "Best New Songs", songs: Array(viewModel.trending.prefix(5)))
+                NewSongListPreview(title: String(localized: "Best New Songs"), songs: Array(viewModel.trending.prefix(5)))
             }
 
             if !viewModel.recentPlaylists.isEmpty {
-                NewPlaylistRail(title: "New This Week", playlists: viewModel.recentPlaylists)
+                NewPlaylistRail(title: String(localized: "New This Week"), playlists: viewModel.recentPlaylists)
             }
 
             if !viewModel.newReleases.isEmpty {
-                NewSongRail(title: "New Releases", songs: viewModel.newReleases)
+                NewSongRail(title: String(localized: "New Releases"), songs: viewModel.newReleases)
             }
 
             if !recentlyPlayed.playlists.isEmpty {
-                NewPlaylistRail(title: "Recently Released", playlists: recentlyPlayed.playlists)
+                NewPlaylistRail(title: String(localized: "Recently Released"), playlists: recentlyPlayed.playlists)
             }
 
             if !viewModel.trending.isEmpty {
-                NewSongRail(title: "More to Explore", songs: viewModel.trending)
+                NewSongRail(title: String(localized: "More to Explore"), songs: viewModel.trending)
             }
         }
     }
@@ -122,23 +122,23 @@ struct NewView: View {
             HStack(alignment: .top, spacing: AM.Spacing.xxl) {
                 VStack(alignment: .leading, spacing: AM.Spacing.xxl) {
                     if !viewModel.newReleases.isEmpty {
-                        NewSongRail(title: "Up Next", songs: Array(viewModel.newReleases.prefix(8)))
+                        NewSongRail(title: String(localized: "Up Next"), songs: Array(viewModel.newReleases.prefix(8)))
                     }
 
                     if !viewModel.recentPlaylists.isEmpty {
-                        NewPlaylistRail(title: "New This Week", playlists: viewModel.recentPlaylists)
+                        NewPlaylistRail(title: String(localized: "New This Week"), playlists: viewModel.recentPlaylists)
                     }
 
                     if !viewModel.newReleases.isEmpty {
-                        NewSongRail(title: "New Releases", songs: viewModel.newReleases)
+                        NewSongRail(title: String(localized: "New Releases"), songs: viewModel.newReleases)
                     }
 
                     if !recentlyPlayed.playlists.isEmpty {
-                        NewPlaylistRail(title: "Recently Released", playlists: recentlyPlayed.playlists)
+                        NewPlaylistRail(title: String(localized: "Recently Released"), playlists: recentlyPlayed.playlists)
                     }
 
                     if !viewModel.trending.isEmpty {
-                        NewSongRail(title: "More to Explore", songs: viewModel.trending)
+                        NewSongRail(title: String(localized: "More to Explore"), songs: viewModel.trending)
                     }
                 }
                 .frame(minWidth: 520, maxWidth: .infinity, alignment: .topLeading)
@@ -147,7 +147,7 @@ struct NewView: View {
                 VStack(alignment: .leading, spacing: AM.Spacing.xxl) {
                     if !viewModel.trending.isEmpty {
                         NewSongListPreview(
-                            title: "Best New Songs",
+                            title: String(localized: "Best New Songs"),
                             songs: Array(viewModel.trending.prefix(5)),
                             horizontalPadding: 0
                         )

--- a/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
+++ b/Twinskaraoke/Features/Library/ArtDetail/ZoomableImageViewer.swift
@@ -151,7 +151,7 @@ struct ZoomableImageViewer: View {
         if reduceMotion {
             showOverlay.toggle()
         } else {
-            withAnimation(.easeInOut(duration: 0.25)) {
+            withAnimation(AppMotion.easeInOut(duration: 0.25)) {
                 showOverlay.toggle()
             }
         }

--- a/Twinskaraoke/Features/Library/ArtistsView.swift
+++ b/Twinskaraoke/Features/Library/ArtistsView.swift
@@ -244,7 +244,7 @@ struct ArtistDetailView: View {
                 }
             }
         }
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: showsCollapsedTitle)
+        .animation(reduceMotion ? nil : AppMotion.quick, value: showsCollapsedTitle)
         .onAppear { loader.load(id: artist.id, fallback: artist) }
     }
 

--- a/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
+++ b/Twinskaraoke/Features/Library/CreatePlaylistSheet.swift
@@ -126,7 +126,7 @@ struct CreatePlaylistSheet: View {
                 focusedField = .name
             }
             .animation(reduceMotion ? nil : AppMotion.quick, value: isSaving)
-            .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: errorMessage)
+            .animation(reduceMotion ? nil : AppMotion.quick, value: errorMessage)
             .animation(reduceMotion ? nil : AppMotion.quick, value: trimmedName)
         }
     }

--- a/Twinskaraoke/Features/Library/DownloadedSongsView.swift
+++ b/Twinskaraoke/Features/Library/DownloadedSongsView.swift
@@ -101,7 +101,7 @@ struct DownloadedSongsView: View {
             Text("All offline songs on this device will be removed. You can download them again from song menus.")
         }
         .musicScreenBackground()
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: showsCollapsedTitle)
+        .animation(reduceMotion ? nil : AppMotion.quick, value: showsCollapsedTitle)
         .scrollIndicators(.hidden)
         .refreshable {
             AppHaptic.selection.play()

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -784,7 +784,7 @@ struct RecentlyAddedSection: View {
     private let cols = AM.Layout.songGridColumns
     var body: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
-            AMSectionHeader("Recently Added", horizontalPadding: headerHorizontalPadding)
+            AMSectionHeader(String(localized: "Recently Added"), horizontalPadding: headerHorizontalPadding)
             LazyVGrid(columns: cols, spacing: AM.Spacing.xl) {
                 ForEach(songs) { song in
                     MusicGridCard(song: song, context: songs, fillsWidth: true)

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -617,9 +617,9 @@ struct PlaylistListRow: View {
     let playlist: Playlist
     var body: some View {
         HStack(spacing: 12) {
-            PlaylistArtwork(playlist: playlist, cornerRadius: 6)
+            PlaylistArtwork(playlist: playlist, cornerRadius: AM.Radius.thumb)
                 .frame(width: 48, height: 48)
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
             VStack(alignment: .leading, spacing: 2) {
                 Text(playlist.name)
                     .font(.subheadline)

--- a/Twinskaraoke/Features/Library/LibraryView.swift
+++ b/Twinskaraoke/Features/Library/LibraryView.swift
@@ -744,18 +744,22 @@ struct PlaylistGridCell: View {
         VStack(alignment: .leading, spacing: AM.Spacing.s) {
             artwork
                 .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
-            Text(playlist.name)
-                .font(AM.Font.tileTitle)
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-            PlaylistSongCountLabel(
-                playlist: playlist,
-                fallbackText: prefersDetailCount ? nil : "Playlist",
-                prefersDetailCount: prefersDetailCount
-            )
-                .font(AM.Font.tileCaption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
+            // Same two-level structure as MusicGridCard: the label pair sits
+            // tight and is set away from the artwork as a unit.
+            VStack(alignment: .leading, spacing: 2) {
+                Text(playlist.name)
+                    .font(AM.Font.tileTitle)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                PlaylistSongCountLabel(
+                    playlist: playlist,
+                    fallbackText: prefersDetailCount ? nil : "Playlist",
+                    prefersDetailCount: prefersDetailCount
+                )
+                    .font(AM.Font.tileCaption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
         }
         .frame(width: width, alignment: .leading)
         .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
@@ -779,14 +783,9 @@ struct RecentlyAddedSection: View {
     var headerHorizontalPadding: CGFloat = AM.Spacing.screenMargin
     private let cols = AM.Layout.songGridColumns
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Recently Added")
-                .font(AM.Font.sectionHeader)
-                .foregroundStyle(.primary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, headerHorizontalPadding)
-                .padding(.top, 2)
-            LazyVGrid(columns: cols, spacing: 22) {
+        VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+            AMSectionHeader("Recently Added", horizontalPadding: headerHorizontalPadding)
+            LazyVGrid(columns: cols, spacing: AM.Spacing.xl) {
                 ForEach(songs) { song in
                     MusicGridCard(song: song, context: songs, fillsWidth: true)
                 }
@@ -803,7 +802,7 @@ struct PlaylistContextPreview: View {
 
     var body: some View {
         ContextPreviewCard {
-            PlaylistArtwork(playlist: playlist, cornerRadius: 12)
+            PlaylistArtwork(playlist: playlist, cornerRadius: AM.Radius.hero)
                 .frame(width: 220, height: 220)
         } label: {
             VStack(alignment: .leading, spacing: 3) {

--- a/Twinskaraoke/Features/Library/PlaylistDetailView.swift
+++ b/Twinskaraoke/Features/Library/PlaylistDetailView.swift
@@ -899,9 +899,9 @@ private struct PlaylistDetailContextPreview: View {
 
     var body: some View {
         ContextPreviewCard {
-            PlaylistArtworkContent(playlist: playlist, coverURLs: coverURLs, cornerRadius: 10)
+            PlaylistArtworkContent(playlist: playlist, coverURLs: coverURLs, cornerRadius: AM.Radius.card)
                 .frame(width: 220, height: 220)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: AM.Radius.card, style: .continuous))
         } label: {
             VStack(alignment: .leading, spacing: 3) {
                 Text(playlist.isFavorites ? "Favorites" : "Playlist")

--- a/Twinskaraoke/Features/Library/RandomSongsView.swift
+++ b/Twinskaraoke/Features/Library/RandomSongsView.swift
@@ -67,7 +67,7 @@ struct RandomSongsView: View {
         .task {
             await viewModel.loadIfNeeded()
         }
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: viewModel.isLoading)
+        .animation(reduceMotion ? nil : AppMotion.quick, value: viewModel.isLoading)
     }
 
     @ViewBuilder

--- a/Twinskaraoke/Features/Library/Video/ContinueWatchingSection.swift
+++ b/Twinskaraoke/Features/Library/Video/ContinueWatchingSection.swift
@@ -85,7 +85,7 @@ private struct ContinueWatchingCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            VideoThumbnail(video: video, cornerRadius: 10)
+            VideoThumbnail(video: video, cornerRadius: AM.Radius.card)
                 .frame(width: 208)
                 .overlay(alignment: .bottomLeading) {
                     if let remaining = point.remaining {

--- a/Twinskaraoke/Features/Library/Video/VideoGalleryComponents.swift
+++ b/Twinskaraoke/Features/Library/Video/VideoGalleryComponents.swift
@@ -200,7 +200,7 @@ struct VideoContextPreview: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            VideoThumbnail(video: video, cornerRadius: 12)
+            VideoThumbnail(video: video, cornerRadius: AM.Radius.card)
                 .frame(width: 252)
             VStack(alignment: .leading, spacing: 4) {
                 if isFeatured {
@@ -413,7 +413,7 @@ private struct SimilarVideoRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            VideoThumbnail(video: video, cornerRadius: 8)
+            VideoThumbnail(video: video, cornerRadius: AM.Radius.card)
                 .frame(width: 140)
             VStack(alignment: .leading, spacing: 4) {
                 Text(video.displayTitle)

--- a/Twinskaraoke/Features/Library/Video/VideoPlayerScreen.swift
+++ b/Twinskaraoke/Features/Library/Video/VideoPlayerScreen.swift
@@ -288,7 +288,7 @@ private struct VideoPlayerSurface: View {
                     onToggleFullScreen: onToggleFullScreen
                 )
                 .opacity(visibilityTracker.isUserInterfaceHidden ? 0 : 1)
-                .animation(.easeInOut(duration: 0.18), value: visibilityTracker.isUserInterfaceHidden)
+                .animation(AppMotion.easeInOut(duration: 0.18), value: visibilityTracker.isUserInterfaceHidden)
             }
         }
         .contentShape(Rectangle())
@@ -307,7 +307,7 @@ private struct VideoPlayerSurface: View {
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: resumedFrom)
+        .animation(AppMotion.quick, value: resumedFrom)
     }
 }
 

--- a/Twinskaraoke/Features/Library/VideoGalleryView.swift
+++ b/Twinskaraoke/Features/Library/VideoGalleryView.swift
@@ -266,7 +266,7 @@ private struct VideoGalleryCell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            VideoThumbnail(video: video, cornerRadius: 10)
+            VideoThumbnail(video: video, cornerRadius: AM.Radius.card)
                 .shadow(color: .black.opacity(0.12), radius: 6, y: 3)
             VStack(alignment: .leading, spacing: 2) {
                 Text(video.displayTitle)

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -292,7 +292,7 @@ private struct PlayerFavoriteButton: View {
 /// surfaces.
 private struct PlayerMoreMenu: View {
     let song: Song
-    var font: Font = .headline.bold()
+    var font: Font = AM.Font.playerGlyph
     var size: CGFloat = 44
     var showsChrome: Bool = true
     let onAddToPlaylist: () -> Void
@@ -738,13 +738,13 @@ struct FullScreenPlayerView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(song.title)
-                    .font(.headline.bold())
+                    .font(AM.Font.nowPlayingTitleCompact)
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .contentTransition(.opacity)
                 Text(song.displayArtist)
-                    .font(.subheadline)
+                    .font(AM.Font.nowPlayingArtistCompact)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .contentTransition(.opacity)
@@ -855,20 +855,20 @@ struct FullScreenPlayerView: View {
                 HStack(spacing: 12) {
                     RemoteArtworkImage(
                         url: audioManager.displayImageURL(for: song, variant: .thumbnail),
-                        cornerRadius: 8,
+                        cornerRadius: AM.Radius.thumb,
                         contentMode: .fill,
                         lowResURL: song.thumbnailURL
                     )
                     .frame(width: metrics.lyricsArtworkSize, height: metrics.lyricsArtworkSize)
-                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
                     .id(song.id)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(song.title)
-                            .font(metrics.lyricsTitleSize <= 15 ? .subheadline.bold() : .headline.bold())
+                            .font(metrics.lyricsTitleSize <= 15 ? .subheadline.bold() : AM.Font.nowPlayingTitleCompact)
                             .foregroundStyle(.primary)
                             .lineLimit(1)
                         Text(song.displayArtist)
-                            .font(metrics.lyricsSubtitleSize <= 12 ? .caption : .subheadline)
+                            .font(metrics.lyricsSubtitleSize <= 12 ? .caption : AM.Font.nowPlayingArtistCompact)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
@@ -896,7 +896,7 @@ struct FullScreenPlayerView: View {
     private func padLyricsHeader(song _: Song) -> some View {
         HStack(alignment: .center, spacing: 12) {
             Text("Lyrics")
-                .font(.title2.bold())
+                .font(AM.Font.sectionHeader)
                 .foregroundStyle(.primary)
                 .accessibilityIdentifier("FullScreenPlayer.wideLyricsTitle")
 
@@ -908,7 +908,7 @@ struct FullScreenPlayerView: View {
                 }
             } label: {
                 Image(systemName: "chevron.down")
-                    .font(.headline.bold())
+                    .font(AM.Font.playerGlyph)
                     .foregroundStyle(playerTitleIconColor())
                     .playerTitleButtonChrome(true, size: 44)
             }
@@ -929,14 +929,14 @@ struct FullScreenPlayerView: View {
                 MarqueeText(
                     text: song.title,
                     font: compact || metrics.titleSize <= 20
-                        ? .headline.bold() : AM.Font.nowPlayingTitle,
+                        ? AM.Font.nowPlayingTitleCompact : AM.Font.nowPlayingTitle,
                     color: .primary,
                     isPaused: !presentation.isExpanded
                 )
                 MarqueeText(
                     text: song.displayArtist,
                     font: compact || metrics.artistSize <= 15
-                        ? .subheadline : AM.Font.nowPlayingArtist,
+                        ? AM.Font.nowPlayingArtistCompact : AM.Font.nowPlayingArtist,
                     color: .secondary,
                     isPaused: !presentation.isExpanded
                 )
@@ -1178,7 +1178,7 @@ struct FullScreenPlayerView: View {
                     }
                 }
                 Image(systemName: showTranslatedLyrics ? "globe.badge.chevron.backward" : "globe")
-                    .font(.headline)
+                    .font(AM.Font.playerGlyph)
                     .foregroundStyle(showTranslatedLyrics ? Color.appAccent : .secondary)
             }
             .frame(width: 44, height: 44)

--- a/Twinskaraoke/Features/Player/LyricsView.swift
+++ b/Twinskaraoke/Features/Player/LyricsView.swift
@@ -365,7 +365,7 @@ private struct IntroDots: View {
             color: isActive ? .primary : .primary.opacity(0.4)
         )
         .opacity(isActive ? 1.0 : 0.3)
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: isActive)
+        .animation(reduceMotion ? nil : AppMotion.easeInOut(duration: 0.4), value: isActive)
     }
 
 }

--- a/Twinskaraoke/Features/Player/NowPlaying/MiniPlayerBar.swift
+++ b/Twinskaraoke/Features/Player/NowPlaying/MiniPlayerBar.swift
@@ -172,13 +172,13 @@ struct MiniPlayerBar: View {
     private static let marqueeGap: CGFloat = 28
 
     private var titleFont: Font {
-        isInline ? .caption.weight(.semibold) : .subheadline.weight(.semibold)
+        isInline ? .caption.weight(.semibold) : AM.Font.rowCompactTitle.weight(.semibold)
     }
 
     /// Explicitly `.regular`: the artist should never inherit the title's
     /// weight, which is the whole contrast the pair is built on.
     private var subtitleFont: Font {
-        isInline ? .caption2.weight(.regular) : .caption.weight(.regular)
+        isInline ? .caption2.weight(.regular) : AM.Font.rowCompactSubtitle.weight(.regular)
     }
 
     /// Upward only, and judged on where the finger ended rather than on

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -213,11 +213,11 @@ struct QueueView: View {
             HStack(spacing: 12) {
                 RemoteArtworkImage(
                     url: audioManager.displayImageURL(for: current, variant: .row),
-                    cornerRadius: 6,
+                    cornerRadius: AM.Radius.thumb,
                     lowResURL: current.thumbnailURL
                 )
                     .frame(width: 48, height: 48)
-                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Now Playing")
                         .font(AM.Font.badge)

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -161,7 +161,7 @@ struct QueueView: View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Playing Next")
-                    .font(.headline.weight(.semibold))
+                    .font(AM.Font.groupHeader)
                     .foregroundStyle(.primary)
                 Text(upNextCount == 1 ? "1 song queued" : "\(upNextCount) songs queued")
                     .font(.caption)
@@ -181,7 +181,7 @@ struct QueueView: View {
                     }
                 } label: {
                     Text("Clear")
-                        .font(.subheadline.weight(.semibold))
+                        .font(AM.Font.rowCompactTitle.weight(.semibold))
                         .foregroundStyle(Color.appAccent)
                         .padding(.horizontal, 12)
                         .frame(minWidth: 44, minHeight: 44)
@@ -220,15 +220,15 @@ struct QueueView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Now Playing")
-                        .font(.caption2.weight(.semibold))
+                        .font(AM.Font.badge)
                         .foregroundStyle(Color.appAccent)
                         .textCase(.uppercase)
                     Text(current.title)
-                        .font(.headline.weight(.semibold))
+                        .font(AM.Font.groupHeader)
                         .foregroundStyle(.primary)
                         .lineLimit(1)
                     Text(current.displayArtist)
-                        .font(.subheadline)
+                        .font(AM.Font.rowSubtitle)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }

--- a/Twinskaraoke/Features/Radio/RadioQueueHero.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueHero.swift
@@ -12,7 +12,7 @@ struct RadioQueueHero: View {
     var body: some View {
         HStack(alignment: .center, spacing: 11) {
             ZStack(alignment: .bottomLeading) {
-                RadioQueueArtwork(song: song, cornerRadius: 10)
+                RadioQueueArtwork(song: song, cornerRadius: AM.Radius.card)
                     .frame(width: 72, height: 72)
                     .amShadow(isPlaying ? AM.Shadow.heroPlaying : AM.Shadow.heroIdle)
 

--- a/Twinskaraoke/Features/Radio/RadioQueueRows.swift
+++ b/Twinskaraoke/Features/Radio/RadioQueueRows.swift
@@ -7,7 +7,7 @@ struct RadioQueueTrackRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            RadioQueueArtwork(song: song, cornerRadius: 7)
+            RadioQueueArtwork(song: song, cornerRadius: AM.Radius.thumb)
                 .frame(width: 54, height: 54)
                 .overlay(alignment: .topLeading) {
                     if isCurrent {

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -421,7 +421,7 @@ struct RadioView: View {
         horizontalPadding: CGFloat = AM.Spacing.screenMargin
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            RadioSectionHeader("New & Recent")
+            AMSectionHeader(String(localized: "New & Recent"), horizontalPadding: 0)
                 .padding(.horizontal, horizontalPadding)
             LazyVStack(spacing: 0) {
                 ForEach(history.prefix(10).enumerated().map { PositionedRadioHistoryItem(offset: $0.offset, item: $0.element) }) { positioned in
@@ -467,24 +467,6 @@ private struct PositionedRadioHistoryItem: Identifiable {
 
     var id: ID {
         ID(offset: offset, songID: item.song.id)
-    }
-}
-
-private struct RadioSectionHeader: View {
-    let title: String
-
-    init(_ title: String) {
-        self.title = title
-    }
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: AM.Spacing.s) {
-            Text(title)
-                .font(AM.Font.sectionHeader)
-                .foregroundStyle(.primary)
-            Spacer()
-        }
-        .padding(.top, 2)
     }
 }
 

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -647,7 +647,7 @@ private struct RadioStationContextPreview: View {
                     .foregroundStyle(Color.appAccent)
                     .textCase(.uppercase)
                 Text(title)
-                    .font(AM.Font.chevron)
+                    .font(AM.Font.rowTitle.weight(.semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(2)
                 Text(subtitle)

--- a/Twinskaraoke/Features/Radio/RadioView.swift
+++ b/Twinskaraoke/Features/Radio/RadioView.swift
@@ -243,12 +243,12 @@ struct RadioView: View {
         VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Featured Episode")
-                    .font(.caption.bold())
+                    .font(AM.Font.eyebrow)
                     .foregroundStyle(.secondary)
                     .textCase(.uppercase)
                     .accessibilityIdentifier("Radio.FeaturedEpisode.Label")
                 Text(song?.displayTitle ?? np?.station.name ?? "Twinskaraoke Radio")
-                    .font(.title.bold())
+                    .font(AM.Font.heroTitle)
                     .foregroundStyle(.primary)
                     .lineLimit(2)
                     .accessibilityIdentifier("Radio.FeaturedEpisode.Title")
@@ -278,31 +278,31 @@ struct RadioView: View {
                         if let art = next.art, let url = URL(string: art) {
                             RemoteArtworkImage(
                                 url: ArtworkURLBuilder.variantURL(from: url, variant: .row) ?? url,
-                                cornerRadius: 6,
+                                cornerRadius: AM.Radius.thumb,
                                 fixedDisplaySize: CGSize(width: 48, height: 48)
                             )
                             .frame(width: 48, height: 48)
-                            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
                         } else {
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous)
                                 .fill(Color.secondary.opacity(0.15))
                                 .frame(width: 48, height: 48)
                         }
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Up Next")
-                                .font(.caption.weight(.semibold))
+                                .font(AM.Font.eyebrow)
                                 .foregroundStyle(.secondary)
                             Text(next.title ?? next.text ?? "")
-                                .font(.body.weight(.semibold))
+                                .font(AM.Font.rowTitle.weight(.semibold))
                                 .lineLimit(1)
                             Text(next.artist ?? "")
-                                .font(.subheadline)
+                                .font(AM.Font.rowSubtitle)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                         }
                         Spacer()
                         Image(systemName: "chevron.right")
-                            .font(.headline.weight(.semibold))
+                            .font(AM.Font.chevron)
                             .foregroundStyle(.secondary)
                     }
                     .padding(.horizontal, 16)
@@ -505,7 +505,7 @@ private struct RadioLiveBadge: View {
             .frame(width: 12, height: 12)
 
             Text("LIVE")
-                .font(.caption.bold())
+                .font(AM.Font.eyebrow)
                 .foregroundStyle(.white)
         }
         .padding(.horizontal, 9)
@@ -565,7 +565,7 @@ private struct RadioStatusPill: View {
 
     var body: some View {
         Label(text, systemImage: systemImage)
-            .font(.caption.weight(.semibold))
+            .font(AM.Font.eyebrow)
             .lineLimit(1)
             .minimumScaleFactor(0.78)
             .foregroundStyle(tint)
@@ -585,7 +585,7 @@ private struct RadioRefreshBanner: View {
     var body: some View {
         HStack(spacing: 10) {
             Text(message)
-                .font(.subheadline)
+                .font(AM.Font.rowSubtitle)
                 .foregroundStyle(.primary)
                 .lineLimit(2)
             Spacer(minLength: 8)
@@ -649,27 +649,27 @@ private struct RadioStationContextPreview: View {
                 if let artworkURL {
                     RemoteArtworkImage(
                         url: ArtworkURLBuilder.variantURL(from: artworkURL, variant: .card) ?? artworkURL,
-                        cornerRadius: 10,
+                        cornerRadius: AM.Radius.hero,
                         lowResURL: ArtworkURLBuilder.variantURL(from: artworkURL, variant: .thumbnail)
                     )
                 } else {
-                    MusicArtworkPlaceholder(cornerRadius: 10)
+                    MusicArtworkPlaceholder(cornerRadius: AM.Radius.hero)
                 }
             }
             .frame(width: 220, height: 220)
-            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: AM.Radius.hero, style: .continuous))
         } label: {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Live Station")
-                    .font(.caption.bold())
+                    .font(AM.Font.eyebrow)
                     .foregroundStyle(Color.appAccent)
                     .textCase(.uppercase)
                 Text(title)
-                    .font(.headline.weight(.semibold))
+                    .font(AM.Font.chevron)
                     .foregroundStyle(.primary)
                     .lineLimit(2)
                 Text(subtitle)
-                    .font(.subheadline)
+                    .font(AM.Font.rowSubtitle)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
@@ -696,28 +696,28 @@ private struct RadioHistoryRow: View {
             if let art = song.art, let url = URL(string: art) {
                 RemoteArtworkImage(
                     url: ArtworkURLBuilder.variantURL(from: url, variant: .row) ?? url,
-                    cornerRadius: 6,
+                    cornerRadius: AM.Radius.thumb,
                     fixedDisplaySize: CGSize(width: 48, height: 48)
                 )
                 .frame(width: 48, height: 48)
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous))
             } else {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                RoundedRectangle(cornerRadius: AM.Radius.thumb, style: .continuous)
                     .fill(Color.secondary.opacity(0.15))
                     .frame(width: 48, height: 48)
             }
             VStack(alignment: .leading, spacing: 2) {
                 Text(song.title ?? song.text ?? "")
-                    .font(.body.weight(.semibold))
+                    .font(AM.Font.rowTitle.weight(.semibold))
                     .lineLimit(1)
                 Text(song.artist ?? "")
-                    .font(.subheadline)
+                    .font(AM.Font.rowSubtitle)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
             Spacer()
             Image(systemName: "chevron.right")
-                .font(.headline.weight(.semibold))
+                .font(AM.Font.chevron)
                 .foregroundStyle(.secondary)
         }
     }

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -149,7 +149,7 @@ private struct SearchResultsSummaryHeader: View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline) {
                 Text("Songs")
-                    .font(.title2.bold())
+                    .font(AM.Font.sectionHeader)
                     .foregroundStyle(.primary)
                 Spacer(minLength: 12)
                 Text(resultCountText)
@@ -538,7 +538,7 @@ private struct GenreDetailLoadingView: View {
 
                 VStack(spacing: 8) {
                     Text(genre.name)
-                        .font(.title2.bold())
+                        .font(AM.Font.sectionHeader)
                         .multilineTextAlignment(.center)
                     Text("Loading songs")
                         .font(.subheadline)
@@ -637,7 +637,7 @@ private struct SearchNoResultsStateView: View {
             SearchStateGlyph()
             VStack(spacing: AM.Spacing.s) {
                 Text("No Results")
-                    .font(.title2.bold())
+                    .font(AM.Font.sectionHeader)
                     .foregroundStyle(.primary)
                     .multilineTextAlignment(.center)
                 Text("No songs matched \"\(query.trimmingCharacters(in: .whitespacesAndNewlines))\".")
@@ -649,7 +649,7 @@ private struct SearchNoResultsStateView: View {
 
             VStack(alignment: .leading, spacing: AM.Spacing.m) {
                 Text("Explore instead")
-                    .font(.caption.weight(.semibold))
+                    .font(AM.Font.eyebrow)
                     .foregroundStyle(.secondary)
                     .textCase(.uppercase)
                 LazyVGrid(
@@ -709,7 +709,7 @@ private struct SearchRecoveryStateView: View {
 
             VStack(spacing: AM.Spacing.s) {
                 Text(title)
-                    .font(.title2.bold())
+                    .font(AM.Font.sectionHeader)
                     .foregroundStyle(.primary)
                     .multilineTextAlignment(.center)
                 Text(message)
@@ -809,7 +809,7 @@ private struct SearchCategoryLoadingView: View {
 
                 VStack(spacing: 8) {
                     Text(title)
-                        .font(.title2.bold())
+                        .font(AM.Font.sectionHeader)
                         .multilineTextAlignment(.center)
                     Text("Loading songs")
                         .font(.subheadline)

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -792,7 +792,10 @@ private struct SearchStateGlyph: View {
 
 
     private var pulseAnimation: Animation? {
-        reduceMotion ? nil : .spring(response: 0.9, dampingFraction: 0.78)
+        // Deliberately slower than any AppMotion role: this is a perpetual
+        // loading pulse, and the interaction springs would drive it at roughly
+        // twice the rate, which reads as agitation rather than waiting.
+        reduceMotion ? nil : AppMotion.spring(response: 0.9, dampingFraction: 0.78)
             .repeatForever(autoreverses: true)
     }
 }

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -338,7 +338,7 @@ private struct BrowseCategoriesView: View {
 
     private var featuredSectionContent: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.m) {
-            AMSectionHeader("Featured")
+            AMSectionHeader(String(localized: "Featured"))
             featuredGrid
         }
         .accessibilityIdentifier("SearchBrowse.Featured")
@@ -394,7 +394,7 @@ private struct BrowseCategoriesView: View {
 
     private var genresSection: some View {
         VStack(alignment: .leading, spacing: AM.Spacing.m) {
-            AMSectionHeader("Genres")
+            AMSectionHeader(String(localized: "Genres"))
             genresGridContent
                 .padding(.horizontal, sectionHorizontalPadding)
             if genresVM.isLoadingMore {
@@ -485,7 +485,9 @@ private struct PublicPlaylistsCollectionView: View {
 
     var body: some View {
         PlaylistListView(
-            title: "Public Playlists",
+            // "Twinskaraoke Top 100" next door is a product name and stays as
+            // typed; this one is a description and should translate.
+            title: String(localized: "Public Playlists"),
             playlists: viewModel.playlists,
             apiURL: { startIndex, pageSize in
                 viewModel.urlForList(startIndex: startIndex, pageSize: pageSize)

--- a/Twinskaraoke/Features/Search/SearchView.swift
+++ b/Twinskaraoke/Features/Search/SearchView.swift
@@ -311,18 +311,14 @@ private struct BrowseCategoriesView: View {
 
     private var wideBrowseBoard: some View {
         HStack(alignment: .top, spacing: AM.Spacing.xxl) {
-            VStack(alignment: .leading, spacing: AM.Spacing.l) {
-                Text("Featured")
-                    .font(AM.Font.sectionHeader)
-                    .foregroundStyle(.primary)
+            VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+                AMSectionHeader(String(localized: "Featured"), horizontalPadding: 0)
                 featuredGrid(horizontalPadding: 0)
             }
             .frame(width: 390, alignment: .topLeading)
 
-            VStack(alignment: .leading, spacing: AM.Spacing.l) {
-                Text("Genres")
-                    .font(AM.Font.sectionHeader)
-                    .foregroundStyle(.primary)
+            VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+                AMSectionHeader(String(localized: "Genres"), horizontalPadding: 0)
                 genresGridContent
             }
             .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -3644,6 +3644,9 @@
     "Behavior" : {
 
     },
+    "Best New Songs" : {
+
+    },
     "Broadcasting" : {
       "localizations" : {
         "de" : {
@@ -8807,6 +8810,9 @@
     "Language Support" : {
 
     },
+    "Latest Single" : {
+
+    },
     "Latest Video" : {
       "localizations" : {
         "de" : {
@@ -10508,6 +10514,9 @@
         }
       }
     },
+    "Made for You" : {
+
+    },
     "More" : {
       "localizations" : {
         "de" : {
@@ -10663,6 +10672,9 @@
           }
         }
       }
+    },
+    "More to Explore" : {
+
     },
     "More Watchalongs" : {
 
@@ -10875,6 +10887,9 @@
         }
       }
     },
+    "New & Recent" : {
+
+    },
     "New Code" : {
 
     },
@@ -10981,6 +10996,12 @@
           }
         }
       }
+    },
+    "New Releases" : {
+
+    },
+    "New This Week" : {
+
     },
     "Next" : {
 
@@ -15505,6 +15526,9 @@
       }
     },
     "Recently Played" : {
+
+    },
+    "Recently Released" : {
 
     },
     "Refresh" : {
@@ -21061,6 +21085,9 @@
       }
     },
     "This video couldn't be played" : {
+
+    },
+    "Top Picks for You" : {
 
     },
     "Trending" : {


### PR DESCRIPTION
Aligns the interface with Apple Music by finishing what the `AM` token layer
started, and fixes three bugs found along the way.

The tokens existed but were barely adopted — 31 uses of `AM.Font` against 343
raw `.font()` call sites — and the values that *were* adopted did not match the
thing they were modelled on.

## Type

`sectionHeader` drops from `.title` (28pt) to `.title2` (22pt), where Apple
Music's shelf headers sit. Tile title and caption become a matched subheadline
pair separating on colour alone, rather than a headline with a caption beneath
it, so a shelf reads as a grid of items instead of a grid of headlines. The ramp
grows to cover roles that were being spelled out by hand at each call site:
`screenTitle`, `heroTitle`, `eyebrow`, `rowCompact*`, `badge`, `playerGlyph`,
and a compact now-playing pair.

`AM.Font` uses go 31 → 82; raw `.font(.…)` 343 → 298. What stays raw is
deliberate: body and caption text in empty states and inset-grouped `List` rows,
which should read as system settings, and card-overlay titles that need to stay
bold over artwork.

## Radius

The old ramp was flat — 7/8/10 across a 44pt row thumbnail and a 340pt player
hero. Now 6/10/16, so the corner tracks the element, and artwork across the app
follows that rule instead of picking a nearby literal (137 → 97 hardcoded radii).

`hero` stays a single token deliberately: `ArtworkMorphLayer` lerps
`thumb → hero` while `PlayerArtworkView` draws at `hero`, so the flying artwork
still lands on the shape it becomes. Splitting it would desync the morph.

## Structure and motion

Five hand-rolled section headers now call one `AMSectionHeader`. The
header-to-content gap was four different values and is now one; the phone feeds
were on a literal 18 while every iPad variant already used 28.

`SongRow` could stack a download badge, a duration and an ellipsis at once; it
now shows one status accessory plus the menu.

Nine animations move onto the `AppMotion` scale — layout changes to the shared
spring, pure crossfades through `AppMotion.easeInOut`. Search's loading pulse
keeps its slower response on purpose: it repeats forever, and an interaction
spring would run it at roughly twice the rate. Linear progress fills, the shimmer
placeholders, the player's ambient crossfades and the Aurora backdrop are
untouched — none are spring-shaped.

## Bugs fixed

**Shelf headings never translated.** "Top Picks for You", "Made for You", "New
Releases", "More to Explore", "Best New Songs", "New This Week", "Recently
Released", "Latest Single" shipped as English in all eight locales, and none were
in the string catalog, so no translator had been offered them. A shelf holds its
title as a `String` and hands the same value to the destination's
`navigationTitle`, and a literal reaching a custom initializer is not extracted.
`LocalizedStringKey` cannot be read back out for the navigation title;
`LocalizedStringResource` is not extracted here either, verified on a clean build.
`String(localized:)` at the call site is what works, and is now the convention.
Confirmed with `xcodebuild -exportLocalizations`: all nine appear in the zh-Hans
xliff.

**Shelves clipped at accessibility text sizes.** Heights were a fixed
`tileWidth + 90` inside a `GeometryReader`, so nothing could grow them; at
Accessibility L tile titles were sliced through the baseline and the song-count
line vanished. Now `AM.Layout.shelfLabelAllowance` scaled per shelf with
`@ScaledMetric`. `NewFeaturedRail` had the same bug at a flat 316 and is split the
same way — `243 + 73` reproduces 316 exactly at the default text size. This
predates the branch.

**A downloaded row lost its duration for VoiceOver.** The status glyph replaces
the duration rather than sitting beside it, and `songRowAccessibility` — which
carries the duration — is not applied on six of the screens that draw a `SongRow`.
The glyph now carries the duration itself.

## Not included

The string catalog is deliberately untouched. Running `-exportLocalizations`
against a build that excludes the tvOS target prunes that target's strings, and
committing that would have deleted seven Apple TV entries. A normal Xcode build
of the full project picks the new keys up safely.

## Verification

iOS, watchOS, tvOS and macOS targets all build clean, no new warnings.
`TwinskaraokeTests` green, zero failures. Home, Library, Search, Radio and New
checked on an iPhone 17 Pro simulator against live content, and again at
Accessibility L for clipping.

Not verified: the full-screen player. The simulator cannot decode the audio, so
its title pair and the rounder artwork corner want a look on device.

## Summary by Sourcery

Align the app’s interface with Apple Music while improving localization, accessibility sizing, VoiceOver metadata, and consistency across shared visual and motion patterns.

Bug Fixes:
- Localize shelf headings so they are translated consistently and reused for navigation titles.
- Make home and featured shelves adapt their height to accessibility text sizes, preventing clipped labels.
- Preserve song durations in VoiceOver announcements when download status replaces the visible duration.

Enhancements:
- Align typography, artwork corner radii, section spacing, shelf layouts, song-row accessories, and grid label treatments with Apple Music’s visual language.
- Consolidate section headers and design tokens while adopting shared motion animations across the interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved adaptive sizing for home shelves and featured cards, helping text remain visible at larger accessibility sizes.
  * Added more consistent section headers across Home, Library, Radio, and Search.
* **Enhancements**
  * Refined typography, spacing, artwork corner radii, and controls throughout the app for a more consistent appearance.
  * Improved song-row status display and accessibility labels.
  * Added localized titles across Home, New, and Search sections.
  * Standardized animation timing for smoother transitions and motion settings support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->