### PR TITLE
Fix cross-platform request lifecycles and playback edge cases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,19 @@ jobs:
             -scheme "Twinskaraoke" \
             -destination "platform=iOS Simulator,id=$udid" \
             -only-testing:TwinskaraokeTests \
+            -resultBundlePath "$RUNNER_TEMP/ios-tests.xcresult" \
             CODE_SIGNING_ALLOWED=NO
+
+      - name: Preserve iOS test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-test-diagnostics
+          path: |
+            ${{ runner.temp }}/ios-tests.xcresult
+            ~/Library/Logs/DiagnosticReports
+            ~/Library/Developer/CoreSimulator/Devices/*/data/Library/Logs/CrashReporter
+          if-no-files-found: warn
 
   watch-tests:
     name: watchOS Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,11 @@ jobs:
               end
             end
           ')
+          test -n "$udid"
           echo "Using simulator UDID: $udid"
+          # Wait for a usable simulator before launching the test host. Keep
+          # one worker below so Xcode uses this booted device, not cold clones.
+          xcrun simctl bootstatus "$udid" -b
           # -skipPackagePluginValidation: Pillarbox ships PillarboxPackageInfoPlugin,
           # an SPM build tool plugin, and Xcode will not run a plugin that has not
           # been trusted. Trust is normally granted through a prompt in the GUI,
@@ -45,6 +49,7 @@ jobs:
             -scheme "Twinskaraoke" \
             -destination "platform=iOS Simulator,id=$udid" \
             -only-testing:TwinskaraokeTests \
+            -parallel-testing-enabled NO \
             -resultBundlePath "$RUNNER_TEMP/ios-tests.xcresult" \
             CODE_SIGNING_ALLOWED=NO
 

--- a/Twinskaraoke/Models/Search/SearchViewModel.swift
+++ b/Twinskaraoke/Models/Search/SearchViewModel.swift
@@ -620,6 +620,14 @@ final class SearchViewModel {
     @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
     @ObservationIgnored private var lastDispatchedQuery = ""
 
+    @ObservationIgnored private let loadSongs: @MainActor (String) async throws -> [Song]
+
+    init(loadSongs: @escaping @MainActor (String) async throws -> [Song] = {
+        try await KaraokeAPIClient.searchSongs(query: $0, pageSize: 30)
+    }) {
+        self.loadSongs = loadSongs
+    }
+
     /// Replaces the former `$searchText.debounce().removeDuplicates()` pipeline:
     /// `@Observable` has no publisher projection, so the 500ms coalescing and
     /// the duplicate-query suppression are done here instead. Trimming still
@@ -628,13 +636,18 @@ final class SearchViewModel {
     /// search request.
     private func scheduleSearch() {
         searchDebounceTask?.cancel()
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query != lastDispatchedQuery else { return }
+        // Invalidate immediately: the previous response must not appear under
+        // the new query while its debounce is pending.
+        clearSearch()
+        lastDispatchedQuery = ""
+        guard !query.isEmpty else { return }
         searchDebounceTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(500))
             guard !Task.isCancelled, let self else { return }
-            let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard query != lastDispatchedQuery else { return }
             lastDispatchedQuery = query
-            if query.isEmpty { clearSearch() } else { search(query) }
+            search(query)
         }
     }
 
@@ -660,7 +673,7 @@ final class SearchViewModel {
         searchTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let songs = try await KaraokeAPIClient.searchSongs(query: trimmedQuery, pageSize: 30)
+                let songs = try await loadSongs(trimmedQuery)
                 guard !Task.isCancelled else { return }
                 applySearchResponse(songs, token: token)
             } catch is CancellationError {
@@ -704,6 +717,7 @@ final class SearchViewModel {
     }
 
     deinit {
+        searchDebounceTask?.cancel()
         searchTask?.cancel()
     }
 }

--- a/Twinskaraoke/Services/Radio/RadioController.swift
+++ b/Twinskaraoke/Services/Radio/RadioController.swift
@@ -16,7 +16,14 @@ final class RadioController {
     private var pollTimer: Timer?
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
     private var lastMetadataSignature: String?
-    private init() {}
+    @ObservationIgnored private let loadMetadata: @MainActor () async throws -> Data
+
+    init(loadMetadata: @escaping @MainActor () async throws -> Data = {
+        let (data, _) = try await URLSession.shared.data(from: RadioController.metadataURL)
+        return data
+    }) {
+        self.loadMetadata = loadMetadata
+    }
     func start() {
         if AppRuntime.isUITestMode {
             pollTimer?.invalidate()
@@ -43,6 +50,7 @@ final class RadioController {
         pollTimer = nil
         refreshTask?.cancel()
         refreshTask = nil
+        isRefreshing = false
     }
 
     func playLiveStream(retry: Int = 0) {
@@ -81,21 +89,25 @@ final class RadioController {
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             await performRefresh()
-            refreshTask = nil
+            if !Task.isCancelled { refreshTask = nil }
         }
         refreshTask = task
         await task.value
     }
 
     private func performRefresh() async {
+        guard !Task.isCancelled else { return }
         isRefreshing = true
-        defer { isRefreshing = false }
+        defer {
+            if !Task.isCancelled { isRefreshing = false }
+        }
 
         let maxRetries = 3
 
         for attempt in 0 ..< maxRetries {
             do {
-                let (data, _) = try await URLSession.shared.data(from: Self.metadataURL)
+                let data = try await loadMetadata()
+                try Task.checkCancellation()
                 let np = try JSONDecoder().decode(RadioNowPlaying.self, from: data)
                 nowPlaying = np
                 prefetchArtwork(from: np)

--- a/Twinskaraoke/Services/Shimeji/ShimejiZipReader.swift
+++ b/Twinskaraoke/Services/Shimeji/ShimejiZipReader.swift
@@ -1,4 +1,5 @@
 import Compression
+import Darwin
 import Foundation
 
 /// A minimal, dependency-free ZIP reader. iOS has no built-in ZIP archive
@@ -18,34 +19,67 @@ nonisolated enum ShimejiZipReader {
 
     /// Extracts every file entry in `zipURL` into `destinationDirectory`,
     /// recreating the archive's internal folder structure.
-    static func extract(zipURL: URL, to destinationDirectory: URL) throws {
+    static func extract(
+        zipURL: URL,
+        to destinationDirectory: URL,
+        beforeWritingFile: ((String) throws -> Void)? = nil
+    ) throws {
         let data = try Data(contentsOf: zipURL, options: .mappedIfSafe)
         let entries = try readCentralDirectory(data)
-
-        let fm = FileManager.default
         let root = destinationDirectory.standardizedFileURL.resolvingSymlinksInPath()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let rootFD = open(root.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+        guard rootFD >= 0 else { throw ZipError.corruptArchive }
+        defer { close(rootFD) }
+
         for entry in entries where !entry.isDirectory {
-            let components = entry.path.split(separator: "/")
-            guard !components.contains("..") else { throw ZipError.corruptArchive }
-            var candidate = root
-            for component in components {
-                candidate.appendPathComponent(String(component))
-                if (try? fm.destinationOfSymbolicLink(atPath: candidate.path)) != nil {
-                    throw ZipError.corruptArchive
-                }
-            }
-            let destination = root.appendingPathComponent(entry.path)
-                .standardizedFileURL.resolvingSymlinksInPath()
-            guard !entry.path.hasPrefix("/"), !entry.path.contains("\0"),
-                  destination.path.hasPrefix(root.path + "/") else {
+            guard !entry.path.hasPrefix("/"), !entry.path.contains("\0") else {
                 throw ZipError.corruptArchive
             }
-            try fm.createDirectory(
-                at: destination.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
+            let components = entry.path.split(separator: "/").filter { $0 != "." }
+            guard !components.isEmpty, !components.contains("..") else { throw ZipError.corruptArchive }
             let fileData = try extractFileData(data, entry: entry)
-            try fileData.write(to: destination, options: .atomic)
+            try writeFile(fileData, components: components, rootFD: rootFD) {
+                try beforeWritingFile?(entry.path)
+            }
+        }
+    }
+
+    /// Each directory is opened relative to its already-open parent, without
+    /// following links. Replacing a pathname cannot redirect the held handle.
+    private static func writeFile(
+        _ data: Data,
+        components: [Substring],
+        rootFD: Int32,
+        beforeWriting: () throws -> Void
+    ) throws {
+        var directoryFD = dup(rootFD)
+        guard directoryFD >= 0 else { throw ZipError.corruptArchive }
+        defer { close(directoryFD) }
+        for component in components.dropLast() {
+            let name = String(component)
+            guard mkdirat(directoryFD, name, 0o700) == 0 || errno == EEXIST else {
+                throw ZipError.corruptArchive
+            }
+            let childFD = openat(directoryFD, name, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+            guard childFD >= 0 else { throw ZipError.corruptArchive }
+            close(directoryFD)
+            directoryFD = childFD
+        }
+        try beforeWriting()
+        let temporaryName = ".extract-" + UUID().uuidString
+        let fileFD = openat(directoryFD, temporaryName, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        guard fileFD >= 0 else { throw ZipError.corruptArchive }
+        let handle = FileHandle(fileDescriptor: fileFD, closeOnDealloc: false)
+        defer {
+            try? handle.close()
+            unlinkat(directoryFD, temporaryName, 0)
+        }
+        try handle.write(contentsOf: data)
+        // renameat replaces an existing final symlink rather than following it.
+        guard let filename = components.last,
+              renameat(directoryFD, temporaryName, directoryFD, String(filename)) == 0 else {
+            throw ZipError.corruptArchive
         }
     }
 

--- a/Twinskaraoke/Services/Shimeji/ShimejiZipReader.swift
+++ b/Twinskaraoke/Services/Shimeji/ShimejiZipReader.swift
@@ -23,8 +23,23 @@ nonisolated enum ShimejiZipReader {
         let entries = try readCentralDirectory(data)
 
         let fm = FileManager.default
+        let root = destinationDirectory.standardizedFileURL.resolvingSymlinksInPath()
         for entry in entries where !entry.isDirectory {
-            let destination = destinationDirectory.appendingPathComponent(entry.path)
+            let components = entry.path.split(separator: "/")
+            guard !components.contains("..") else { throw ZipError.corruptArchive }
+            var candidate = root
+            for component in components {
+                candidate.appendPathComponent(String(component))
+                if (try? fm.destinationOfSymbolicLink(atPath: candidate.path)) != nil {
+                    throw ZipError.corruptArchive
+                }
+            }
+            let destination = root.appendingPathComponent(entry.path)
+                .standardizedFileURL.resolvingSymlinksInPath()
+            guard !entry.path.hasPrefix("/"), !entry.path.contains("\0"),
+                  destination.path.hasPrefix(root.path + "/") else {
+                throw ZipError.corruptArchive
+            }
             try fm.createDirectory(
                 at: destination.deletingLastPathComponent(),
                 withIntermediateDirectories: true
@@ -150,6 +165,7 @@ nonisolated enum ShimejiZipReader {
 
         switch entry.compressionMethod {
         case 0:
+            guard compressed.count == entry.uncompressedSize else { throw ZipError.corruptArchive }
             return compressed
         case 8:
             return try inflateRaw(compressed, uncompressedSize: entry.uncompressedSize)
@@ -164,6 +180,7 @@ nonisolated enum ShimejiZipReader {
     /// method-8 entries contain.
     private static func inflateRaw(_ compressed: Data, uncompressedSize: Int) throws -> Data {
         guard uncompressedSize > 0 else { return Data() }
+        guard !compressed.isEmpty else { throw ZipError.decompressionFailed }
         var output = Data(count: uncompressedSize)
         let writtenCount: Int = output.withUnsafeMutableBytes { destRaw in
             compressed.withUnsafeBytes { srcRaw in

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -44,6 +44,37 @@ private nonisolated final class DownloadTaskRegistry: @unchecked Sendable {
     }
 }
 
+/// Owns temporary promotion files until the main actor accepts their request.
+nonisolated struct DownloadCachePromotion: Sendable {
+    let stagedAudio: URL
+    let stagedSource: URL
+    let audio: URL
+    let source: URL
+    let directory: URL
+
+    /// Stale work discards only its own staging files, preserving any retry.
+    func commit(ifCurrent isCurrent: Bool) throws -> Bool {
+        let fm = FileManager.default
+        defer {
+            try? fm.removeItem(at: stagedAudio)
+            try? fm.removeItem(at: stagedSource)
+        }
+        guard isCurrent else { return false }
+        try DownloadManager.commitDownloadedAudioFile(at: stagedAudio, to: audio, in: directory)
+        do {
+            if fm.fileExists(atPath: source.path) {
+                _ = try fm.replaceItemAt(source, withItemAt: stagedSource)
+            } else {
+                try fm.moveItem(at: stagedSource, to: source)
+            }
+        } catch {
+            try? fm.removeItem(at: audio)
+            throw error
+        }
+        return true
+    }
+}
+
 struct SongDownloadStatus: Equatable, Sendable {
     let isDownloaded: Bool
     let isDownloading: Bool
@@ -531,13 +562,13 @@ final class DownloadManager {
         for song: Song,
         remoteURL: URL,
         token: UUID
-    ) -> Bool {
+    ) -> DownloadCachePromotion? {
         let expectedDuration = song.duration > 0 ? TimeInterval(song.duration) : nil
         guard let cachedURL = AudioCacheStore.playableMainURL(
             for: song.id,
             expectedRemoteURL: remoteURL,
             expectedDuration: expectedDuration
-        ), !Task.isCancelled else { return false }
+        ), !Task.isCancelled else { return nil }
 
         let songFiles = files(for: song.id, sourceURL: remoteURL)
         let stagedAudio = Self.promotionStagingURL(
@@ -549,9 +580,12 @@ final class DownloadManager {
             "main.source.promoting-\(token.uuidString)"
         )
         let fm = FileManager.default
+        var keepStaging = false
         defer {
-            try? fm.removeItem(at: stagedAudio)
-            try? fm.removeItem(at: stagedSource)
+            if !keepStaging {
+                try? fm.removeItem(at: stagedAudio)
+                try? fm.removeItem(at: stagedSource)
+            }
         }
 
         do {
@@ -560,38 +594,21 @@ final class DownloadManager {
             guard !Task.isCancelled,
                   Self.isValidDownloadedAudio(at: stagedAudio, expectedDuration: expectedDuration),
                   let sourceData = remoteURL.absoluteString.data(using: .utf8)
-            else { return false }
+            else { return nil }
             try sourceData.write(to: stagedSource, options: [.atomic])
 
-            return try taskRegistry.performIfActive(songID: song.id, token: token) {
-                try Self.commitDownloadedAudioFile(
-                    at: stagedAudio,
-                    to: songFiles.audio,
-                    in: songFiles.directory
-                )
-                if fm.fileExists(atPath: songFiles.source.path) {
-                    do {
-                        _ = try fm.replaceItemAt(songFiles.source, withItemAt: stagedSource)
-                    } catch {
-                        try? fm.removeItem(at: songFiles.audio)
-                        throw error
-                    }
-                } else {
-                    do {
-                        try fm.moveItem(at: stagedSource, to: songFiles.source)
-                    } catch {
-                        try? fm.removeItem(at: songFiles.audio)
-                        throw error
-                    }
-                }
-                return true
-            } ?? false
+            keepStaging = true
+            return DownloadCachePromotion(
+                stagedAudio: stagedAudio, stagedSource: stagedSource,
+                audio: songFiles.audio, source: songFiles.source,
+                directory: songFiles.directory
+            )
         } catch {
             DebugLogger.log(
                 "Playback cache promotion failed for \(song.id): \(error.localizedDescription)",
                 category: .cache
             )
-            return false
+            return nil
         }
     }
 
@@ -599,14 +616,17 @@ final class DownloadManager {
         song: Song,
         remoteURL: URL,
         token: UUID,
-        promoted: Bool
+        promoted: DownloadCachePromotion?
     ) {
         // A cancelled promotion may finish after the same song is queued
         // again. It must not remove the replacement task's concurrency slot.
         let isCurrentTask = taskRegistry.performIfActive(songID: song.id, token: token) { true } ?? false
+        // No suspension between token validation, publishing files, and
+        // finishing the download: cancel/retry cannot interleave here.
+        let committed = (try? promoted?.commit(ifCurrent: isCurrentTask)) ?? false
         guard isCurrentTask else { return }
         cachePromotionTasks.removeValue(forKey: song.id)
-        if promoted {
+        if committed {
             DebugLogger.log("Download promoted from playback cache: \(song.id)", category: .cache)
             finishDownload(songID: song.id, song: song, moved: true, token: token)
             return

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -601,6 +601,10 @@ final class DownloadManager {
         token: UUID,
         promoted: Bool
     ) {
+        // A cancelled promotion may finish after the same song is queued
+        // again. It must not remove the replacement task's concurrency slot.
+        let isCurrentTask = taskRegistry.performIfActive(songID: song.id, token: token) { true } ?? false
+        guard isCurrentTask else { return }
         cachePromotionTasks.removeValue(forKey: song.id)
         if promoted {
             DebugLogger.log("Download promoted from playback cache: \(song.id)", category: .cache)
@@ -608,8 +612,7 @@ final class DownloadManager {
             return
         }
 
-        let isCurrentTask = taskRegistry.performIfActive(songID: song.id, token: token) { true } ?? false
-        guard isCurrentTask, inProgress.contains(song.id) else {
+        guard inProgress.contains(song.id) else {
             startQueuedDownloadsIfPossible()
             logDownloadQueueCompletionIfNeeded()
             return

--- a/TwinskaraokeMacApp/Models/SearchViewModel.swift
+++ b/TwinskaraokeMacApp/Models/SearchViewModel.swift
@@ -9,6 +9,7 @@ final class MacSearchViewModel {
     private(set) var isSearching = false
     private(set) var errorMessage: String?
 
+    private var queryToken = 0
     private var searchTask: Task<Void, Never>?
     private static let debounce = Duration.milliseconds(300)
 
@@ -16,6 +17,11 @@ final class MacSearchViewModel {
     /// previous task also cancels its in-flight URLSession work.
     func queryChanged() {
         searchTask?.cancel()
+        queryToken &+= 1
+        let token = queryToken
+        isSearching = false
+        errorMessage = nil
+        results = []
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard trimmed.count >= 2 else {
@@ -28,21 +34,24 @@ final class MacSearchViewModel {
         searchTask = Task { [weak self] in
             try? await Task.sleep(for: Self.debounce)
             guard !Task.isCancelled else { return }
-            await self?.performSearch(trimmed)
+            await self?.performSearch(trimmed, token: token)
         }
     }
 
-    private func performSearch(_ text: String) async {
+    private func performSearch(_ text: String, token: Int) async {
         isSearching = true
         errorMessage = nil
-        defer { isSearching = false }
+        defer {
+            if queryToken == token { isSearching = false }
+        }
         do {
             let songs = try await KaraokeAPIClient.searchSongs(query: text, pageSize: 50)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, queryToken == token else { return }
             results = songs
         } catch is CancellationError {
             return
         } catch {
+            guard !Task.isCancelled, queryToken == token else { return }
             results = []
             errorMessage = "Search failed. Please try again."
         }
@@ -50,6 +59,8 @@ final class MacSearchViewModel {
 
     func clear() {
         searchTask?.cancel()
+        queryToken &+= 1
+        isSearching = false
         query = ""
         results = []
         errorMessage = nil

--- a/TwinskaraokeMacApp/Services/MacAudioManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAudioManager.swift
@@ -85,7 +85,10 @@ final class MacAudioManager {
     // MARK: - Transport
 
     func play(song: Song, context: [Song] = []) {
-        let playbackQueue = context.isEmpty ? [song] : context
+        var playbackQueue = context.isEmpty ? [song] : context
+        if !playbackQueue.contains(where: { $0.id == song.id }) {
+            playbackQueue.insert(song, at: 0)
+        }
         let index = playbackQueue.firstIndex { $0.id == song.id } ?? 0
         queue = playbackQueue
         currentIndex = index
@@ -140,12 +143,13 @@ final class MacAudioManager {
     }
 
     func seek(to seconds: Double) {
-        guard let player, duration > 0 else { return }
+        guard let player, seconds.isFinite, duration.isFinite, duration > 0 else { return }
         let clamped = min(max(seconds, 0), duration)
-        player.seek(to: CMTime(seconds: clamped, preferredTimescale: 600)) { [weak self] _ in
+        player.seek(to: CMTime(seconds: clamped, preferredTimescale: 600)) { [weak self] finished in
             Task { @MainActor in
-                self?.currentTime = clamped
-                self?.updateNowPlayingPlaybackState()
+                guard finished, let self, self.player === player else { return }
+                self.currentTime = clamped
+                self.updateNowPlayingPlaybackState()
             }
         }
     }
@@ -164,16 +168,17 @@ final class MacAudioManager {
         currentSong = song
         playbackError = nil
 
+        teardownPlayer()
+        currentTime = 0
+        duration = 0
+
         guard let url = song.audioURL else {
             handleFailure("This song has no playable audio.")
             return
         }
 
-        teardownPlayer()
         isLoading = true
         wantsPlaybackWhenReady = true
-        currentTime = 0
-        duration = 0
 
         let item = AVPlayerItem(url: url)
         let player = AVPlayer(playerItem: item)
@@ -182,7 +187,7 @@ final class MacAudioManager {
 
         statusObservation = item.observe(\.status, options: [.new]) { [weak self] item, _ in
             Task { @MainActor in
-                guard let self else { return }
+                guard let self, self.player === player else { return }
                 switch item.status {
                 case .readyToPlay:
                     self.isLoading = false
@@ -208,7 +213,7 @@ final class MacAudioManager {
             queue: .main
         ) { [weak self] time in
             Task { @MainActor in
-                guard let self else { return }
+                guard let self, self.player === player else { return }
                 self.currentTime = time.seconds.isFinite ? time.seconds : 0
                 if self.duration == 0, let itemDuration = self.player?.currentItem?.duration.seconds,
                    itemDuration.isFinite, itemDuration > 0 {
@@ -222,7 +227,10 @@ final class MacAudioManager {
             object: item,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in self?.handleReachedEnd() }
+            Task { @MainActor in
+                guard let self, self.player === player else { return }
+                self.handleReachedEnd()
+            }
         }
     }
 
@@ -230,13 +238,6 @@ final class MacAudioManager {
         if playbackMode == .songLoop {
             seek(to: 0)
             resume()
-            return
-        }
-        // Single-song queue with no loop: stop rather than restart.
-        if queue.count <= 1, playbackMode != .shuffle {
-            isPlaying = false
-            currentTime = 0
-            updateNowPlayingPlaybackState()
             return
         }
         playNext()
@@ -248,16 +249,23 @@ final class MacAudioManager {
         playbackError = message
         failedIndices.insert(currentIndex)
         // Every remaining track failed — stop instead of cycling the queue.
-        guard failedIndices.count < queue.count, queue.count > 1 else { return }
-        playNext()
+        guard failedIndices.count < queue.count, queue.count > 1 else {
+            teardownPlayer()
+            updateNowPlayingPlaybackState()
+            return
+        }
+        // Yield between invalid items instead of recursively exhausting a
+        // potentially large queue on one stack. Ignore superseded failures.
+        let failedSong = currentSong?.id
+        let failedIndex = currentIndex
+        Task { @MainActor [weak self] in
+            guard let self, self.currentSong?.id == failedSong,
+                  self.currentIndex == failedIndex, self.playbackError != nil else { return }
+            self.playNext()
+        }
     }
 
-    /// Excludes indices already known to have failed, not just the current one.
-    /// `handleFailure` -> `playNext` -> `startCurrent` -> `handleFailure` runs on
-    /// one call stack for songs with no audio URL, and the recursion only ends
-    /// when `failedIndices` covers the queue. Re-picking a failed index made no
-    /// progress, so a queue with several unplayable songs could recurse without
-    /// bound.
+    /// Avoid revisiting failed indices while searching for playable audio.
     private func randomIndex(excluding excluded: Int?) -> Int {
         let candidates = queue.indices.filter { $0 != excluded && !failedIndices.contains($0) }
         if let pick = candidates.randomElement() { return pick }

--- a/TwinskaraokeMacApp/Services/MacAudioManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAudioManager.swift
@@ -164,6 +164,7 @@ final class MacAudioManager {
 
     private func startCurrent() {
         guard queue.indices.contains(currentIndex) else { return }
+        wantsPlaybackWhenReady = true
         let song = queue[currentIndex]
         currentSong = song
         playbackError = nil
@@ -178,7 +179,6 @@ final class MacAudioManager {
         }
 
         isLoading = true
-        wantsPlaybackWhenReady = true
 
         let item = AVPlayerItem(url: url)
         let player = AVPlayer(playerItem: item)
@@ -260,7 +260,8 @@ final class MacAudioManager {
         let failedIndex = currentIndex
         Task { @MainActor [weak self] in
             guard let self, self.currentSong?.id == failedSong,
-                  self.currentIndex == failedIndex, self.playbackError != nil else { return }
+                  self.currentIndex == failedIndex, self.playbackError != nil,
+                  self.wantsPlaybackWhenReady else { return }
             self.playNext()
         }
     }

--- a/TwinskaraokeMacApp/Services/MacAuthManager.swift
+++ b/TwinskaraokeMacApp/Services/MacAuthManager.swift
@@ -58,7 +58,7 @@ final class MacAuthManager {
     /// `TVAuthManager.refreshAccount` — same endpoints, same partial-failure
     /// handling, so one endpoint being down doesn't blank the whole screen.
     func refreshAccount() async {
-        guard isLoggedIn, CredentialStore.token != nil, !isRefreshingProfile else { return }
+        guard isLoggedIn, let token = CredentialStore.token, !isRefreshingProfile else { return }
         isRefreshingProfile = true
         profileError = nil
         defer { isRefreshingProfile = false }
@@ -66,6 +66,7 @@ final class MacAuthManager {
         async let fetchedProfile = try? Self.authorizedData(path: "/api/badge/profile")
         async let fetchedLimits = try? Self.authorizedData(path: "/api/user/upload-limits")
         let (profileData, limitsData) = await (fetchedProfile, fetchedLimits)
+        guard !Task.isCancelled, isLoggedIn, CredentialStore.token == token else { return }
 
         var didFail = false
         if let profileData {

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -806,9 +806,21 @@
           }
         },
         "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld songs"
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld song"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld songs"
+                }
+              }
+            }
           }
         },
         "fi" : {

--- a/TwinskaraokeShared/Services/FavoritesManager.swift
+++ b/TwinskaraokeShared/Services/FavoritesManager.swift
@@ -45,6 +45,7 @@ final class FavoritesManager {
     }
 
     func toggle(songID: String) {
+        guard CredentialStore.isAuthenticated else { return }
         guard !inFlight.contains(songID) else { return }
         let wasFavorite = favoriteIDs.contains(songID)
         if wasFavorite {
@@ -82,7 +83,7 @@ final class FavoritesManager {
     }
 
     private func load() async {
-        guard CredentialStore.isAuthenticated else { return }
+        guard CredentialStore.isAuthenticated, !isLoading else { return }
         let generation = stateGeneration
         let revision = mutationRevision
         isLoading = true
@@ -241,6 +242,8 @@ final class FavoritesManager {
         )
         else { return false }
         req.httpMethod = "PUT"
-        return (try? await KaraokeAPIClient.data(for: req)) != nil
+        // This endpoint flips membership, so repeating a successful write
+        // after a lost response would undo the user's change.
+        return (try? await KaraokeAPIClient.data(for: req, allowsRetry: false)) != nil
     }
 }

--- a/TwinskaraokeTVApp/Models/SearchViewModel.swift
+++ b/TwinskaraokeTVApp/Models/SearchViewModel.swift
@@ -37,17 +37,18 @@ final class SearchViewModel {
     /// the duplicate-query suppression are done here instead.
     private func scheduleSearch() {
         searchDebounceTask?.cancel()
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query != lastDispatchedQuery else { return }
+        // Invalidate immediately: the previous response must not appear under
+        // the new query while its debounce is pending.
+        clearSearch()
+        lastDispatchedQuery = ""
+        guard !query.isEmpty else { return }
         searchDebounceTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(400))
             guard !Task.isCancelled, let self else { return }
-            let text = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard text != lastDispatchedQuery else { return }
-            lastDispatchedQuery = text
-            if text.isEmpty {
-                clearSearch()
-            } else {
-                performSearch(query: text)
-            }
+            lastDispatchedQuery = query
+            performSearch(query: query)
         }
     }
 

--- a/TwinskaraokeTVApp/Services/AudioManager.swift
+++ b/TwinskaraokeTVApp/Services/AudioManager.swift
@@ -161,7 +161,7 @@ final class AudioManager {
             .sink { [weak self] dur in
                 guard let self, self.player === player else { return }
                 let seconds = CMTimeGetSeconds(dur)
-                if !seconds.isNaN, seconds > 0 {
+                if seconds.isFinite, seconds > 0 {
                     duration = seconds
                 }
             }
@@ -196,7 +196,7 @@ final class AudioManager {
         timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) {
             [weak self] time in
             Task { @MainActor [weak self] in
-                guard let self else { return }
+                guard let self, self.player === player else { return }
                 let seconds = CMTimeGetSeconds(time)
                 if seconds.isFinite, !seconds.isNaN {
                     currentTime = max(0, seconds)
@@ -207,7 +207,10 @@ final class AudioManager {
         endTimeObserver = NotificationCenter.default.addObserver(
             forName: .AVPlayerItemDidPlayToEndTime, object: playerItem, queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.playEnded() }
+            Task { @MainActor [weak self] in
+                guard let self, self.player === player else { return }
+                self.playEnded()
+            }
         }
     }
 
@@ -354,8 +357,10 @@ final class AudioManager {
     }
 
     func seek(to time: Double) {
-        player?.seek(to: CMTime(seconds: time, preferredTimescale: 600))
-        currentTime = time
+        guard let player, time.isFinite, duration.isFinite, duration > 0 else { return }
+        let clamped = min(max(time, 0), duration)
+        player.seek(to: CMTime(seconds: clamped, preferredTimescale: 600))
+        currentTime = clamped
         updateNowPlayingInfo()
     }
 

--- a/TwinskaraokeTVApp/Services/TVAuthManager.swift
+++ b/TwinskaraokeTVApp/Services/TVAuthManager.swift
@@ -252,7 +252,7 @@ final class TVAuthManager {
     }
 
     func refreshAccount() async {
-        guard isLoggedIn, CredentialStore.token != nil, !isRefreshing else { return }
+        guard isLoggedIn, let token = CredentialStore.token, !isRefreshing else { return }
         isRefreshing = true
         profileError = nil
         defer { isRefreshing = false }
@@ -260,6 +260,7 @@ final class TVAuthManager {
         async let fetchedProfile = try? Self.authorizedData(path: "/api/badge/profile")
         async let fetchedLimits = try? Self.authorizedData(path: "/api/user/upload-limits")
         let (profileData, limitsData) = await (fetchedProfile, fetchedLimits)
+        guard !Task.isCancelled, isLoggedIn, CredentialStore.token == token else { return }
 
         var didFail = false
         if let profileData {

--- a/TwinskaraokeTests/DownloadManagerTests.swift
+++ b/TwinskaraokeTests/DownloadManagerTests.swift
@@ -4,6 +4,57 @@ import Testing
 
 @Suite("Download validation")
 struct DownloadManagerTests {
+    @Test("Cancelled promotion discards only its own files", arguments: [false, true])
+    func cancelledPromotionDoesNotPublishOrDeleteRetry(hasReplacement: Bool) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let promotion = DownloadCachePromotion(
+            stagedAudio: directory.appendingPathComponent("main.promoting-old.mp3"),
+            stagedSource: directory.appendingPathComponent("main.source.promoting-old"),
+            audio: directory.appendingPathComponent("main.mp3"),
+            source: directory.appendingPathComponent("main.source"),
+            directory: directory
+        )
+        try Data("cancelled".utf8).write(to: promotion.stagedAudio)
+        try Data("old-source".utf8).write(to: promotion.stagedSource)
+        if hasReplacement {
+            try Data("replacement".utf8).write(to: promotion.audio)
+            try Data("new-source".utf8).write(to: promotion.source)
+        }
+        #expect(try !promotion.commit(ifCurrent: false))
+        #expect(!FileManager.default.fileExists(atPath: promotion.stagedAudio.path))
+        #expect(!FileManager.default.fileExists(atPath: promotion.stagedSource.path))
+        if hasReplacement {
+            #expect(try Data(contentsOf: promotion.audio) == Data("replacement".utf8))
+            #expect(try Data(contentsOf: promotion.source) == Data("new-source".utf8))
+        } else {
+            #expect(!FileManager.default.fileExists(atPath: promotion.audio.path))
+            #expect(!FileManager.default.fileExists(atPath: promotion.source.path))
+        }
+    }
+
+    @Test("Accepted promotion publishes its audio and source together")
+    func acceptedPromotionPublishesFiles() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let promotion = DownloadCachePromotion(
+            stagedAudio: directory.appendingPathComponent("main.promoting-current.mp3"),
+            stagedSource: directory.appendingPathComponent("main.source.promoting-current"),
+            audio: directory.appendingPathComponent("main.mp3"),
+            source: directory.appendingPathComponent("main.source"),
+            directory: directory
+        )
+        try Data("audio".utf8).write(to: promotion.stagedAudio)
+        try Data("source".utf8).write(to: promotion.stagedSource)
+        #expect(try promotion.commit(ifCurrent: true))
+        #expect(try Data(contentsOf: promotion.audio) == Data("audio".utf8))
+        #expect(try Data(contentsOf: promotion.source) == Data("source".utf8))
+        #expect(!FileManager.default.fileExists(atPath: promotion.stagedAudio.path))
+        #expect(!FileManager.default.fileExists(atPath: promotion.stagedSource.path))
+    }
+
     @Test("Fallback artwork selection is stable and bounded")
     func fallbackArtworkSelectionIsDeterministic() {
         let first = FallbackArtProvider.fallbackIndex(for: "song-without-art", count: 12)

--- a/TwinskaraokeTests/RadioLifecycleTests.swift
+++ b/TwinskaraokeTests/RadioLifecycleTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+@MainActor
+@Suite("Radio refresh lifecycle")
+struct RadioLifecycleTests {
+    @Test("Stopping and restarting cannot let an old refresh clear the new spinner")
+    func supersededRefresh() async {
+        var responses: [CheckedContinuation<Data, Never>] = []
+        let controller = RadioController(loadMetadata: {
+            await withCheckedContinuation { responses.append($0) }
+        })
+        let first = Task { await controller.refresh() }
+        while responses.count < 1 { await Task.yield() }
+        #expect(controller.isRefreshing)
+        controller.stop()
+        #expect(!controller.isRefreshing)
+
+        let second = Task { await controller.refresh() }
+        while responses.count < 2 { await Task.yield() }
+        responses[0].resume(returning: Data())
+        await first.value
+        #expect(controller.isRefreshing)
+        #expect(controller.refreshErrorMessage == nil)
+
+        controller.stop()
+        responses[1].resume(returning: Data())
+        await second.value
+        #expect(!controller.isRefreshing)
+        #expect(controller.refreshErrorMessage == nil)
+    }
+}

--- a/TwinskaraokeTests/SearchLifecycleTests.swift
+++ b/TwinskaraokeTests/SearchLifecycleTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+@MainActor
+@Suite("Search lifecycle")
+struct SearchLifecycleTests {
+    @Test("Editing a query clears results and errors before the debounce")
+    func editingInvalidatesPresentationImmediately() {
+        let model = SearchViewModel()
+        model.results = [UITestFixtures.song(id: "old", title: "Old", artist: "Artist")]
+        model.searchErrorMessage = "Old error"
+        model.isSearching = true
+        model.searchText = "new query"
+        #expect(model.results.isEmpty)
+        #expect(model.searchErrorMessage == nil)
+        #expect(!model.isSearching)
+        model.searchText = ""
+    }
+
+    @Test("An old response is rejected during the next query's debounce")
+    func lateResponseDuringDebounce() async {
+        var response: CheckedContinuation<[Song], Never>?
+        let model = SearchViewModel(loadSongs: { _ in
+            await withCheckedContinuation { response = $0 }
+        })
+        model.search("old")
+        while response == nil { await Task.yield() }
+        model.searchText = "new"
+        response?.resume(returning: [UITestFixtures.song(id: "old", title: "Old", artist: "Artist")])
+        for _ in 0..<10 { await Task.yield() }
+        #expect(model.results.isEmpty)
+        #expect(model.searchErrorMessage == nil)
+        model.searchText = ""
+    }
+
+    @Test("Clearing a pending query cancels the search without waiting")
+    func clearingPendingQuery() async throws {
+        let model = SearchViewModel()
+        model.searchText = "pending"
+        model.searchText = "  \n"
+        #expect(!model.hasActiveQuery)
+        #expect(model.results.isEmpty)
+        #expect(!model.isSearching)
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(model.results.isEmpty)
+        #expect(!model.isSearching)
+        #expect(model.searchErrorMessage == nil)
+    }
+}

--- a/TwinskaraokeTests/ShimejiZipReaderTests.swift
+++ b/TwinskaraokeTests/ShimejiZipReaderTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke
+
+@Suite("Resource pack extraction")
+struct ShimejiZipReaderTests {
+    @Test("Normal nested pack files extract successfully")
+    func nestedFile() throws {
+        try withArchive(valid) { archive, root in
+            try ShimejiZipReader.extract(zipURL: archive, to: root)
+            #expect(try String(contentsOf: root.appendingPathComponent("img/frame.txt"), encoding: .utf8) == "sprite")
+        }
+    }
+
+    @Test("Parent traversal cannot write outside the pack")
+    func parentTraversal() throws {
+        try withArchive(traversal) { archive, root in
+            #expect(throws: ShimejiZipReader.ZipError.self) {
+                try ShimejiZipReader.extract(zipURL: archive, to: root)
+            }
+            #expect(!FileManager.default.fileExists(atPath: root.deletingLastPathComponent().appendingPathComponent("escaped.txt").path))
+        }
+    }
+
+    @Test("Existing symbolic links cannot redirect extraction outside the pack")
+    func symlinkEscape() throws {
+        try withArchive(symlink) { archive, root in
+            let outside = root.deletingLastPathComponent().appendingPathComponent("outside")
+            try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+            try FileManager.default.createSymbolicLink(at: root.appendingPathComponent("linked"), withDestinationURL: outside)
+            #expect(throws: ShimejiZipReader.ZipError.self) {
+                try ShimejiZipReader.extract(zipURL: archive, to: root)
+            }
+            #expect(!FileManager.default.fileExists(atPath: outside.appendingPathComponent("escaped.txt").path))
+        }
+    }
+
+    private func withArchive(_ encoded: String, body: (URL, URL) throws -> Void) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let root = directory.appendingPathComponent("pack")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let archive = directory.appendingPathComponent("pack.zip")
+        try #require(Data(base64Encoded: encoded)).write(to: archive)
+        try body(archive, root)
+    }
+    private let valid = "UEsDBBQAAAAAAJBoJl2ejx01BgAAAAYAAAANAAAAaW1nL2ZyYW1lLnR4dHNwcml0ZVBLAQIUAxQAAAAAAJBoJl2ejx01BgAAAAYAAAANAAAAAAAAAAAAAACAAQAAAABpbWcvZnJhbWUudHh0UEsFBgAAAAABAAEAOwAAADEAAAAAAA=="
+    private let traversal = "UEsDBBQAAAAAAJBoJl2ejx01BgAAAAYAAAAOAAAALi4vZXNjYXBlZC50eHRzcHJpdGVQSwECFAMUAAAAAACQaCZdno8dNQYAAAAGAAAADgAAAAAAAAAAAAAAgAEAAAAALi4vZXNjYXBlZC50eHRQSwUGAAAAAAEAAQA8AAAAMgAAAAAA"
+    private let symlink = "UEsDBBQAAAAAAJBoJl2ejx01BgAAAAYAAAASAAAAbGlua2VkL2VzY2FwZWQudHh0c3ByaXRlUEsBAhQDFAAAAAAAkGgmXZ6PHTUGAAAABgAAABIAAAAAAAAAAAAAAIABAAAAAGxpbmtlZC9lc2NhcGVkLnR4dFBLBQYAAAAAAQABAEAAAAA2AAAAAAA="
+}

--- a/TwinskaraokeTests/ShimejiZipReaderTests.swift
+++ b/TwinskaraokeTests/ShimejiZipReaderTests.swift
@@ -35,6 +35,22 @@ struct ShimejiZipReaderTests {
         }
     }
 
+    @Test("Replacing an opened directory with a symlink cannot redirect a write")
+    func replacedDirectoryCannotRedirectWrite() throws {
+        try withArchive(valid) { archive, root in
+            let fm = FileManager.default
+            let outside = root.deletingLastPathComponent().appendingPathComponent("outside")
+            try fm.createDirectory(at: outside, withIntermediateDirectories: true)
+            try ShimejiZipReader.extract(zipURL: archive, to: root) { _ in
+                let directory = root.appendingPathComponent("img")
+                try fm.moveItem(at: directory, to: root.appendingPathComponent("original-img"))
+                try fm.createSymbolicLink(at: directory, withDestinationURL: outside)
+            }
+            #expect(!fm.fileExists(atPath: outside.appendingPathComponent("frame.txt").path))
+            #expect(try String(contentsOf: root.appendingPathComponent("original-img/frame.txt"), encoding: .utf8) == "sprite")
+        }
+    }
+
     private func withArchive(_ encoded: String, body: (URL, URL) throws -> Void) throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let root = directory.appendingPathComponent("pack")

--- a/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
+++ b/TwinskaraokeWatchApp/Models/Search/SearchViewModel.swift
@@ -38,17 +38,18 @@ final class SearchViewModel {
     /// the duplicate-query suppression are done here instead.
     private func scheduleSearch() {
         searchDebounceTask?.cancel()
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query != lastDispatchedQuery else { return }
+        // Invalidate immediately: the previous response must not appear under
+        // the new query while its debounce is pending.
+        clearSearch()
+        lastDispatchedQuery = ""
+        guard !query.isEmpty else { return }
         searchDebounceTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(500))
             guard !Task.isCancelled, let self else { return }
-            let text = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard text != lastDispatchedQuery else { return }
-            lastDispatchedQuery = text
-            if text.isEmpty {
-                clearSearch()
-            } else {
-                performSearch(query: text)
-            }
+            lastDispatchedQuery = query
+            performSearch(query: query)
         }
     }
 

--- a/TwinskaraokeWatchApp/Services/RadioController.swift
+++ b/TwinskaraokeWatchApp/Services/RadioController.swift
@@ -40,7 +40,7 @@ final class RadioController {
                 try? await Task.sleep(for: interval)
                 guard let self, self.shouldKeepPolling else { break }
             }
-            self?.clearPollTask()
+            if !Task.isCancelled { self?.clearPollTask() }
         }
     }
 
@@ -99,15 +99,18 @@ final class RadioController {
         }
         let task = Task { @MainActor [weak self] in
             await self?.performRefresh()
-            self?.refreshTask = nil
+            if !Task.isCancelled { self?.refreshTask = nil }
         }
         refreshTask = task
         await task.value
     }
 
     private func performRefresh() async {
+        guard !Task.isCancelled else { return }
         isRefreshing = true
-        defer { isRefreshing = false }
+        defer {
+            if !Task.isCancelled { isRefreshing = false }
+        }
 
         do {
             var request = URLRequest(url: RadioStation.metadataURL)

--- a/TwinskaraokeWatchAppTests/WatchSearchLifecycleTests.swift
+++ b/TwinskaraokeWatchAppTests/WatchSearchLifecycleTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Twinskaraoke_Watch_App
+
+@MainActor
+@Suite("Watch search lifecycle")
+struct WatchSearchLifecycleTests {
+    @Test("Editing the query immediately clears an obsolete error and spinner")
+    func editInvalidatesState() {
+        let model = SearchViewModel()
+        model.loadError = "Old error"
+        model.isLoading = true
+        model.searchText = "new"
+        #expect(model.loadError == nil)
+        #expect(!model.isLoading)
+        model.searchText = ""
+    }
+
+    @Test("Clearing a pending query prevents it from starting")
+    func clearPendingQuery() async throws {
+        let model = SearchViewModel()
+        model.searchText = "pending"
+        model.searchText = ""
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(model.results.isEmpty)
+        #expect(!model.isLoading)
+        #expect(model.loadError == nil)
+    }
+}


### PR DESCRIPTION
Rapid query changes, playback switches, and cancelled background work could let obsolete callbacks overwrite newer app state. This change invalidates superseded work and fixes related playback, favorites, and resource-extraction issues across iOS, watchOS, macOS, and tvOS.

- Clear obsolete search results immediately when a query changes; prevent cancelled Mac searches from overwriting loading/error state.
- Reject stale radio refresh cleanup and Mac/TV account responses after sign-out. Keep promoted downloads in token-specific staging until the main actor accepts them; discard stale staging without touching a replacement download.
- Stop retrying membership-flipping favorite requests, which could undo a successful toggle after a lost response.
- Fix Mac queue selection, invalid-track handling, and single-song Repeat All. Honor pauses before deferred failure recovery; guard Mac/TV callbacks against replaced players and clamp seeks.
- Extract ZIP files through directory-relative, no-follow operations so replacing an intermediate directory cannot redirect a write. Reject traversal and malformed stored/compressed data.
- Add English singular/plural rules for song counts and regression coverage for search, radio, archive extraction, and cancelled download promotion.
- Wait for the iOS simulator to finish booting, run one test worker, and preserve result bundles/crash reports. The original CI failure was an abort before the test host connected; a diagnostic rerun of the same app code passed both iOS and Watch jobs.

Validation: 211 iOS unit tests passed locally, including deterministic symlink-replacement and cancelled-promotion regressions. The Watch suite previously passed 43 tests. The full iOS UI run passed 25 of 26 cases; the remaining artwork-drag case lost its app connection and passed when rerun alone. Mac and TV Debug builds and the iOS analyzer passed; the Mac build was repeated after the pause fix. Final-head CI is running. Real-device audio routes, CarPlay, and live account operations still require device/service verification.
