### PR TITLE
Make the settings controls do what they claim

### DIFF
--- a/Twinskaraoke/Features/Account/DeveloperMenuView.swift
+++ b/Twinskaraoke/Features/Account/DeveloperMenuView.swift
@@ -35,6 +35,8 @@ struct DeveloperMenuView: View {
         .alert("Disable developer mode?", isPresented: $showDisableConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Disable Developer Mode", role: .destructive) {
+                debugLogging = false
+                easterEggAlwaysTrigger = false
                 DeveloperMode.isEnabled = false
                 dismiss()
             }

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -839,17 +839,6 @@ private struct EqualizerBands: View {
         }
         return "\(Int(hz))"
     }
-
-    private func frequencyAccessibilityLabel(_ hz: Double) -> String {
-        if hz >= 1000 {
-            let k = hz / 1000
-            if k.truncatingRemainder(dividingBy: 1) == 0 {
-                return "\(Int(k)) kilohertz"
-            }
-            return String(format: "%.1f kilohertz", k)
-        }
-        return "\(Int(hz)) hertz"
-    }
 }
 
 private struct EqualizerBand: View {

--- a/Twinskaraoke/Features/Account/SettingsView.swift
+++ b/Twinskaraoke/Features/Account/SettingsView.swift
@@ -4,10 +4,6 @@ struct SettingsView: View {
     @Bindable private var audioManager = AudioPlayerManager.shared
     private let cacheManager = CacheManager.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @AppStorage("nk.addPlaylistSongsToLibrary") private var addPlaylistSongsToLibrary: Bool = false
-    @AppStorage("nk.addFavoriteSongsToLibrary") private var addFavoriteSongsToLibrary: Bool = true
-    @AppStorage("nk.syncLibrary") private var syncLibrary: Bool = true
-    @AppStorage("nk.streamingQuality") private var streamingQuality: String = "high"
     @AppStorage("nk.downloadOnPlay") private var downloadOnPlay: Bool = false
     @AppStorage("nk.appearance") private var appearanceMode: String = AppearanceMode.dark.rawValue
     @AppStorage(AppLanguage.storageKey) private var languageMode: String = AppLanguage.system.rawValue
@@ -17,7 +13,10 @@ struct SettingsView: View {
     @AppStorage("nk.experimentsEnabled") private var experimentsEnabled: Bool = false
     @AppStorage("nk.experimentalThemesEnabled") private var experimentalThemesEnabled: Bool = false
     @AppStorage("nk.experimentalShimejiEnabled") private var shimejiEnabled: Bool = false
+    @AppStorage("nk.developerMode") private var developerModeEnabled = false
     @State private var pendingAction: SettingsDestructiveAction?
+    @State private var isClearingStorage = false
+    @State private var showStorageError = false
     @State private var showAutoAnalyzeAlert = false
     @State private var showExperimentsAlert = false
     private var visibleEQPresets: [EQPreset] {
@@ -34,8 +33,13 @@ struct SettingsView: View {
         settingsContent
             .navigationTitle("Music")
             .navigationBarTitleDisplayMode(.inline)
+            .alert("Could Not Clear Storage", isPresented: $showStorageError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Some files could not be removed. Please try again.")
+            }
             .alert(
-                pendingAction?.title ?? "",
+                Text(LocalizedStringKey(pendingAction?.title ?? "")),
                 isPresented: Binding(
                     get: { pendingAction != nil },
                     set: { if !$0 { pendingAction = nil } }
@@ -44,11 +48,11 @@ struct SettingsView: View {
             ) { action in
                 Button("Cancel", role: .cancel) {}
                     .tint(Color(uiColor: .systemBlue))
-                Button(action.actionLabel, role: .destructive) {
+                Button(LocalizedStringKey(action.actionLabel), role: .destructive) {
                     perform(action)
                 }
             } message: { action in
-                Text(action.message)
+                Text(LocalizedStringKey(action.message))
             }
             .alert(
                 "Turn on auto-analyze during playback?",
@@ -101,7 +105,6 @@ struct SettingsView: View {
 
     private var settingsList: some View {
         List {
-            librarySection
             audioSection
             downloadsSection
             if DeviceCapability.supportsKaraoke {
@@ -123,38 +126,6 @@ struct SettingsView: View {
         .groupedScreenBackground()
     }
 
-    private var librarySection: some View {
-        Section {
-            Toggle("Add Playlist Songs", isOn: $addPlaylistSongsToLibrary)
-            .toggleHaptic(addPlaylistSongsToLibrary)
-                .tint(.appAccent)
-            Toggle("Add Favorite Songs", isOn: $addFavoriteSongsToLibrary)
-            .toggleHaptic(addFavoriteSongsToLibrary)
-                .tint(.appAccent)
-            Toggle("Sync Library", isOn: $syncLibrary)
-            .toggleHaptic(syncLibrary)
-                .tint(.appAccent)
-        } header: {
-            Text("Library")
-        } footer: {
-            Text("Add songs to your library when you add them to playlists or favorite them. Sync keeps library changes available across this app on your devices.")
-        }
-    }
-
-    private var overviewSection: some View {
-        Section {
-            SettingsOverviewCard(
-                title: audioManager.currentSong?.title ?? "Ready to Play",
-                subtitle: audioManager.currentSong?.displayArtist ?? "Tune playback for Twinskaraoke",
-                isPlaying: audioManager.isPlaying,
-                badges: settingsBadges
-            )
-            .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 8, trailing: 16))
-            .listRowBackground(Color.clear)
-        }
-        .listSectionSpacing(8)
-    }
-
     private var audioSection: some View {
         Section {
             Toggle("Auto Mix", isOn: $audioManager.autoMixEnabled)
@@ -172,24 +143,18 @@ struct SettingsView: View {
                 )
             }
             Toggle(
-                "Autoplay Similar Songs",
+                "Autoplay",
                 isOn: Binding(
                     get: { audioManager.autoplayEnabled },
-                    set: { _ in audioManager.toggleAutoplay() }
+                    set: { audioManager.autoplayEnabled = $0 }
                 )
             )
             .toggleHaptic(audioManager.autoplayEnabled)
             .tint(.appAccent)
-            Picker("Audio Quality", selection: $streamingQuality) {
-                Text("High Efficiency").tag("low")
-                Text("High Quality").tag("medium")
-                Text("Lossless").tag("high")
-            }
-            .selectionHaptic(streamingQuality)
         } header: {
             Text("Audio")
         } footer: {
-            Text("Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose.")
+            Text("Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose. Autoplay continues with account recommendations, or trending songs when recommendations are unavailable. These features do not apply to radio.")
         }
     }
 
@@ -197,11 +162,14 @@ struct SettingsView: View {
         Section {
             Toggle("Auto-Download Played Songs", isOn: $downloadOnPlay)
             .toggleHaptic(downloadOnPlay)
+                .onChange(of: downloadOnPlay) { _, enabled in
+                    if enabled { audioManager.autoDownloadCurrentSongIfEnabled() }
+                }
                 .tint(.appAccent)
         } header: {
             Text("Downloads")
         } footer: {
-            Text("When enabled, songs you play are saved for offline listening.")
+            Text("When enabled, the current song and songs you play next are saved for offline listening. This may use cellular data. Turning this off leaves existing downloads and downloads already in progress intact.")
         }
     }
 
@@ -224,16 +192,17 @@ struct SettingsView: View {
             if hapticsEnabled {
                 Picker("Strength", selection: hapticStrengthBinding) {
                     ForEach(AppHapticStrength.allCases) { strength in
-                        Text(strength.label).tag(strength)
+                        Text(LocalizedStringKey(strength.label)).tag(strength)
                     }
                 }
+                .accessibilityIdentifier("Settings.HapticStrength")
             }
         } header: {
             Text("Haptics")
         } footer: {
-            Text(hapticsEnabled
+            Text(LocalizedStringKey(hapticsEnabled
                 ? "Taps, swipes and controls answer back with a vibration. Strength sets how hard they land — each control keeps its own character at every level."
-                : "Taps, swipes and controls answer back with a vibration.")
+                : "Taps, swipes and controls answer back with a vibration."))
         }
     }
 
@@ -277,13 +246,18 @@ struct SettingsView: View {
         Section("Appearance") {
             Picker("Theme", selection: $appearanceMode) {
                 ForEach(visibleAppearanceModes, id: \.rawValue) { mode in
-                    Text(mode.label).tag(mode.rawValue)
+                    Text(LocalizedStringKey("Theme." + mode.rawValue)).tag(mode.rawValue)
                 }
             }
+            .accessibilityIdentifier("Settings.Theme")
             .selectionHaptic(appearanceMode)
             Picker("Language", selection: $languageMode) {
                 ForEach(AppLanguage.allCases) { language in
-                    Text(language.displayName).tag(language.rawValue)
+                    if language == .system {
+                        Text("System").tag(language.rawValue)
+                    } else {
+                        Text(language.displayName).tag(language.rawValue)
+                    }
                 }
             }
             .selectionHaptic(languageMode)
@@ -373,7 +347,7 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var developerSection: some View {
-        if DeveloperMode.isEnabled {
+        if developerModeEnabled {
             Section {
                 NavigationLink {
                     DeveloperMenuView()
@@ -384,29 +358,6 @@ struct SettingsView: View {
         }
     }
 
-    private var settingsBadges: [SettingsOverviewBadge] {
-        var badges: [SettingsOverviewBadge] = []
-        if audioManager.crossfadeEnabled {
-            badges.append(SettingsOverviewBadge(title: "\(Int(audioManager.crossfadeSeconds.rounded()))s Crossfade", symbol: "arrow.left.arrow.right"))
-        }
-        if audioManager.eqEnabled {
-            badges.append(SettingsOverviewBadge(title: "EQ", symbol: "slider.vertical.3"))
-        }
-        if audioManager.karaokeMode {
-            badges.append(SettingsOverviewBadge(title: "Vocal Removal", symbol: "music.mic"))
-        } else if audioManager.bassEnhanceMode {
-            badges.append(SettingsOverviewBadge(title: "Bass Enhance", symbol: "speaker.wave.3"))
-        } else if audioManager.vocalEnhanceMode {
-            badges.append(SettingsOverviewBadge(title: "Vocal Enhance", symbol: "music.mic.circle"))
-        } else if audioManager.instrumentalEnhanceMode {
-            badges.append(SettingsOverviewBadge(title: "Instrumental", symbol: "music.note"))
-        }
-        if downloadOnPlay {
-            badges.append(SettingsOverviewBadge(title: "Auto Download", symbol: "arrow.down.circle"))
-        }
-        return badges.isEmpty ? [SettingsOverviewBadge(title: "Default", symbol: "checkmark.circle")] : badges
-    }
-
     private var equalizerSection: some View {
         Section {
             Toggle("Equalizer", isOn: $audioManager.eqEnabled)
@@ -415,7 +366,7 @@ struct SettingsView: View {
             if audioManager.eqEnabled {
                 Picker("Preset", selection: $audioManager.eqPreset) {
                     ForEach(visibleEQPresets) { preset in
-                        Text(preset.rawValue).tag(preset)
+                        Text(LocalizedStringKey(preset.rawValue)).tag(preset)
                     }
                 }
                 .selectionHaptic(audioManager.eqPreset)
@@ -429,7 +380,7 @@ struct SettingsView: View {
         } header: {
             Text("Equalizer")
         } footer: {
-            Text("10-band parametric EQ. Drag each band between -12 dB and +12 dB.")
+            Text("10-band parametric EQ. Drag each band between -12 dB and +12 dB. Equalizer and AI audio effects apply to songs, not radio.")
         }
     }
 
@@ -487,7 +438,7 @@ struct SettingsView: View {
                 HStack {
                     Text("Removal Level")
                     Spacer()
-                    Text(aiStrengthLabel)
+                    Text(LocalizedStringKey(aiStrengthLabel))
                         .foregroundStyle(.secondary)
                 }
                 StrengthSlider(
@@ -504,7 +455,7 @@ struct SettingsView: View {
                 HStack {
                     Text("Strength")
                     Spacer()
-                    Text(bassStrengthLabel)
+                    Text(LocalizedStringKey(bassStrengthLabel))
                         .foregroundStyle(.secondary)
                 }
                 StrengthSlider(
@@ -521,7 +472,7 @@ struct SettingsView: View {
                 HStack {
                     Text("Strength")
                     Spacer()
-                    Text(vocalEnhanceStrengthLabel)
+                    Text(LocalizedStringKey(vocalEnhanceStrengthLabel))
                         .foregroundStyle(.secondary)
                 }
                 StrengthSlider(
@@ -538,7 +489,7 @@ struct SettingsView: View {
                 HStack {
                     Text("Strength")
                     Spacer()
-                    Text(instrumentalEnhanceStrengthLabel)
+                    Text(LocalizedStringKey(instrumentalEnhanceStrengthLabel))
                         .foregroundStyle(.secondary)
                 }
                 StrengthSlider(
@@ -589,7 +540,7 @@ struct SettingsView: View {
                 SettingsStorageActionRow(
                     symbol: "text.quote",
                     title: "Lyrics Cache",
-                    detail: "\(cacheManager.formattedLyricsCacheSize()) / 2 GB"
+                    detail: "\(cacheManager.formattedLyricsCacheSize()) / 64 MB"
                 )
             }
             .buttonStyle(PressableButtonStyle(scale: 0.98, dim: 0.82))
@@ -616,12 +567,16 @@ struct SettingsView: View {
             }
             .buttonStyle(PressableButtonStyle(scale: 0.98, dim: 0.82))
         } header: {
-            Text("Storage")
+            HStack {
+                Text("Storage")
+                if isClearingStorage { ProgressView() }
+            }
         } footer: {
             Text(
-                "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 2 GB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits."
+                "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 64 MB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits."
             )
         }
+        .disabled(isClearingStorage)
     }
 
     private func request(_ action: SettingsDestructiveAction) {
@@ -630,20 +585,32 @@ struct SettingsView: View {
     }
 
     private func perform(_ action: SettingsDestructiveAction) {
+        guard !isClearingStorage else { return }
+        pendingAction = nil
+        isClearingStorage = true
         switch action {
         case .removeDownloads:
-            DownloadManager.shared.removeAll()
+            DownloadManager.shared.removeAll { success in finishStorageAction(success) }
         case .clearImageCache:
-            cacheManager.clearImageCache()
+            cacheManager.clearImageCache { success in finishStorageAction(success) }
         case .clearMusicCache:
             audioManager.clearCache()
-            cacheManager.clearMusicCache()
+            cacheManager.clearMusicCache { success in finishStorageAction(success) }
         case .clearLyricsCache:
-            cacheManager.clearLyricsCache()
+            cacheManager.clearLyricsCache { success in finishStorageAction(success) }
         case .clearRecentlyPlayed:
             RecentlyPlayedStore.shared.reset()
+            finishStorageAction(true)
         }
-        AppHaptic.success.play()
+    }
+
+    private func finishStorageAction(_ success: Bool) {
+        isClearingStorage = false
+        if success {
+            AppHaptic.success.play()
+        } else {
+            showStorageError = true
+        }
     }
 
     private var aiStrengthLabel: String {
@@ -676,97 +643,10 @@ struct SettingsView: View {
     }
 }
 
-private struct SettingsOverviewBadge: Hashable, Identifiable {
-    let title: String
-    let symbol: String
-
-    var id: String {
-        "\(symbol)-\(title)"
-    }
-}
-
-private struct SettingsOverviewCard: View {
-    let title: String
-    let subtitle: String
-    let isPlaying: Bool
-    let badges: [SettingsOverviewBadge]
-    @Environment(\.appReduceMotion) private var reduceMotion
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 14) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(Color.appControlActiveFill)
-                    Image(systemName: isPlaying ? "waveform" : "music.note")
-                        .font(.title2.bold())
-                        .foregroundStyle(Color.appControlActiveForeground)
-                        .scaleEffect(reduceMotion ? 1 : (isPlaying ? 1.06 : 1))
-                        .opacity(isPlaying ? 1 : 0.88)
-                        .animation(overviewAnimation, value: isPlaying)
-                }
-                .frame(width: 62, height: 62)
-                .shadow(color: Color.appShadow, radius: 10, y: 5)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(isPlaying ? "Now Playing" : "Playback")
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                        .textCase(.uppercase)
-                    Text(title)
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                    Text(subtitle)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
-            }
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(badges) { badge in
-                        SettingsOverviewPill(badge: badge)
-                    }
-                }
-                .padding(.vertical, 1)
-            }
-        }
-        .padding(16)
-        .background(Color.appControlInactiveFill, in: RoundedRectangle(cornerRadius: AM.Radius.sheet, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(isPlaying ? "Now playing" : "Playback settings"), \(title), \(subtitle)")
-    }
-
-    private var overviewAnimation: Animation? {
-        reduceMotion ? nil : AppMotion.playful
-    }
-}
-
-private struct SettingsOverviewPill: View {
-    let badge: SettingsOverviewBadge
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: badge.symbol)
-                .font(.caption.bold())
-            Text(badge.title)
-                .font(.caption.bold())
-                .lineLimit(1)
-        }
-        .foregroundStyle(Color.appAccent)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(Color.appAccent.opacity(0.12), in: Capsule())
-    }
-}
-
 private struct SettingsStorageActionRow: View {
     let symbol: String
-    let title: String
-    let detail: String
+    let title: LocalizedStringKey
+    let detail: LocalizedStringKey
     var isDestructive = false
 
     var body: some View {
@@ -792,7 +672,7 @@ private struct SettingsStorageActionRow: View {
 
 private struct StrengthSlider: View {
     @Binding var value: Float
-    var title: String = "Strength"
+    var title: LocalizedStringKey = "Strength"
     var valueDescription: String?
     var step: Float = 0.05
 
@@ -812,11 +692,11 @@ private struct StrengthSlider: View {
         Int((clampedValue * 100).rounded())
     }
 
-    private var accessibilityValueText: String {
+    private var accessibilityValueText: Text {
         if let valueDescription {
-            return "\(valueDescription), \(percent) percent"
+            return Text("\(Text(LocalizedStringKey(valueDescription))), \(percent) percent")
         }
-        return "\(percent) percent"
+        return Text("\(percent) percent")
     }
 
     var body: some View {
@@ -919,7 +799,7 @@ private struct EqualizerBands: View {
                     EqualizerBand(
                         value: bandBinding(i),
                         range: range,
-                        title: "\(frequencyAccessibilityLabel(Double(AVEnginePlayback.bandFrequencies[i]))) Equalizer"
+                        title: "\(Int(AVEnginePlayback.bandFrequencies[i])) Hz Equalizer"
                     )
                     .frame(maxWidth: .infinity)
                     .frame(height: 140)
@@ -975,7 +855,7 @@ private struct EqualizerBands: View {
 private struct EqualizerBand: View {
     @Binding var value: Float
     let range: ClosedRange<Float>
-    var title: String
+    var title: LocalizedStringKey
 
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var lastFeedbackStep: Int?
@@ -1053,7 +933,7 @@ private struct EqualizerBand: View {
         }
         .accessibilityElement()
         .accessibilityLabel(title)
-        .accessibilityValue(valueText)
+        .accessibilityValue(Text("\(Int(clampedValue.rounded())) decibels"))
         .accessibilityHint("Swipe up or down to adjust this band by one decibel.")
         .accessibilityAdjustableAction { direction in
             switch direction {
@@ -1139,17 +1019,13 @@ private enum SettingsDestructiveAction {
 private struct CrossfadeDurationRow: View {
     @Binding var seconds: Double
     private let range: ClosedRange<Double> = 1 ... 15
-    private var displayLabel: String {
-        let s = Int(seconds.rounded())
-        return "\(s) Second\(s == 1 ? "" : "s")"
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Text("Duration")
                 Spacer()
-                Text(displayLabel)
+                Text("\(Int(seconds.rounded())) s")
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
             }
@@ -1178,11 +1054,9 @@ private struct CrossfadeDurationRow: View {
 }
 
 struct NotificationsView: View {
+    @Bindable private var notifications = DownloadNotifications.shared
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @AppStorage("nk.notifications.newSongs") private var notificationsNewSongs = true
-    @AppStorage("nk.notifications.radio") private var notificationsRadio = true
-    @AppStorage("nk.notifications.downloads") private var notificationsDownloads = true
-    @AppStorage("nk.notifications.account") private var notificationsAccount = true
 
     var body: some View {
         Group {
@@ -1200,52 +1074,42 @@ struct NotificationsView: View {
         }
         .navigationTitle("Notifications")
         .navigationBarTitleDisplayMode(.inline)
+        .task { await notifications.refreshAuthorization() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active { Task { await notifications.refreshAuthorization() } }
+        }
+        .alert("Could Not Enable Notifications", isPresented: $notifications.hasError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Please try again.")
+        }
     }
 
     private var notificationsList: some View {
         List {
             Section {
-                NotificationPreferenceToggle(
-                    title: "New Songs",
-                    isOn: $notificationsNewSongs
-                )
-                NotificationPreferenceToggle(
-                    title: "Radio",
-                    isOn: $notificationsRadio
-                )
-                NotificationPreferenceToggle(
-                    title: "Downloads",
-                    isOn: $notificationsDownloads
-                )
-                NotificationPreferenceToggle(
-                    title: "Account",
-                    isOn: $notificationsAccount
-                )
+                Toggle("Download Notifications", isOn: Binding(
+                    get: { notifications.isEnabled },
+                    set: { enabled in
+                        Task { await notifications.setEnabled(enabled) }
+                    }
+                ))
+                .disabled(notifications.isUpdating)
+                .tint(.appAccent)
+                if notifications.permissionDenied {
+                    Button("Open Notification Settings") {
+                        guard let url = URL(string: UIApplication.openNotificationSettingsURLString) else { return }
+                        UIApplication.shared.open(url)
+                    }
+                }
             } footer: {
-                Text("Preferences are saved on this device and use the same account settings style as Music.")
+                Text(LocalizedStringKey(notifications.permissionDenied
+                    ? "Notifications are disabled in system settings. Allow notifications there to receive download updates."
+                    : "Notify when downloads finish while the app is in the background."))
             }
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .groupedScreenBackground()
-    }
-}
-
-private struct NotificationPreferenceToggle: View {
-    let title: String
-    @Binding var isOn: Bool
-
-    var body: some View {
-        Toggle(isOn: $isOn) {
-            Text(title)
-                .font(.body)
-                .foregroundStyle(.primary)
-        }
-        .tint(.appAccent)
-        .accessibilityLabel(title)
-        .accessibilityValue(isOn ? "On" : "Off")
-        .onChange(of: isOn) { _, enabled in
-            enabled ? AppHaptic.selection.play() : AppHaptic.dismiss.play()
-        }
     }
 }

--- a/Twinskaraoke/Features/Account/ShimejiSettingsView.swift
+++ b/Twinskaraoke/Features/Account/ShimejiSettingsView.swift
@@ -102,7 +102,7 @@ struct ShimejiSettingsView: View {
 
     private var spawnCountSection: some View {
         Section {
-            Stepper(value: $spawnSettings.maxCount, in: 0 ... 8) {
+            Stepper(value: $spawnSettings.maxCount, in: ShimejiSpawnSettings.countRange) {
                 HStack {
                     Text("On Screen At Once")
                     Spacer()
@@ -161,14 +161,13 @@ struct ShimejiSettingsView: View {
 
     private func bindingFor(_ character: ShimejiCharacterDefinition) -> Binding<Bool> {
         Binding(
-            get: { spawnSettings.enabledCharacterIDs.contains(character.id) },
+            get: {
+                guard let manifest = resources.manifest else { return false }
+                return spawnSettings.enabledIDs(for: manifest).contains(character.id)
+            },
             set: { isOn in
-                if isOn {
-                    spawnSettings.enabledCharacterIDs.insert(character.id)
-                } else {
-                    spawnSettings.enabledCharacterIDs.remove(character.id)
-                }
-                spawnSettings.hasCustomizedCharacters = true
+                guard let manifest = resources.manifest else { return }
+                spawnSettings.setCharacter(character.id, enabled: isOn, manifest: manifest)
                 AppHaptic.selection.play()
                 persistAndRespawn()
             }

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -2292,6 +2292,14 @@ final class AudioPlayerManager {
                         forceNowPlayingUpdate: true,
                         reason: "startStreamPlayback.cacheFailed"
                     )
+                    // Nothing downstream will release the transition task on
+                    // this path: playback never reaches startPlayingFile, and
+                    // an autoplay handoff has already cleared its token, so
+                    // cancelAutoplayRequest() returns early. Without this the
+                    // task is held until iOS expires it.
+                    #if canImport(UIKit)
+                        endTrackTransitionBackgroundTask()
+                    #endif
                 }
             }
         }

--- a/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
+++ b/Twinskaraoke/Services/Audio/AudioPlayerManager.swift
@@ -82,7 +82,14 @@ final class AudioPlayerManager {
     var routeName: String = ""
     var repeatMode: RepeatMode = .off
     var isShuffled: Bool { queueState.isShuffled }
-    var autoplayEnabled: Bool = true
+    var autoplayEnabled: Bool = UserDefaults.standard.object(forKey: "nk.autoplayEnabled") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(autoplayEnabled, forKey: "nk.autoplayEnabled")
+            if !autoplayEnabled {
+                cancelAutoplayRequest()
+            }
+        }
+    }
     var isRadioMode: Bool = false
     var radioArtworkURL: URL?
     private var isStreamMode: Bool {
@@ -99,6 +106,12 @@ final class AudioPlayerManager {
             UserDefaults.standard.set(aiEnabled, forKey: "nk.aiEnabled")
             DebugLogger.log("AI enabled: \(aiEnabled)", category: .ai)
             if !aiEnabled {
+                cancelBackgroundAnalysisRetry()
+                instrumentalTask?.cancel()
+                instrumentalTask = nil
+                preparedStemTask?.cancel()
+                preparedStemTask = nil
+                separationGeneration &+= 1
                 _suppressModeSwitch = true
                 karaokeMode = false
                 bassEnhanceMode = false
@@ -111,6 +124,9 @@ final class AudioPlayerManager {
                 VocalSeparator.shared.cancelBackgroundAnalysis()
                 VocalSeparator.shared.cleanupRealtimeTemp()
                 if avEngine.mode == .aiStems { avEngine.revertToMain() }
+            } else if aiAutoAnalyze, let song = currentSong, !isRadioMode {
+                triggerBackgroundAnalysis(for: song)
+                prepareBackgroundStemPlaybackIfPossible(for: song)
             }
         }
     }
@@ -128,6 +144,7 @@ final class AudioPlayerManager {
                 prepareBackgroundStemPlaybackIfPossible(for: song)
             }
             if !aiAutoAnalyze {
+                cancelBackgroundAnalysisRetry()
                 preparedStemSongID = nil
                 deferredAIEffect = nil
                 VocalSeparator.shared.cancelBackgroundAnalysis()
@@ -357,7 +374,8 @@ final class AudioPlayerManager {
     private var streamPlaybackRequested = false
     @ObservationIgnored private var remotePlaybackCacheTask: Task<Void, Never>?
     private var remotePlaybackCacheToken: UUID?
-    private var fetchRandomTrendingToken: UUID?
+    private var autoplayRequestToken: UUID?
+    @ObservationIgnored private var autoplayTask: Task<Void, Never>?
     private var cacheRecoverySongID: String?
     // Song IDs already sent through enrichSongMetadataIfNeeded this session;
     // repeat-one loops would otherwise re-issue the search + trending
@@ -1355,6 +1373,7 @@ final class AudioPlayerManager {
         preserveCacheRecoveryState: Bool = false,
         reportsPlayCount: Bool = true
     ) {
+        cancelAutoplayRequest()
         if !preserveCacheRecoveryState {
             cacheRecoverySongID = nil
         }
@@ -1399,6 +1418,9 @@ final class AudioPlayerManager {
         }
         progress = 0
         currentSong = song
+        if UserDefaults.standard.bool(forKey: "nk.downloadOnPlay"), song.audioURL != nil {
+            DownloadManager.shared.download(song: song)
+        }
         warmPlayerArtwork(for: song)
         queueState.replaceContext(context, current: song)
         checkEasterEgg(for: song)
@@ -1608,6 +1630,7 @@ final class AudioPlayerManager {
     /// Returns true when a pause request matched an active or resumable playback path.
     @discardableResult
     private func pauseCurrentPlayback(source: String = #function) -> Bool {
+        cancelAutoplayRequest()
         if !handlingAudioSessionInterruption {
             wasPlayingBeforeInterruption = false
         }
@@ -1911,7 +1934,7 @@ final class AudioPlayerManager {
         case .play(let song):
             play(song: song)
         case .autoplay:
-            fetchRandomTrending()
+            fetchAutoplaySongs()
         case .stop:
             avEngine.pause()
             setPlaybackState(
@@ -2101,6 +2124,7 @@ final class AudioPlayerManager {
     }
 
     func playRadio(streamURL: URL, song: Song, artworkURL: URL?) {
+        cancelAutoplayRequest()
         AppPerformance.event("Radio Playback Request")
         resetEasterEggWork()
         let alreadyOnSameStation = isRadioMode && currentSong?.id == song.id
@@ -2440,6 +2464,10 @@ final class AudioPlayerManager {
         warmedPlayerArtworkAt.removeAll()
         cacheCompressionTask?.cancel()
         remotePlaybackCacheTask?.cancel()
+        remotePlaybackCacheToken = UUID()
+        remotePlaybackCacheTask = nil
+        cancelBackgroundAnalysisRetry()
+        separationGeneration &+= 1
         instrumentalTask?.cancel()
         instrumentalTask = nil
         preparedStemTask?.cancel()
@@ -2450,13 +2478,13 @@ final class AudioPlayerManager {
         VocalSeparator.shared.cancel()
         VocalSeparator.shared.cancelBackgroundAnalysis()
         VocalSeparator.shared.cleanupRealtimeTemp()
-        let fm = FileManager.default
-        if let entries = try? fm.contentsOfDirectory(
-            at: AudioPlayerManager.audioCacheDir, includingPropertiesForKeys: nil
-        ) {
-            for url in entries {
-                try? fm.removeItem(at: url)
-            }
+        // CacheManager removes files once, on its serial maintenance queue.
+        // Keep cancellation and engine mutations on the main actor.
+        temporarilyDisableAIEffects()
+        if avEngine.mode == .aiStems { avEngine.revertToMain() }
+        if !isRadioMode, isBuffering {
+            streamPlaybackRequested = false
+            setPlaybackState(playing: false, buffering: false, reason: "clearCache")
         }
         #if canImport(UIKit)
             AudioPlayerManager.artworkCache.removeAllObjects()
@@ -2470,6 +2498,12 @@ final class AudioPlayerManager {
             return nil
         }
         return immediatelyCachedStems(for: song, sourceURL: localPlaybackFileURL(for: song))
+    }
+
+    func autoDownloadCurrentSongIfEnabled() {
+        guard !isRadioMode, UserDefaults.standard.bool(forKey: "nk.downloadOnPlay"),
+              let song = currentSong, song.audioURL != nil else { return }
+        DownloadManager.shared.download(song: song)
     }
 
     private func triggerBackgroundAnalysis(for song: Song) {
@@ -3212,37 +3246,49 @@ final class AudioPlayerManager {
         }
     }
 
-    private func fetchRandomTrending() {
-        // Staleness fence (same idea as remotePlaybackCacheToken): the fetch
-        // is unstructured, so if the user starts other playback while it is
-        // in flight, the completion must not stomp that playback.
+    private func cancelAutoplayRequest() {
+        guard autoplayRequestToken != nil else { return }
+        autoplayRequestToken = nil
+        autoplayTask?.cancel()
+        autoplayTask = nil
+        setPlaybackState(playing: false, buffering: false, reason: "autoplay.cancelled")
+        #if canImport(UIKit)
+            endTrackTransitionBackgroundTask()
+        #endif
+    }
+
+    private func fetchAutoplaySongs() {
+        cancelAutoplayRequest()
+        guard autoplayEnabled else { return }
+        #if canImport(UIKit)
+            beginTrackTransitionBackgroundTask()
+        #endif
         let fenceSongID = currentSong?.id
         let requestToken = UUID()
-        fetchRandomTrendingToken = requestToken
-        Task {
-            guard let songs = try? await KaraokeAPIClient.trendingSongs(days: 7, take: 50),
-                  let random = songs.randomElement()
-            else {
-                // Only touch state/the background task while this request
-                // still owns the playback flow.
-                guard fetchRandomTrendingToken == requestToken, currentSong?.id == fenceSongID else { return }
-                setPlaybackState(
-                    playing: false,
-                    buffering: false,
-                    reason: "fetchRandomTrending.failed"
-                )
+        autoplayRequestToken = requestToken
+        autoplayTask = Task { [weak self] in
+            var candidates: [Song] = []
+            if CredentialStore.isAuthenticated {
+                candidates = (try? await KaraokeAPIClient.songSuggestions(take: 50)) ?? []
+            }
+            guard !Task.isCancelled else { return }
+            var songs = AutoplaySelection.playableSongs(candidates, excluding: fenceSongID)
+            if songs.isEmpty {
+                candidates = (try? await KaraokeAPIClient.trendingSongs(days: 7, take: 50)) ?? []
+                songs = AutoplaySelection.playableSongs(candidates, excluding: fenceSongID).shuffled()
+            }
+            guard !Task.isCancelled, let self, autoplayEnabled, !isRadioMode,
+                  autoplayRequestToken == requestToken, currentSong?.id == fenceSongID else { return }
+            autoplayRequestToken = nil
+            autoplayTask = nil
+            guard let next = songs.first else {
+                setPlaybackState(playing: false, buffering: false, reason: "autoplay.noSongs")
                 #if canImport(UIKit)
                     endTrackTransitionBackgroundTask()
                 #endif
                 return
             }
-            let rotatedQueue: [Song] = if let index = songs.firstIndex(of: random) {
-                Array(songs[index...]) + Array(songs[..<index])
-            } else {
-                songs
-            }
-            guard fetchRandomTrendingToken == requestToken, currentSong?.id == fenceSongID else { return }
-            play(song: random, context: rotatedQueue)
+            play(song: next, context: songs)
         }
     }
 
@@ -3441,6 +3487,7 @@ final class AudioPlayerManager {
         }
         upcomingSong = nil
         checkEasterEgg(for: song)
+        autoDownloadCurrentSongIfEnabled()
         setPlaybackState(
             playing: true,
             buffering: false,

--- a/Twinskaraoke/Services/Audio/AutoplaySelection.swift
+++ b/Twinskaraoke/Services/Audio/AutoplaySelection.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+nonisolated enum AutoplaySelection {
+    /// Preserve the server's recommendation order while excluding the song
+    /// that just ended, duplicates, and entries without a playable source.
+    static func playableSongs(_ candidates: [Song], excluding songID: String?) -> [Song] {
+        var seen = Set<String>()
+        return candidates.filter {
+            $0.id != songID && $0.audioURL != nil && seen.insert($0.id).inserted
+        }
+    }
+}

--- a/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
+++ b/Twinskaraoke/Services/Audio/TransitionCoordinator.swift
@@ -192,7 +192,7 @@ final class TransitionCoordinator {
                 } else {
                     let result = Self.computeFade(outBPM: outBPM, inBPM: inBPM)
 
-                    fadeDuration = min(result.duration, max(1.0, crossfadeSeconds))
+                    fadeDuration = result.duration
                     rampStyle = result.style
                 }
             } else {

--- a/Twinskaraoke/Services/Shimeji/ShimejiEngine.swift
+++ b/Twinskaraoke/Services/Shimeji/ShimejiEngine.swift
@@ -174,7 +174,7 @@ final class ShimejiEngine: NSObject {
             instances = []
             return
         }
-        let count = min(settings.maxCount, 12)
+        let count = settings.clampedCount
         instances = (0 ..< count).map { _ in
             let character = pool.randomElement()!
             let x = CGFloat.random(in: bounds.minX + spriteHalfWidth ... max(bounds.minX + spriteHalfWidth, bounds.maxX - spriteHalfWidth))
@@ -445,8 +445,10 @@ final class ShimejiEngine: NSObject {
 /// ShimejiSettingsView, persisted to UserDefaults directly (rather than
 /// @AppStorage) since it's an array/struct, not a primitive.
 struct ShimejiSpawnSettings: Codable {
+    static let countRange = 0 ... 8
     var enabledCharacterIDs: Set<String>
     var maxCount: Int
+    var clampedCount: Int { min(Self.countRange.upperBound, max(Self.countRange.lowerBound, maxCount)) }
     /// nil means "never touched the character list" (old data, or first
     /// run) — falls back to every character. Once set, the person's exact
     /// choice is honored, including choosing zero characters via "Use None".
@@ -461,7 +463,9 @@ struct ShimejiSpawnSettings: Codable {
         else {
             return ShimejiSpawnSettings(enabledCharacterIDs: [], maxCount: 3, hasCustomizedCharacters: nil)
         }
-        return decoded
+        var settings = decoded
+        settings.maxCount = settings.clampedCount
+        return settings
     }
 
     func save() {
@@ -478,5 +482,12 @@ struct ShimejiSpawnSettings: Codable {
             return enabledCharacterIDs
         }
         return Set(manifest.characters.map(\.id))
+    }
+
+    mutating func setCharacter(_ id: String, enabled: Bool, manifest: ShimejiManifest) {
+        enabledCharacterIDs = enabledIDs(for: manifest)
+        if enabled { enabledCharacterIDs.insert(id) }
+        else { enabledCharacterIDs.remove(id) }
+        hasCustomizedCharacters = true
     }
 }

--- a/Twinskaraoke/Services/Storage/CacheManager.swift
+++ b/Twinskaraoke/Services/Storage/CacheManager.swift
@@ -161,19 +161,21 @@ final class CacheManager {
         lyricsCacheSize
     }
 
-    func clearImageCache() {
+    func clearImageCache(completion: @escaping @MainActor @Sendable (Bool) -> Void = { _ in }) {
         SDImageCache.shared.clearMemory()
         SDImageCache.shared.clearDisk { [weak self] in
+            let remainingSize = UInt64(SDImageCache.shared.totalDiskSize())
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 FallbackArtProvider.shared.resetBindings()
-                imageCacheSize = 0
+                imageCacheSize = remainingSize
+                completion(remainingSize == 0)
                 DebugLogger.log("Image cache cleared", category: .cache)
             }
         }
     }
 
-    func clearMusicCache() {
+    func clearMusicCache(completion: @escaping @MainActor @Sendable (Bool) -> Void = { _ in }) {
         let dir = AudioPlayerManager.audioCacheDir
         Self.maintenanceQueue.async { [weak self] in
             guard let self else { return }
@@ -188,10 +190,12 @@ final class CacheManager {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 guard let remainingSize else {
+                    completion(false)
                     DebugLogger.log("Could not verify music cache deletion", category: .cache)
                     return
                 }
                 musicCacheSize = remainingSize
+                completion(remainingSize == 0)
                 DebugLogger.log(
                     remainingSize == 0
                         ? "Music cache cleared"
@@ -202,7 +206,7 @@ final class CacheManager {
         }
     }
 
-    func clearLyricsCache() {
+    func clearLyricsCache(completion: @escaping @MainActor @Sendable (Bool) -> Void = { _ in }) {
         Self.maintenanceQueue.async { [weak self] in
             guard let self else { return }
             LyricsCacheStore.clear()
@@ -214,10 +218,12 @@ final class CacheManager {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 guard let remainingSize else {
+                    completion(false)
                     DebugLogger.log("Could not verify lyrics cache deletion", category: .cache)
                     return
                 }
                 lyricsCacheSize = remainingSize
+                completion(remainingSize == 0)
                 DebugLogger.log(
                     remainingSize == 0
                         ? "Lyrics cache cleared"
@@ -585,14 +591,12 @@ final class CacheManager {
         }
     }
 
-    // Deliberately per-call: ByteCountFormatter is not Sendable and not
-    // thread-safe, and this is called from both the maintenance queue and the
-    // main actor. Caching one instance would be a data race, and this is a
-    // cold path (one maintenance pass, eviction logs, Settings size labels).
     private nonisolated func formatBytes(_ bytes: UInt64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useMB, .useGB]
-        formatter.countStyle = .binary
-        return formatter.string(fromByteCount: Int64(bytes))
+        let language = UserDefaults.standard.string(forKey: "nk.language") ?? "system"
+        let locale = language == "system" ? Locale.current : Locale(identifier: language)
+        return Int64(clamping: bytes).formatted(
+            .byteCount(style: .binary, allowedUnits: [.mb, .gb], spellsOutZero: false)
+                .locale(locale)
+        )
     }
 }

--- a/Twinskaraoke/Services/Storage/DownloadManager.swift
+++ b/Twinskaraoke/Services/Storage/DownloadManager.swift
@@ -918,7 +918,7 @@ final class DownloadManager {
         try? fm.removeItem(at: cacheDir.appendingPathComponent("\(storageKey).json"))
     }
 
-    func removeAll() {
+    func removeAll(completion: @escaping @MainActor @Sendable (Bool) -> Void = { _ in }) {
         let fm = FileManager.default
         let deletionDirectory = cacheDir.deletingLastPathComponent().appendingPathComponent(
             "\(Self.pendingDeletionPrefix)\(UUID().uuidString)",
@@ -939,6 +939,7 @@ final class DownloadManager {
                         "Could not remove downloads: staging failed (\(stagingError)); deletion failed (\(deletionError))",
                         category: .network
                     )
+                    completion(false)
                     return
                 }
             }
@@ -973,7 +974,14 @@ final class DownloadManager {
 
         if let stagedDirectory {
             Self.deletionQueue.async {
-                try? FileManager.default.removeItem(at: stagedDirectory)
+                let success: Bool
+                do {
+                    try FileManager.default.removeItem(at: stagedDirectory)
+                    success = true
+                } catch {
+                    success = !FileManager.default.fileExists(atPath: stagedDirectory.path)
+                }
+                Task { @MainActor in completion(success) }
             }
         } else if !fm.fileExists(atPath: cacheDir.path) {
             try? fm.createDirectory(at: cacheDir, withIntermediateDirectories: true)
@@ -983,6 +991,7 @@ final class DownloadManager {
             state.inProgress.removeAll()
         }
         DebugLogger.log("All downloads removed", category: .network)
+        if stagedDirectory == nil { completion(true) }
     }
 
     nonisolated static func isPendingDeletionDirectoryName(_ name: String) -> Bool {
@@ -1020,6 +1029,9 @@ final class DownloadManager {
         if completedInCurrentQueue > 1, failedInCurrentQueue == 0, cancelledInCurrentQueue == 0 {
             AppHaptic.celebrate.play()
         }
+        DownloadNotifications.shared.downloadsFinished(
+            completed: completedInCurrentQueue, failed: failedInCurrentQueue
+        )
         isLoggingDownloadQueue = false
         completedInCurrentQueue = 0
         failedInCurrentQueue = 0

--- a/Twinskaraoke/Services/User/DownloadNotifications.swift
+++ b/Twinskaraoke/Services/User/DownloadNotifications.swift
@@ -1,0 +1,109 @@
+import Observation
+import UIKit
+import UserNotifications
+
+@MainActor
+protocol DownloadNotificationCenter {
+    func authorizationStatus() async -> UNAuthorizationStatus
+    func requestAuthorization() async throws -> Bool
+    func add(_ request: UNNotificationRequest) async throws
+    func clearCompletionNotifications()
+}
+
+@MainActor
+private struct SystemDownloadNotificationCenter: DownloadNotificationCenter {
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+    }
+    func requestAuthorization() async throws -> Bool {
+        try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+    }
+    func add(_ request: UNNotificationRequest) async throws {
+        try await UNUserNotificationCenter.current().add(request)
+    }
+    func clearCompletionNotifications() {
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: [DownloadNotifications.requestID])
+        center.removeDeliveredNotifications(withIdentifiers: [DownloadNotifications.requestID])
+    }
+}
+
+@MainActor
+@Observable
+final class DownloadNotifications {
+    static let shared = DownloadNotifications()
+    // The old notifications.downloads key was an inert, default-on switch.
+    // Require an explicit opt-in to the newly implemented notification feature.
+    static let storageKey = "nk.notifications.downloadCompletion"
+    fileprivate static let requestID = "nk.downloadCompletion"
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let center: any DownloadNotificationCenter
+    private(set) var isEnabled: Bool
+    private(set) var isUpdating = false
+    private(set) var permissionDenied = false
+    var hasError = false
+
+    init(defaults: UserDefaults = .standard, center: (any DownloadNotificationCenter)? = nil) {
+        self.defaults = defaults
+        self.center = center ?? SystemDownloadNotificationCenter()
+        isEnabled = defaults.bool(forKey: Self.storageKey)
+    }
+
+    func refreshAuthorization() async {
+        permissionDenied = await center.authorizationStatus() == .denied
+    }
+
+    func setEnabled(_ enabled: Bool) async {
+        guard !isUpdating else { return }
+        isUpdating = true
+        defer { isUpdating = false }
+        if enabled {
+            do {
+                let allowed = try await center.requestAuthorization()
+                await refreshAuthorization()
+                guard allowed else { return }
+            } catch {
+                hasError = true
+                return
+            }
+        }
+        isEnabled = enabled
+        defaults.set(enabled, forKey: Self.storageKey)
+        if !enabled {
+            center.clearCompletionNotifications()
+        }
+    }
+
+    func downloadsFinished(completed: Int, failed: Int) {
+        guard isEnabled, completed + failed > 0, !AppRuntime.isUITestMode,
+              UIApplication.shared.applicationState != .active else { return }
+        Task { await sendCompletion(completed: completed, failed: failed) }
+    }
+
+    func sendCompletion(completed: Int, failed: Int) async {
+        guard isEnabled, completed + failed > 0 else { return }
+        let content = UNMutableNotificationContent()
+        let language = AppLanguage(rawValue: defaults.string(forKey: AppLanguage.storageKey) ?? "system") ?? .system
+        let locale = Locale(identifier: language.localeIdentifier)
+        // String's locale formats interpolated values; the bundle determines
+        // which translation is loaded outside SwiftUI's locale environment.
+        let bundle = language == .system ? Bundle.main : Bundle.main
+            .path(forResource: language.rawValue, ofType: "lproj")
+            .flatMap(Bundle.init(path:)) ?? .main
+        content.title = String(localized: "Downloads", bundle: bundle, locale: locale)
+        content.body = failed == 0
+            ? String(localized: "Your songs are ready for offline listening.", bundle: bundle, locale: locale)
+            : String(localized: "Some songs could not be downloaded. Open the app to retry.", bundle: bundle, locale: locale)
+        content.sound = .default
+        let request = UNNotificationRequest(identifier: Self.requestID, content: content, trigger: nil)
+        do {
+            try await center.add(request)
+            // An off toggle may have interleaved while add was awaiting.
+            if !isEnabled {
+                center.clearCompletionNotifications()
+            }
+        } catch {
+            DebugLogger.log("Download notification failed: \(error)", category: .network)
+        }
+    }
+}

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -1,6 +1,3840 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Vocal Removal Level" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vocal Removal Level"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Gesangsentfernung"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau de suppression de la voix"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボーカル除去レベル"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laulun poiston voimakkuus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рівень видалення вокалу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人声消除程度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人聲消除程度"
+          }
+        }
+      }
+    },
+    "Bass Enhance Strength" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bass Enhance Strength"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Bassverstärkung"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force du renforcement des basses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音強調の強さ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bassokorostuksen voimakkuus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сила підсилення басів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增强强度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增強強度"
+          }
+        }
+      }
+    },
+    "Vocal Enhance Strength" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vocal Enhance Strength"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Gesangsverstärkung"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force du renforcement de la voix"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボーカル強調の強さ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laulukorostuksen voimakkuus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сила підсилення вокалу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人声增强强度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人聲增強強度"
+          }
+        }
+      }
+    },
+    "Instrumental Enhance Strength" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instrumental Enhance Strength"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Instrumentenverstärkung"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force du renforcement instrumental"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伴奏強調の強さ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Säestyksen korostuksen voimakkuus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сила підсилення інструменталу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伴奏增强强度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伴奏增強強度"
+          }
+        }
+      }
+    },
+    "%@, %lld percent" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld percent"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld Prozent"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld pour cent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@、%lld パーセント"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld prosenttia"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld відсотків"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@，百分之 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@，百分之 %lld"
+          }
+        }
+      }
+    },
+    "Autoplay" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoplay"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatische Wiedergabe"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture automatique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動再生"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automaattinen toisto"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автовідтворення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动播放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動播放"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "System" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Système"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Järjestelmä"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟随系统"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟隨系統"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Light" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leicht"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Léger"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弱"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kevyt"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Легка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輕"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Dark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dunkel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダーク"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tumma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Темна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Medium" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medium"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mittel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moyen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keskitaso"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Середня"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Strong" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strong"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stark"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fort"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voimakas"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сильна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Heavy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heavy"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sehr stark"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Très fort"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非常に強い"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erittäin voimakas"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дуже сильна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "很强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "很強"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Maximum" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suurin"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимум"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Almost off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almost off"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fast aus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presque désactivé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ほぼオフ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lähes pois"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Майже вимкнено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "几乎关闭"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "幾乎關閉"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Nwero" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Could Not Clear Storage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could Not Clear Storage"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicher konnte nicht geleert werden"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de vider le stockage"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストレージを消去できませんでした"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallennustilaa ei voitu tyhjentää"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося очистити сховище"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法清理存储"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法清理儲存空間"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Could Not Enable Notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could Not Enable Notifications"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitteilungen konnten nicht aktiviert werden"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’activer les notifications"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知を有効にできませんでした"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ilmoituksia ei voitu ottaa käyttöön"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося ввімкнути сповіщення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法启用通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法啟用通知"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Download Notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download Notifications"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download-Mitteilungen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications de téléchargement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード通知"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latausilmoitukset"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сповіщення про завантаження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載通知"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Open Notification Settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Notification Settings"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitteilungseinstellungen öffnen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir les réglages des notifications"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知設定を開く"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avaa ilmoitusasetukset"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відкрити налаштування сповіщень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开通知设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟通知設定"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Please try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please try again."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitte erneut versuchen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veuillez réessayer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "もう一度お試しください。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yritä uudelleen."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спробуйте ще раз."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請重試。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Some files could not be removed. Please try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some files could not be removed. Please try again."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einige Dateien konnten nicht entfernt werden. Bitte erneut versuchen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certains fichiers n’ont pas pu être supprimés. Veuillez réessayer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のファイルを削除できませんでした。もう一度お試しください。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Joitakin tiedostoja ei voitu poistaa. Yritä uudelleen."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Деякі файли не вдалося видалити. Спробуйте ще раз."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分文件无法移除。请重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分檔案無法移除。請重試。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Image Cache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image Cache"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildcache"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache d’images"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像キャッシュ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kuvavälimuisti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кеш зображень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖片快取"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Music Cache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Music Cache"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musikcache"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache musical"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音楽キャッシュ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musiikkivälimuisti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кеш музики"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音乐缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音樂快取"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Lyrics Cache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyrics Cache"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liedtextcache"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache des paroles"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞キャッシュ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sanoitusvälimuisti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кеш текстів пісень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌词缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞快取"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear image cache?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear image cache?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildcache leeren?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache d’images ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像キャッシュを消去しますか？"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö kuvavälimuisti?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш зображень?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除图片缓存？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除圖片快取？"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear music cache?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear music cache?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musikcache leeren?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache musical ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音楽キャッシュを消去しますか？"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö musiikkivälimuisti?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш музики?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音乐缓存？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音樂快取？"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear lyrics cache?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear lyrics cache?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liedtextcache leeren?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache des paroles ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞キャッシュを消去しますか？"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö sanoitusvälimuisti?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш текстів пісень?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌词缓存？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌詞快取？"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear recently played history?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear recently played history?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabeverlauf löschen?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer l’historique d’écoute ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生履歴を消去しますか？"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö kuunteluhistoria?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити історію прослуховувань?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放记录？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放記錄？"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Remove All Downloads" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove All Downloads"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Downloads entfernen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer tous les téléchargements"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのダウンロードを削除"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poista kaikki lataukset"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити всі завантаження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所有下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所有下載"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear Image Cache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Image Cache"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildcache leeren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache d’images"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像キャッシュを消去"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä kuvavälimuisti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш зображень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除图片缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除圖片快取"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear Music Cache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Music Cache"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musikcache leeren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache musical"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音楽キャッシュを消去"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä musiikkivälimuisti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш музики"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音乐缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音樂快取"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear Lyrics Cache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Lyrics Cache"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liedtextcache leeren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache des paroles"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞キャッシュを消去"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä sanoitusvälimuisti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш текстів пісень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌词缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌詞快取"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Clear Recently Played" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Recently Played"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabeverlauf löschen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer l’historique d’écoute"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生履歴を消去"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä kuunteluhistoria"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити історію прослуховувань"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放記錄"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Offline songs on this device" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline songs on this device"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Songs auf diesem Gerät"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titres hors ligne sur cet appareil"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスのオフライン曲"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tämän laitteen offline-kappaleet"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн-пісні на цьому пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的离线歌曲"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此裝置上的離線歌曲"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Listening history on this device" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listening history on this device"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabeverlauf auf diesem Gerät"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historique d’écoute sur cet appareil"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスの再生履歴"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tämän laitteen kuunteluhistoria"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Історія прослуховувань на цьому пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的播放记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此裝置上的播放記錄"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Flat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flat"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neutral"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neutre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フラット"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tasainen"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рівна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平直"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平直"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Bass Boost" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bass Boost"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bassverstärkung"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basses renforcées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音強調"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bassokorostus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підсилення басів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增強"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Treble Boost" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Treble Boost"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Höhenverstärkung"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aigus renforcés"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高音強調"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diskanttikorostus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підсилення високих частот"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高音增强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高音增強"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Vocal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vocal"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesang"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voix"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボーカル"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laulu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вокал"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人声"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人聲"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Rock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロック"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рок"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摇滚"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搖滾"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Pop" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ポップ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поп"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流行"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Jazz" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジャズ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Джаз"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "爵士"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "爵士"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Electronic" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Electronic"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elektronisch"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Électronique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エレクトロニック"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elektroninen"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Електронна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电子"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電子"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Classical" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classical"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassik"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クラシック"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassinen"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Класична"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "古典"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "古典"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Hip-Hop" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-Hop"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-Hop"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-hop"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヒップホップ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-hop"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хіп-хоп"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "嘻哈"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "嘻哈"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Loudness" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loudness"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loudness"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correction physiologique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラウドネス"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loudness"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тонкомпенсація"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "响度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "響度"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Custom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefiniert"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mukautettu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Власна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "%lld s" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld с"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "%lld Hz Equalizer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz Equalizer"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld-Hz-Equalizer"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Égaliseur %lld Hz"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz イコライザ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz:n taajuuskorjain"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Еквалайзер %lld Гц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz 均衡器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz 等化器"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "%lld decibels" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld decibels"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Dezibel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld décibels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld デシベル"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld desibeliä"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld децибел"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 分贝"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 分貝"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    ", %lld percent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", %lld percent"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", %lld Prozent"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", %lld pour cent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "、%lld パーセント"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", %lld prosenttia"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", %lld відсотків"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "，百分之 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "，百分之 %lld"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose. Autoplay continues with account recommendations, or trending songs when recommendations are unavailable. These features do not apply to radio." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose. Autoplay continues with account recommendations, or trending songs when recommendations are unavailable. These features do not apply to radio."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix mischt passende Songs automatisch. Crossfade nutzt die gewählte Dauer. Autoplay spielt Kontoempfehlungen oder beliebte Songs weiter. Diese Funktionen gelten nicht für Radio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix mélange automatiquement les titres compatibles. Le fondu enchaîné utilise la durée choisie. La lecture automatique poursuit avec vos recommandations, ou des titres populaires à défaut. Ces fonctions ne s’appliquent pas à la radio."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mixは相性のよい曲を自動でミックスします。クロスフェードは指定した長さで切り替えます。自動再生はアカウントのおすすめ曲、取得できない場合は人気曲を再生します。ラジオには適用されません。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix yhdistää yhteensopivat kappaleet automaattisesti. Ristiinhäivytys käyttää valittua kestoa. Automaattinen toisto jatkuu tilin suosituksilla tai suosituilla kappaleilla, jos suosituksia ei ole. Toiminnot eivät koske radiota."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix автоматично змішує сумісні пісні. Перехресне згасання використовує вибрану тривалість. Автовідтворення продовжує рекомендованими для облікового запису або популярними піснями. Ці функції не застосовуються до радіо."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动混音会混合适合的歌曲。交叉淡化使用所选时长。自动播放会继续播放账号推荐歌曲；无法获取推荐时则播放热门歌曲。这些功能不适用于电台。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動混音會混合適合的歌曲。交叉淡化使用所選時長。自動播放會繼續播放帳號推薦歌曲；無法取得推薦時則播放熱門歌曲。這些功能不適用於電台。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "When enabled, the current song and songs you play next are saved for offline listening. This may use cellular data. Turning this off leaves existing downloads and downloads already in progress intact." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When enabled, the current song and songs you play next are saved for offline listening. This may use cellular data. Turning this off leaves existing downloads and downloads already in progress intact."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichert den aktuellen Song und danach gespielte Songs zum Offline-Hören. Dabei können mobile Daten verwendet werden. Ausschalten behält vorhandene und bereits laufende Downloads bei."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistre le titre actuel et les suivants pour une écoute hors ligne. Cela peut utiliser les données mobiles. La désactivation conserve les téléchargements existants et ceux en cours."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効にすると、現在の曲と次に再生する曲をオフライン用に保存します。モバイルデータを使用する場合があります。無効にしても、保存済みや進行中のダウンロードはそのまま残ります。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallentaa nykyisen ja seuraavaksi toistettavat kappaleet offline-kuuntelua varten. Tämä voi käyttää mobiilidataa. Pois kytkeminen säilyttää valmiit ja käynnissä olevat lataukset."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зберігає поточну й наступні пісні для офлайн-прослуховування. Можливе використання мобільних даних. Вимкнення зберігає наявні й уже розпочаті завантаження."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后会保存当前及之后播放的歌曲，供离线收听。这可能使用蜂窝数据。关闭不会移除已有下载或取消正在进行的下载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後會儲存目前及之後播放的歌曲，供離線聆聽。這可能使用行動數據。關閉不會移除已有下載或取消正在進行的下載。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "10-band parametric EQ. Drag each band between -12 dB and +12 dB. Equalizer and AI audio effects apply to songs, not radio." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-band parametric EQ. Drag each band between -12 dB and +12 dB. Equalizer and AI audio effects apply to songs, not radio."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parametrischer 10-Band-EQ. Jedes Band ist von −12 bis +12 dB einstellbar. Equalizer und KI-Audioeffekte gelten für Songs, nicht für Radio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Égaliseur paramétrique à 10 bandes, réglables de −12 à +12 dB. L’égaliseur et les effets audio IA s’appliquent aux titres, pas à la radio."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10バンドのパラメトリックEQ。各バンドを−12〜+12 dBで調整できます。イコライザとAIエフェクトは曲に適用され、ラジオには適用されません。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-kaistainen parametrinen taajuuskorjain. Säädä kaistoja välillä −12 ja +12 dB. Taajuuskorjain ja tekoälytehosteet koskevat kappaleita, eivät radiota."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-смуговий параметричний еквалайзер. Кожна смуга регулюється від −12 до +12 дБ. Еквалайзер та ШІ-ефекти застосовуються до пісень, але не до радіо."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 段参数均衡器，每段可在 −12 至 +12 dB 之间调节。均衡器和 AI 音频效果适用于歌曲，不适用于电台。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 段參數等化器，每段可在 −12 至 +12 dB 之間調節。等化器和 AI 音訊效果適用於歌曲，不適用於電台。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 64 MB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 64 MB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe auf eine Anzeige, um den Cache zu leeren. Limits: Bilder 2 GB, Musik einschließlich KI-Spuren 4 GB, Liedtexte 64 MB. Einträge über 6 Monate werden automatisch entfernt. Downloads sind ausgenommen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touchez un indicateur pour vider le cache. Limites : images 2 Go, musique avec pistes IA 4 Go, paroles 64 Mo. Les éléments de plus de 6 mois sont supprimés automatiquement. Les téléchargements sont exclus."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目をタップするとキャッシュを消去します。上限は画像2 GB、AI分離音源を含む音楽4 GB、歌詞64 MBです。6か月を超えた項目は自動削除されます。ダウンロードは対象外です。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä välimuisti napauttamalla sen riviä. Rajat: kuvat 2 Gt, musiikki ja tekoälyraidat 4 Gt, sanoitukset 64 Mt. Yli 6 kuukauden ikäiset kohteet poistetaan automaattisesti. Rajat eivät koske latauksia."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Торкніться показника, щоб очистити кеш. Ліміти: зображення — 2 ГБ, музика зі ШІ-доріжками — 4 ГБ, тексти — 64 МБ. Дані старші за 6 місяців видаляються автоматично. Завантаження не обмежуються цими лімітами."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点按项目可清除相应缓存。图片缓存上限为 2 GB，音乐缓存（包括 AI 分离音轨）为 4 GB，歌词缓存为 64 MB。超过 6 个月的项目会自动清理。离线下载不受这些限制。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按項目可清除相應快取。圖片快取上限為 2 GB，音樂快取（包括 AI 分離音軌）為 4 GB，歌詞快取為 64 MB。超過 6 個月的項目會自動清理。離線下載不受這些限制。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "All offline downloads on this device will be removed." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All offline downloads on this device will be removed."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Offline-Downloads auf diesem Gerät werden entfernt."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les téléchargements hors ligne de cet appareil seront supprimés."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスのオフラインダウンロードをすべて削除します。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaikki tämän laitteen offline-lataukset poistetaan."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Усі офлайн-завантаження на цьому пристрої буде видалено."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除此设备上的所有离线下载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除此裝置上的所有離線下載。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Cached artwork and images will be removed. They will download again as you use the app." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached artwork and images will be removed. They will download again as you use the app."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Bilder werden entfernt und bei Bedarf erneut geladen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les illustrations et images en cache seront supprimées puis téléchargées à nouveau au besoin."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュされた画像を削除します。アプリの使用時に必要に応じて再ダウンロードされます。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välimuistin kuvat poistetaan. Ne ladataan tarvittaessa uudelleen."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кешовані зображення буде видалено. Вони завантажаться знову під час використання застосунку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除缓存的封面和图片，使用应用时会重新下载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除快取的封面和圖片，使用 App 時會重新下載。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Cached audio files and AI stems will be removed. Songs may buffer again the next time you play them." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached audio files and AI stems will be removed. Songs may buffer again the next time you play them."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Audiodateien und KI-Spuren werden entfernt. Songs müssen beim nächsten Abspielen eventuell erneut laden."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les fichiers audio et pistes IA en cache seront supprimés. Les titres pourront nécessiter un chargement à la prochaine écoute."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュされた音声とAI分離音源を削除します。次回再生時に読み込みが必要になる場合があります。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välimuistin ääni ja tekoälyraidat poistetaan. Seuraava toisto voi vaatia puskurointia."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кешовані аудіофайли та ШІ-доріжки буде видалено. Під час наступного відтворення може знадобитися буферизація."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除缓存的音频文件和 AI 分离音轨。下次播放时可能需要重新缓冲。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除快取的音訊檔案和 AI 分離音軌。下次播放時可能需要重新緩衝。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Cached lyrics and lyric translations will be removed." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached lyrics and lyric translations will be removed."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Liedtexte und Übersetzungen werden entfernt."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les paroles et leurs traductions en cache seront supprimées."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュされた歌詞と翻訳を削除します。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välimuistin sanoitukset ja käännökset poistetaan."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кешовані тексти пісень та переклади буде видалено."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除缓存的歌词和歌词翻译。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除快取的歌詞和歌詞翻譯。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Your recently played history will be removed from this device." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your recently played history will be removed from this device."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Wiedergabeverlauf wird von diesem Gerät entfernt."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre historique d’écoute sera supprimé de cet appareil."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスの再生履歴を削除します。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kuunteluhistoria poistetaan tältä laitteelta."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Історію прослуховувань буде видалено з цього пристрою."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将从此设备移除最近播放记录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將從此裝置移除最近播放記錄。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Notify when downloads finish while the app is in the background." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notify when downloads finish while the app is in the background."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benachrichtigt, wenn Downloads abgeschlossen sind und die App im Hintergrund ist."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recevoir une notification à la fin des téléchargements lorsque l’app est en arrière-plan."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリがバックグラウンドのときにダウンロード完了を通知します。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ilmoita latausten valmistumisesta sovelluksen ollessa taustalla."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сповіщати про завершення завантажень, коли застосунок у фоні."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用在后台时，下载完成后发送通知。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App 在背景執行時，下載完成後傳送通知。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Notifications are disabled in system settings. Allow notifications there to receive download updates." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications are disabled in system settings. Allow notifications there to receive download updates."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitteilungen sind in den Systemeinstellungen deaktiviert. Aktiviere sie dort für Download-Mitteilungen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les notifications sont désactivées dans les réglages système. Autorisez-les pour recevoir les mises à jour des téléchargements."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム設定で通知が無効になっています。ダウンロード通知を受け取るには、そこで通知を許可してください。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ilmoitukset on poistettu käytöstä järjestelmäasetuksissa. Salli ne saadaksesi latausilmoituksia."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сповіщення вимкнено в системних налаштуваннях. Дозвольте їх, щоб отримувати сповіщення про завантаження."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统设置中已禁用通知。请在其中允许通知，以接收下载更新。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統設定中已停用通知。請在其中允許通知，以接收下載更新。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Your songs are ready for offline listening." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your songs are ready for offline listening."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Songs sind zum Offline-Hören bereit."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos titres sont prêts pour une écoute hors ligne."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "曲をオフラインで再生できるようになりました。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kappaleesi ovat valmiina offline-kuunteluun."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваші пісні готові до офлайн-прослуховування."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌曲已可供离线收听。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌曲已可供離線聆聽。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Some songs could not be downloaded. Open the app to retry." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some songs could not be downloaded. Open the app to retry."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einige Songs konnten nicht geladen werden. Öffne die App, um es erneut zu versuchen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certains titres n’ont pas pu être téléchargés. Ouvrez l’app pour réessayer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部の曲をダウンロードできませんでした。アプリを開いて再試行してください。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Joitakin kappaleita ei voitu ladata. Avaa sovellus ja yritä uudelleen."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Деякі пісні не вдалося завантажити. Відкрийте застосунок і спробуйте знову."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分歌曲无法下载。请打开应用重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分歌曲無法下載。請開啟 App 重試。"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Theme.system" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Système"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Järjestelmä"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟随系统"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟隨系統"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Theme.light" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hell"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clair"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライト"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaalea"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Світла"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浅色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "淺色"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Theme.dark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dunkel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダーク"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tumma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Темна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "Theme.nwero" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "%@ / 2 GB" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "%@ / 4 GB" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
+    "%@ / 64 MB" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        }
+      },
+      "generatesSymbol" : false
+    },
     "%lld minutes" : {
       "localizations" : {
         "de" : { "stringUnit" : { "state" : "translated", "value" : "%lld Minuten" } },
@@ -209,11 +4043,55 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ ready — %2$lld characters"
+            "state" : "translated",
+            "value" : "%@ ready — %lld characters"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ bereit — %lld Figuren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ prêt — %lld personnages"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 準備完了 — %lld キャラクター"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ valmis — %lld hahmoa"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ готовий — %lld персонажів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已就绪 — %lld 个角色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已就緒 — %lld 個角色"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "%@ views" : {
 
@@ -693,12 +4571,12 @@
       }
     },
     "%lld percent" : {
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld percent"
+            "value" : "%lld Prozent"
           }
         },
         "en" : {
@@ -710,40 +4588,41 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld percent"
+            "value" : "%lld prosenttia"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld percent"
+            "value" : "%lld pour cent"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld percent"
+            "value" : "%lld パーセント"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld percent"
+            "value" : "%lld відсотків"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 百分之"
+            "value" : "百分之 %lld"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 百分之"
+            "value" : "百分之 %lld"
           }
         }
-      }
+      },
+      "generatesSymbol" : false
     },
     "%lld playlists" : {
       "localizations" : {
@@ -2361,7 +6240,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio"
+            "value" : "KI-Audio"
           }
         },
         "en" : {
@@ -2373,25 +6252,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio"
+            "value" : "Tekoälyääni"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio"
+            "value" : "Audio IA"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio"
+            "value" : "AIオーディオ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio"
+            "value" : "ШІ-аудіо"
           }
         },
         "zh-Hans" : {
@@ -2406,14 +6285,16 @@
             "value" : "AI 音訊"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "AI Audio Processing" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio Processing"
+            "value" : "KI-Audioverarbeitung"
           }
         },
         "en" : {
@@ -2425,25 +6306,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio Processing"
+            "value" : "Tekoälyäänenkäsittely"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio Processing"
+            "value" : "Traitement audio IA"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio Processing"
+            "value" : "AIオーディオ処理"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI Audio Processing"
+            "value" : "Обробка аудіо ШІ"
           }
         },
         "zh-Hans" : {
@@ -2458,7 +6339,9 @@
             "value" : "AI 音訊處理"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "AirPlay" : {
       "localizations" : {
@@ -2627,7 +6510,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Always Trigger"
+            "value" : "Immer auslösen"
           }
         },
         "en" : {
@@ -2639,25 +6522,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Always Trigger"
+            "value" : "Aktivoi aina"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Always Trigger"
+            "value" : "Toujours déclencher"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Always Trigger"
+            "value" : "常に発動"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Always Trigger"
+            "value" : "Завжди активувати"
           }
         },
         "zh-Hans" : {
@@ -2669,17 +6552,19 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "始終觸發"
+            "value" : "一律觸發"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Animated lyrics and transitions follow your motion preference." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Animated lyrics and transitions follow your motion preference."
+            "value" : "Animierte Liedtexte und Übergänge folgen deiner Bewegungseinstellung."
           }
         },
         "en" : {
@@ -2691,40 +6576,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Animated lyrics and transitions follow your motion preference."
+            "value" : "Animoidut sanoitukset ja siirtymät noudattavat liikeasetustasi."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Animated lyrics and transitions follow your motion preference."
+            "value" : "Les paroles animées et transitions respectent votre préférence de mouvement."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Animated lyrics and transitions follow your motion preference."
+            "value" : "歌詞のアニメーションと画面切り替えが動きの設定に従います。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Animated lyrics and transitions follow your motion preference."
+            "value" : "Анімовані тексти й переходи враховують ваші налаштування руху."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "动态歌词和过渡效果会根据您的动态效果偏好进行调整。"
+            "value" : "动态歌词和过渡动画会遵循你的动态效果偏好。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "動態歌詞和過場效果會配合您的動態效果偏好。"
+            "value" : "動態歌詞和過場動畫會遵循你的動態效果偏好。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Anyone can find it" : {
 
@@ -2737,7 +6624,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Appearance"
+            "value" : "Darstellung"
           }
         },
         "en" : {
@@ -2749,25 +6636,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Appearance"
+            "value" : "Ulkoasu"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Appearance"
+            "value" : "Apparence"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Appearance"
+            "value" : "外観"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Appearance"
+            "value" : "Вигляд"
           }
         },
         "zh-Hans" : {
@@ -2782,7 +6669,9 @@
             "value" : "外觀"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Approving signs in %@ on the device showing this QR code." : {
       "localizations" : {
@@ -3067,7 +6956,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio"
+            "value" : "Ääni"
           }
         },
         "fr" : {
@@ -3079,13 +6968,13 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio"
+            "value" : "オーディオ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio"
+            "value" : "Аудіо"
           }
         },
         "zh-Hans" : {
@@ -3100,17 +6989,70 @@
             "value" : "音訊"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Audio Effects" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Effects"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audioeffekte"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effets audio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オーディオエフェクト"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Äänitehosteet"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аудіоефекти"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音频效果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音訊效果"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Audio effects use on-device AI to separate vocals and instrumentals in real time. For best results, use headphones or external speakers." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio effects use on-device AI to separate vocals and instrumentals in real time. For best results, use headphones or external speakers."
+            "value" : "Audioeffekte trennen Gesang und Instrumente mit KI auf dem Gerät in Echtzeit. Verwende für beste Ergebnisse Kopfhörer oder externe Lautsprecher."
           }
         },
         "en" : {
@@ -3122,40 +7064,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio effects use on-device AI to separate vocals and instrumentals in real time. For best results, use headphones or external speakers."
+            "value" : "Äänitehosteet erottelevat laulun ja säestyksen laitteen tekoälyllä reaaliajassa. Käytä kuulokkeita tai ulkoisia kaiuttimia parhaan tuloksen saamiseksi."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio effects use on-device AI to separate vocals and instrumentals in real time. For best results, use headphones or external speakers."
+            "value" : "Les effets audio utilisent l’IA sur l’appareil pour séparer voix et instruments en temps réel. Utilisez un casque ou des enceintes externes pour de meilleurs résultats."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio effects use on-device AI to separate vocals and instrumentals in real time. For best results, use headphones or external speakers."
+            "value" : "デバイス上のAIがボーカルと伴奏をリアルタイムで分離します。ヘッドフォンや外部スピーカーの使用をおすすめします。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audio effects use on-device AI to separate vocals and instrumentals in real time. For best results, use headphones or external speakers."
+            "value" : "Аудіоефекти використовують ШІ на пристрої для відокремлення вокалу й інструментів у реальному часі. Для найкращого результату використовуйте навушники або зовнішні динаміки."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "音频效果利用端侧 AI 实时分离人声与伴奏。为了获得最佳效果，请使用耳机或外接扬声器"
+            "value" : "音频效果使用设备端 AI 实时分离人声和伴奏。建议使用耳机或外接扬声器以获得最佳效果。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "音訊效果利用裝置端 AI 即時分離人聲與伴奏。為達最佳效果，請使用耳機或外接揚聲器"
+            "value" : "音訊效果使用裝置端 AI 即時分離人聲和伴奏。建議使用耳機或外接揚聲器以獲得最佳效果。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Audio Quality" : {
       "localizations" : {
@@ -3318,7 +7262,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Analyze During Playback"
+            "value" : "Während der Wiedergabe automatisch analysieren"
           }
         },
         "en" : {
@@ -3330,25 +7274,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Analyze During Playback"
+            "value" : "Analysoi automaattisesti toiston aikana"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Analyze During Playback"
+            "value" : "Analyser automatiquement pendant la lecture"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Analyze During Playback"
+            "value" : "再生中に自動解析"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Analyze During Playback"
+            "value" : "Автоаналіз під час відтворення"
           }
         },
         "zh-Hans" : {
@@ -3363,14 +7307,16 @@
             "value" : "播放時自動分析"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Auto-Download Played Songs" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Download Played Songs"
+            "value" : "Gespielte Songs automatisch herunterladen"
           }
         },
         "en" : {
@@ -3382,40 +7328,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Download Played Songs"
+            "value" : "Lataa toistetut kappaleet automaattisesti"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Download Played Songs"
+            "value" : "Télécharger automatiquement les titres écoutés"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Download Played Songs"
+            "value" : "再生した曲を自動ダウンロード"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Auto-Download Played Songs"
+            "value" : "Автоматично завантажувати відтворені пісні"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动下载听过的歌"
+            "value" : "自动下载播放的歌曲"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自動下載聽過的歌"
+            "value" : "自動下載播放的歌曲"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Autoplay Similar Songs" : {
       "localizations" : {
@@ -3474,7 +7422,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Available after background processing finishes for the current song."
+            "value" : "Verfügbar, sobald die Hintergrundverarbeitung des aktuellen Songs abgeschlossen ist."
           }
         },
         "en" : {
@@ -3486,40 +7434,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Available after background processing finishes for the current song."
+            "value" : "Käytettävissä, kun nykyisen kappaleen taustakäsittely valmistuu."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Available after background processing finishes for the current song."
+            "value" : "Disponible une fois le traitement en arrière-plan du titre actuel terminé."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Available after background processing finishes for the current song."
+            "value" : "現在の曲のバックグラウンド処理が完了すると使用できます。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Available after background processing finishes for the current song."
+            "value" : "Доступно після завершення фонової обробки поточної пісні."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当前歌曲的后台处理完成后可用。"
+            "value" : "当前歌曲的后台处理完成后即可使用。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "目前歌曲的背景處理完成後可用。"
+            "value" : "目前歌曲的背景處理完成後即可使用。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Badges" : {
       "localizations" : {
@@ -3630,7 +7580,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bass Enhance"
+            "value" : "Bass verstärken"
           }
         },
         "en" : {
@@ -3642,25 +7592,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bass Enhance"
+            "value" : "Korosta bassoa"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bass Enhance"
+            "value" : "Renforcer les basses"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bass Enhance"
+            "value" : "低音を強調"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bass Enhance"
+            "value" : "Підсилення басів"
           }
         },
         "zh-Hans" : {
@@ -3675,10 +7625,63 @@
             "value" : "低音增強"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Behavior" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Behavior"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verhalten"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comportement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動作"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toiminta"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поведінка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行为"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行為"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Best New Songs" : {
 
@@ -3899,7 +7902,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancel"
+            "value" : "Abbrechen"
           }
         },
         "en" : {
@@ -3911,25 +7914,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancel"
+            "value" : "Peruuta"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancel"
+            "value" : "Annuler"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancel"
+            "value" : "キャンセル"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancel"
+            "value" : "Скасувати"
           }
         },
         "zh-Hans" : {
@@ -3944,7 +7947,9 @@
             "value" : "取消"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Cancel Download" : {
       "localizations" : {
@@ -4003,7 +8008,59 @@
     },
     "Characters" : {
       "comment" : "A section of the settings view that lists the characters that can spawn.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Characters"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Figuren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnages"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャラクター"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hahmot"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Персонажі"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角色"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Check this code matches the one on your phone before approving." : {
 
@@ -4117,7 +8174,59 @@
     },
     "Choose which characters can spawn. They walk, climb, sit on the tab bar, and can be dragged around the screen." : {
       "comment" : "A footer for the characters section of the Shimeji settings.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose which characters can spawn. They walk, climb, sit on the tab bar, and can be dragged around the screen."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle die Figuren, die erscheinen dürfen. Sie laufen, klettern, sitzen auf der Tableiste und lassen sich über den Bildschirm ziehen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez les personnages autorisés. Ils marchent, grimpent, s’assoient sur la barre d’onglets et peuvent être déplacés sur l’écran."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出現するキャラクターを選びます。歩いたり登ったり、タブバーに座ったりします。ドラッグして移動することもできます。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valitse ilmestyvät hahmot. Ne kävelevät, kiipeävät, istuvat välilehtipalkilla ja niitä voi vetää näytöllä."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть персонажів, які можуть з’являтися. Вони ходять, лазять, сидять на панелі вкладок, і їх можна перетягувати екраном."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择可以生成的角色。它们会行走、攀爬、坐在标签栏上，也可以在屏幕上拖动。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇可以產生的角色。它們會行走、攀爬、坐在標籤列上，也可以在螢幕上拖動。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Clear" : {
       "localizations" : {
@@ -4337,11 +8446,114 @@
       }
     },
     "Climbing" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Climbing"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klettern"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escalade"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登る"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kiipeily"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Лазіння"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "攀爬"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "攀爬"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Climbing lets them scale the screen edges instead of just turning around." : {
       "comment" : "A description of the climbing behavior of Shimeji.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Climbing lets them scale the screen edges instead of just turning around."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt Figuren, an den Bildschirmrändern hochzuklettern."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permet aux personnages de grimper sur les bords de l’écran."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャラクターが画面の端を登れるようにします。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antaa hahmojen kiivetä näytön reunoja pitkin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дозволяє персонажам видиратися краями екрана."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许角色沿屏幕边缘攀爬。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許角色沿螢幕邊緣攀爬。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Close" : {
       "localizations" : {
@@ -5191,7 +9403,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Crossfade Duration"
+            "value" : "Crossfade-Dauer"
           }
         },
         "en" : {
@@ -5203,40 +9415,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Crossfade Duration"
+            "value" : "Ristiinhäivytyksen kesto"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Crossfade Duration"
+            "value" : "Durée du fondu enchaîné"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Crossfade Duration"
+            "value" : "クロスフェードの長さ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Crossfade Duration"
+            "value" : "Тривалість перехресного згасання"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "交叉淡化时间"
+            "value" : "交叉淡化时长"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "交叉淡化時間"
+            "value" : "交叉淡化時長"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Current song" : {
       "extractionState" : "stale",
@@ -5317,7 +9531,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Debug Logging"
+            "value" : "Debug-Protokollierung"
           }
         },
         "en" : {
@@ -5329,25 +9543,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Debug Logging"
+            "value" : "Virheenkorjausloki"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Debug Logging"
+            "value" : "Journalisation de débogage"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Debug Logging"
+            "value" : "デバッグログ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Debug Logging"
+            "value" : "Журнал налагодження"
           }
         },
         "zh-Hans" : {
@@ -5359,10 +9573,12 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Debug 日誌"
+            "value" : "偵錯日誌"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Delete %lld Selected Songs" : {
 
@@ -5381,7 +9597,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Developer"
+            "value" : "Entwickler"
           }
         },
         "en" : {
@@ -5393,25 +9609,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Developer"
+            "value" : "Kehittäjä"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Developer"
+            "value" : "Développeur"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Developer"
+            "value" : "開発者"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Developer"
+            "value" : "Розробник"
           }
         },
         "zh-Hans" : {
@@ -5426,14 +9642,16 @@
             "value" : "開發者"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Disable Developer Mode" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable Developer Mode"
+            "value" : "Entwicklermodus deaktivieren"
           }
         },
         "en" : {
@@ -5445,47 +9663,49 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable Developer Mode"
+            "value" : "Poista kehittäjätila käytöstä"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable Developer Mode"
+            "value" : "Désactiver le mode développeur"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable Developer Mode"
+            "value" : "開発者モードを無効にする"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable Developer Mode"
+            "value" : "Вимкнути режим розробника"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭开发者模式"
+            "value" : "禁用开发者模式"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "關閉開發者模式"
+            "value" : "停用開發者模式"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Disable developer mode?" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable developer mode?"
+            "value" : "Entwicklermodus deaktivieren?"
           }
         },
         "en" : {
@@ -5497,40 +9717,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable developer mode?"
+            "value" : "Poistetaanko kehittäjätila käytöstä?"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable developer mode?"
+            "value" : "Désactiver le mode développeur ?"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable developer mode?"
+            "value" : "開発者モードを無効にしますか？"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disable developer mode?"
+            "value" : "Вимкнути режим розробника?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "确定关闭开发者模式？"
+            "value" : "禁用开发者模式？"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "確定關閉開發者模式？"
+            "value" : "停用開發者模式？"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Dismiss" : {
 
@@ -6277,7 +10499,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download"
+            "value" : "Herunterladen"
           }
         },
         "en" : {
@@ -6289,25 +10511,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download"
+            "value" : "Lataa"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download"
+            "value" : "Télécharger"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download"
+            "value" : "ダウンロード"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download"
+            "value" : "Завантажити"
           }
         },
         "zh-Hans" : {
@@ -6322,7 +10544,9 @@
             "value" : "下載"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Downloaded" : {
       "localizations" : {
@@ -6482,7 +10706,59 @@
     },
     "Downloading Shimeji pack…" : {
       "comment" : "A label displayed when the Shimeji resource pack is downloading.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloading Shimeji pack…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-Paket wird geladen…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement du pack Shimeji…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "しめじパックをダウンロード中…"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ladataan Shimeji-pakettia…"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантаження пакета Shimeji…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在下载 Shimeji 包…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在下載 Shimeji 套件…"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Downloads" : {
       "localizations" : {
@@ -6501,47 +10777,49 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Downloads"
+            "value" : "Lataukset"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Downloads"
+            "value" : "Téléchargements"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Downloads"
+            "value" : "ダウンロード"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Downloads"
+            "value" : "Завантаження"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下载管理"
+            "value" : "下载"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下載管理"
+            "value" : "下載"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Duration" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Duration"
+            "value" : "Dauer"
           }
         },
         "en" : {
@@ -6553,25 +10831,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Duration"
+            "value" : "Kesto"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Duration"
+            "value" : "Durée"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Duration"
+            "value" : "長さ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Duration"
+            "value" : "Тривалість"
           }
         },
         "zh-Hans" : {
@@ -6586,7 +10864,9 @@
             "value" : "時長"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Easter Eggs" : {
       "localizations" : {
@@ -6605,25 +10885,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Easter Eggs"
+            "value" : "Yllätykset"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Easter Eggs"
+            "value" : "Surprises cachées"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Easter Eggs"
+            "value" : "隠し要素"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Easter Eggs"
+            "value" : "Приховані сюрпризи"
           }
         },
         "zh-Hans" : {
@@ -6638,21 +10918,75 @@
             "value" : "彩蛋"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Edit Playlist" : {
 
     },
     "Enable" : {
       "comment" : "A button that enables an experimental feature.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivieren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効にする"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ota käyttöön"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увімкнути"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Enable AI Audio Processing to access vocal removal, bass enhance, and other AI-powered audio features." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enable AI Audio Processing to access vocal removal, bass enhance, and other AI-powered audio features."
+            "value" : "Aktiviere KI-Audioverarbeitung für Gesangsentfernung, Bassverstärkung und weitere KI-Audiofunktionen."
           }
         },
         "en" : {
@@ -6664,40 +10998,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enable AI Audio Processing to access vocal removal, bass enhance, and other AI-powered audio features."
+            "value" : "Ota tekoälyäänenkäsittely käyttöön laulun poistoa, bassokorostusta ja muita tekoälytehosteita varten."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enable AI Audio Processing to access vocal removal, bass enhance, and other AI-powered audio features."
+            "value" : "Activez le traitement audio IA pour supprimer la voix, renforcer les basses et utiliser les autres effets IA."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enable AI Audio Processing to access vocal removal, bass enhance, and other AI-powered audio features."
+            "value" : "AIオーディオ処理を有効にすると、ボーカル除去や低音強調などの機能を利用できます。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enable AI Audio Processing to access vocal removal, bass enhance, and other AI-powered audio features."
+            "value" : "Увімкніть обробку аудіо ШІ для видалення вокалу, підсилення басів та інших функцій."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开启 AI 音频处理即可使用人声消除、低音增强以及其他 AI 驱动的音频功能。"
+            "value" : "启用 AI 音频处理以使用人声消除、低音增强等 AI 音频功能。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "開啟 AI 音訊處理即可使用人聲消除、低音增強以及其他 AI 驅動的音訊功能。"
+            "value" : "啟用 AI 音訊處理以使用人聲消除、低音增強等 AI 音訊功能。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Enable camera access in Settings to scan a sign-in code." : {
       "localizations" : {
@@ -6753,7 +11089,59 @@
     },
     "Enable Experiments" : {
       "comment" : "A toggle that enables or disables experimental features.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Experiments"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente aktivieren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer les expériences"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実験的機能を有効にする"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ota kokeilut käyttöön"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увімкнути експерименти"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用实验功能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用實驗功能"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Enter full screen" : {
 
@@ -6775,25 +11163,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Equalizer"
+            "value" : "Taajuuskorjain"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Equalizer"
+            "value" : "Égaliseur"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Equalizer"
+            "value" : "イコライザ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Equalizer"
+            "value" : "Еквалайзер"
           }
         },
         "zh-Hans" : {
@@ -6808,26 +11196,236 @@
             "value" : "等化器"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Exit full screen" : {
 
     },
     "Experimental Themes" : {
       "comment" : "A toggle that enables experimental themes.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimental Themes"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimentelle Designs"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thèmes expérimentaux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実験的テーマ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kokeelliset teemat"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Експериментальні теми"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实验性主题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實驗性主題"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Experimental Themes adds early, in-progress themes to the theme picker above. Shimeji adds tiny animated characters that wander around on top of the app." : {
       "comment" : "A description of the experimental features that can be enabled in the settings.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimental Themes adds early, in-progress themes to the theme picker above. Shimeji adds tiny animated characters that wander around on top of the app."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimentelle Designs ergänzt den Designwähler um unfertige Designs. Shimeji zeigt kleine animierte Figuren über der App."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les thèmes expérimentaux ajoutent des thèmes en développement au sélecteur. Shimeji ajoute de petits personnages animés qui se promènent sur l’app."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実験的テーマを有効にすると、開発中のテーマが選択肢に追加されます。しめじはアプリ上を歩き回る小さなキャラクターを表示します。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kokeelliset teemat lisäävät keskeneräisiä teemoja valikkoon. Shimeji lisää sovelluksen päällä liikkuvia pieniä hahmoja."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Експериментальні теми додають теми в розробці до списку вище. Shimeji додає маленьких анімованих персонажів поверх застосунку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实验性主题会在上方主题选择器中添加开发中的主题。Shimeji 会在应用上方显示四处走动的小型动画角色。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實驗性主題會在上方主題選擇器中加入開發中的主題。Shimeji 會在 App 上方顯示四處走動的小型動畫角色。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Experiments" : {
       "comment" : "A section in the settings view that lets users enable or disable experimental features.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experiments"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expériences"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実験的機能"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kokeilut"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Експерименти"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实验功能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實驗功能"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Experiments are early, unfinished features. They may be unstable, change without notice, or be removed in a future update." : {
       "comment" : "A description of the effects of enabling experiments.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experiments are early, unfinished features. They may be unstable, change without notice, or be removed in a future update."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente sind frühe, unfertige Funktionen. Sie können instabil sein, sich ohne Vorankündigung ändern oder später entfernt werden."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les expériences sont des fonctions inachevées. Elles peuvent être instables, changer sans préavis ou être supprimées lors d’une mise à jour."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実験的機能は開発途中です。不安定な場合があり、予告なく変更されたり、今後の更新で削除されたりすることがあります。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kokeilut ovat keskeneräisiä toimintoja. Ne voivat olla epävakaita, muuttua ilmoittamatta tai poistua myöhemmässä päivityksessä."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Експерименти — це незавершені функції. Вони можуть бути нестабільними, змінюватися без попередження або бути видаленими в оновленні."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实验功能尚未完成，可能不稳定、随时更改，或在后续更新中移除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實驗功能尚未完成，可能不穩定、隨時變更，或在後續更新中移除。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Explore" : {
       "localizations" : {
@@ -6938,7 +11536,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Export Debug Logs"
+            "value" : "Debug-Protokolle exportieren"
           }
         },
         "en" : {
@@ -6950,25 +11548,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Export Debug Logs"
+            "value" : "Vie virheenkorjauslokit"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Export Debug Logs"
+            "value" : "Exporter les journaux de débogage"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Export Debug Logs"
+            "value" : "デバッグログを書き出す"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Export Debug Logs"
+            "value" : "Експортувати журнали налагодження"
           }
         },
         "zh-Hans" : {
@@ -6980,10 +11578,12 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "匯出 Debug 紀錄"
+            "value" : "匯出偵錯日誌"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Favorite" : {
       "localizations" : {
@@ -7681,10 +12281,112 @@
       }
     },
     "Haptic Feedback" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptic Feedback"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptisches Feedback"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retour haptique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触覚フィードバック"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Värinäpalaute"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тактильний відгук"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触感反馈"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "觸覺回饋"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Haptics" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptics"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptik"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vibrations"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触覚"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Värinä"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вібрація"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触感"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "觸覺"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Hidden" : {
       "localizations" : {
@@ -8159,7 +12861,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instrumental Enhance"
+            "value" : "Instrumente verstärken"
           }
         },
         "en" : {
@@ -8171,25 +12873,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instrumental Enhance"
+            "value" : "Korosta säestystä"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instrumental Enhance"
+            "value" : "Renforcer l’instrumental"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instrumental Enhance"
+            "value" : "伴奏を強調"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instrumental Enhance"
+            "value" : "Підсилення інструменталу"
           }
         },
         "zh-Hans" : {
@@ -8204,7 +12906,9 @@
             "value" : "伴奏增強"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Internal Testing & Metadata" : {
       "localizations" : {
@@ -8796,7 +13500,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Language"
+            "value" : "Sprache"
           }
         },
         "en" : {
@@ -8808,25 +13512,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Language"
+            "value" : "Kieli"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Language"
+            "value" : "Langue"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Language"
+            "value" : "言語"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Language"
+            "value" : "Мова"
           }
         },
         "zh-Hans" : {
@@ -8841,7 +13545,9 @@
             "value" : "語言"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Language Support" : {
 
@@ -10347,7 +15053,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Logging"
+            "value" : "Protokollierung"
           }
         },
         "en" : {
@@ -10359,25 +15065,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Logging"
+            "value" : "Lokitus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Logging"
+            "value" : "Journalisation"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Logging"
+            "value" : "ログ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Logging"
+            "value" : "Журналювання"
           }
         },
         "zh-Hans" : {
@@ -10392,7 +15098,9 @@
             "value" : "日誌"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Lossless" : {
       "localizations" : {
@@ -10503,7 +15211,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lyrics"
+            "value" : "Liedtexte"
           }
         },
         "en" : {
@@ -10515,25 +15223,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lyrics"
+            "value" : "Sanoitukset"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lyrics"
+            "value" : "Paroles"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lyrics"
+            "value" : "歌詞"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lyrics"
+            "value" : "Тексти пісень"
           }
         },
         "zh-Hans" : {
@@ -10548,7 +15256,9 @@
             "value" : "歌詞"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Made for You" : {
 
@@ -10772,7 +15482,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Music"
+            "value" : "Musik"
           }
         },
         "en" : {
@@ -10784,25 +15494,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Music"
+            "value" : "Musiikki"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Music"
+            "value" : "Musique"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Music"
+            "value" : "ミュージック"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Music"
+            "value" : "Музика"
           }
         },
         "zh-Hans" : {
@@ -10817,7 +15527,9 @@
             "value" : "音樂"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "NEUROKARAOKE.COM • EVILKARAOKE.COM • TWINSKARAOKE.COM" : {
       "localizations" : {
@@ -11627,7 +16339,58 @@
 
     },
     "Not downloaded" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not downloaded"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht heruntergeladen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non téléchargé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未ダウンロード"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ei ladattu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не завантажено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未下載"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Not signed in" : {
       "extractionState" : "stale",
@@ -11687,7 +16450,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Notifications"
+            "value" : "Mitteilungen"
           }
         },
         "en" : {
@@ -11699,7 +16462,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Notifications"
+            "value" : "Ilmoitukset"
           }
         },
         "fr" : {
@@ -11711,28 +16474,30 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Notifications"
+            "value" : "通知"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Notifications"
+            "value" : "Сповіщення"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "消息通知"
+            "value" : "通知"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "訊息通知"
+            "value" : "通知"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Now playing" : {
       "localizations" : {
@@ -11891,7 +16656,58 @@
       }
     },
     "OK" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "On" : {
       "localizations" : {
@@ -12051,7 +16867,59 @@
     },
     "On Screen At Once" : {
       "comment" : "A label displayed in a stepper that shows the number of Shimeji that can be on screen at once.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On Screen At Once"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gleichzeitig auf dem Bildschirm"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À l’écran en même temps"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同時に表示する数"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Näytöllä kerrallaan"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Одночасно на екрані"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同时显示数量"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同時顯示數量"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Only you can edit this playlist" : {
       "localizations" : {
@@ -14270,14 +19138,66 @@
     },
     "Population" : {
       "comment" : "A section in the Shimeji settings view that allows the user to adjust the number of Shimeji that can be on screen at once.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Population"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anzahl"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Population"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Määrä"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кількість"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数量"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "數量"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Powered by on-device AI. Audio is separated into vocals and instrumentals using a neural network model." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Powered by on-device AI. Audio is separated into vocals and instrumentals using a neural network model."
+            "value" : "KI auf dem Gerät trennt Audio mithilfe eines neuronalen Netzes in Gesang und Instrumente."
           }
         },
         "en" : {
@@ -14289,40 +19209,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Powered by on-device AI. Audio is separated into vocals and instrumentals using a neural network model."
+            "value" : "Laitteen tekoäly erottelee äänen lauluksi ja säestykseksi neuroverkkomallilla."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Powered by on-device AI. Audio is separated into vocals and instrumentals using a neural network model."
+            "value" : "L’IA sur l’appareil sépare la voix et les instruments à l’aide d’un réseau neuronal."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Powered by on-device AI. Audio is separated into vocals and instrumentals using a neural network model."
+            "value" : "デバイス上のニューラルネットワークモデルが音声をボーカルと伴奏に分離します。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Powered by on-device AI. Audio is separated into vocals and instrumentals using a neural network model."
+            "value" : "ШІ на пристрої розділяє аудіо на вокал та інструменти за допомогою нейромережі."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "由设备端 AI 提供支持 使用神经网络模型将音频分离为人声和伴奏"
+            "value" : "由设备端 AI 驱动，使用神经网络模型将音频分离为人声和伴奏。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "由裝置端 AI 提供支援 使用神經網路模型將音訊分離為人聲和伴奏"
+            "value" : "由裝置端 AI 驅動，使用神經網路模型將音訊分離為人聲和伴奏。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Preferences are saved on this device and use the same account settings style as Music." : {
       "localizations" : {
@@ -14440,7 +19362,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Preset"
+            "value" : "Voreinstellung"
           }
         },
         "en" : {
@@ -14452,25 +19374,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Preset"
+            "value" : "Esiasetus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Preset"
+            "value" : "Préréglage"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Preset"
+            "value" : "プリセット"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Preset"
+            "value" : "Попереднє налаштування"
           }
         },
         "zh-Hans" : {
@@ -14485,7 +19407,9 @@
             "value" : "預設"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Previous" : {
 
@@ -16006,7 +20930,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Removal Level"
+            "value" : "Entfernungsstärke"
           }
         },
         "en" : {
@@ -16018,40 +20942,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Removal Level"
+            "value" : "Poiston voimakkuus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Removal Level"
+            "value" : "Niveau de suppression"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Removal Level"
+            "value" : "除去レベル"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Removal Level"
+            "value" : "Рівень видалення"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "消除强度"
+            "value" : "消除程度"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "消除強度"
+            "value" : "消除程度"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Remove" : {
       "localizations" : {
@@ -16110,7 +21036,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Remove all downloads?"
+            "value" : "Alle Downloads entfernen?"
           }
         },
         "en" : {
@@ -16122,40 +21048,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Remove all downloads?"
+            "value" : "Poistetaanko kaikki lataukset?"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Remove all downloads?"
+            "value" : "Supprimer tous les téléchargements ?"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Remove all downloads?"
+            "value" : "すべてのダウンロードを削除しますか？"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Remove all downloads?"
+            "value" : "Видалити всі завантаження?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移除所有下载内容？"
+            "value" : "移除所有下载？"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移除所有下載內容？"
+            "value" : "移除所有下載？"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Remove Download" : {
       "localizations" : {
@@ -16211,7 +21139,59 @@
     },
     "Remove Downloaded Pack" : {
       "comment" : "A button that deletes the downloaded Shimeji resource pack.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Downloaded Pack"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladenes Paket entfernen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le pack téléchargé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済みパックを削除"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poista ladattu paketti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити завантажений пакет"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除已下载的包"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除已下載的套件"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Remove Downloads" : {
       "localizations" : {
@@ -16652,7 +21632,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset Equalizer"
+            "value" : "Equalizer zurücksetzen"
           }
         },
         "en" : {
@@ -16664,25 +21644,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset Equalizer"
+            "value" : "Nollaa taajuuskorjain"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset Equalizer"
+            "value" : "Réinitialiser l’égaliseur"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset Equalizer"
+            "value" : "イコライザをリセット"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset Equalizer"
+            "value" : "Скинути еквалайзер"
           }
         },
         "zh-Hans" : {
@@ -16697,11 +21677,65 @@
             "value" : "重設等化器"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Resource Pack" : {
       "comment" : "The title of the section that displays the current state of the resource pack.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resource Pack"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ressourcenpaket"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pack de ressources"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リソースパック"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resurssipaketti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пакет ресурсів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "资源包"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資源包"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Resources" : {
       "localizations" : {
@@ -16757,18 +21791,122 @@
     },
     "Respawn clears everyone currently on screen and brings in a fresh set." : {
       "comment" : "A description of the \"Respawn\" button.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respawn clears everyone currently on screen and brings in a fresh set."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ersetzt alle Figuren auf dem Bildschirm durch eine neue Auswahl."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplace tous les personnages à l’écran par un nouveau groupe."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面上のキャラクターを消し、新しい組み合わせで再出現させます。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korvaa kaikki näytöllä olevat hahmot uudella joukolla."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Замінює всіх персонажів на екрані новим набором."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新生成会清除屏幕上的所有角色，并生成一组新角色。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新產生會清除螢幕上的所有角色，並產生一組新角色。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Respawn Now" : {
       "comment" : "A button that respawns all Shimeji characters.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respawn Now"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt neu erscheinen lassen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faire réapparaître"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再出現させる"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Luo hahmot uudelleen"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Створити заново"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即重新生成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即重新產生"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Respect Reduce Motion" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respect Reduce Motion"
+            "value" : "„Bewegung reduzieren“ beachten"
           }
         },
         "en" : {
@@ -16780,40 +21918,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respect Reduce Motion"
+            "value" : "Noudata Vähennä liikettä -asetusta"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respect Reduce Motion"
+            "value" : "Respecter « Réduire les animations »"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respect Reduce Motion"
+            "value" : "「視差効果を減らす」に従う"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respect Reduce Motion"
+            "value" : "Враховувати «Зменшення руху»"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "减弱动态效果"
+            "value" : "遵循“减弱动态效果”"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "減弱動態效果"
+            "value" : "遵循「減少動態效果」"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Results for \"%@\"" : {
       "localizations" : {
@@ -17883,14 +23023,66 @@
     },
     "Setting up…" : {
       "comment" : "A message displayed when the Shimeji resource pack is being set up.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setting up…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird eingerichtet…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuration…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定中…"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valmistellaan…"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在设置…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在設定…"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Settings" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Settings"
+            "value" : "Einstellungen"
           }
         },
         "en" : {
@@ -17902,25 +23094,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Settings"
+            "value" : "Asetukset"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Settings"
+            "value" : "Réglages"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Settings"
+            "value" : "設定"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Settings"
+            "value" : "Налаштування"
           }
         },
         "zh-Hans" : {
@@ -17935,7 +23127,9 @@
             "value" : "設定"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Share artwork" : {
       "extractionState" : "stale",
@@ -18148,15 +23342,171 @@
     },
     "Shimeji" : {
       "comment" : "A toggle that enables Shimeji, a feature that adds tiny animated characters that wander around on top of the app.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "しめじ"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Shimeji Characters" : {
       "comment" : "A label for a view that lets users configure Shimeji.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji Characters"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-Figuren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnages Shimeji"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "しめじキャラクター"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-hahmot"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Персонажі Shimeji"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji 角色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji 角色"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Shimeji characters and animations are downloaded separately from the app so new ones can be added later." : {
       "comment" : "A description of the Shimeji resource pack.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji characters and animations are downloaded separately from the app so new ones can be added later."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-Figuren und Animationen werden separat geladen, damit später neue hinzukommen können."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les personnages et animations Shimeji sont téléchargés séparément pour permettre d’en ajouter plus tard."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "しめじのキャラクターとアニメーションは、後から追加できるようアプリとは別にダウンロードします。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-hahmot ja animaatiot ladataan erikseen, jotta niitä voidaan lisätä myöhemmin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Персонажі та анімації Shimeji завантажуються окремо, щоб згодом можна було додати нові."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji 角色和动画独立于应用下载，以便之后添加新内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji 角色和動畫獨立於 App 下載，以便之後加入新內容。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Show Less" : {
 
@@ -20372,7 +25722,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Storage"
+            "value" : "Speicher"
           }
         },
         "en" : {
@@ -20384,31 +25734,31 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Storage"
+            "value" : "Tallennustila"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Storage"
+            "value" : "Stockage"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Storage"
+            "value" : "ストレージ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Storage"
+            "value" : "Сховище"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "存储空间"
+            "value" : "存储"
           }
         },
         "zh-Hant" : {
@@ -20417,7 +25767,9 @@
             "value" : "儲存空間"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Storage & Limits" : {
 
@@ -20427,7 +25779,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Strength"
+            "value" : "Stärke"
           }
         },
         "en" : {
@@ -20439,25 +25791,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Strength"
+            "value" : "Voimakkuus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Strength"
+            "value" : "Force"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Strength"
+            "value" : "強さ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Strength"
+            "value" : "Сила"
           }
         },
         "zh-Hans" : {
@@ -20472,14 +25824,16 @@
             "value" : "強度"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Swipe up or down to adjust this band by one decibel." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust this band by one decibel."
+            "value" : "Nach oben oder unten streichen, um dieses Band um ein Dezibel anzupassen."
           }
         },
         "en" : {
@@ -20491,40 +25845,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust this band by one decibel."
+            "value" : "Säädä kaistaa yhden desibelin verran pyyhkäisemällä ylös tai alas."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust this band by one decibel."
+            "value" : "Balayez vers le haut ou le bas pour régler cette bande d’un décibel."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust this band by one decibel."
+            "value" : "上下にスワイプすると、このバンドを1デシベルずつ調整します。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust this band by one decibel."
+            "value" : "Проведіть угору або вниз, щоб змінити цю смугу на один децибел."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上下滑动以 1 分贝为单位进行调整"
+            "value" : "向上或向下轻扫可将此频段调节一分贝。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上下滑動以 1 分貝為單位進行調整"
+            "value" : "向上或向下滑動可將此頻段調節一分貝。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Swipe up or down to adjust vocal removal." : {
       "localizations" : {
@@ -20583,7 +25939,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust."
+            "value" : "Zum Anpassen nach oben oder unten streichen."
           }
         },
         "en" : {
@@ -20595,40 +25951,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust."
+            "value" : "Säädä pyyhkäisemällä ylös tai alas."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust."
+            "value" : "Balayez vers le haut ou le bas pour régler."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust."
+            "value" : "上下にスワイプして調整します。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swipe up or down to adjust."
+            "value" : "Проведіть угору або вниз для регулювання."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上下滑动以调整"
+            "value" : "向上或向下轻扫以调节。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上下滑動以調整"
+            "value" : "向上或向下滑動以調節。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Swipe up or down to seek by 15 seconds." : {
       "localizations" : {
@@ -20846,10 +26204,112 @@
       }
     },
     "Taps, swipes and controls answer back with a vibration." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taps, swipes and controls answer back with a vibration."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippen, Wischen und Bedienelemente geben eine Vibration zurück."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les gestes et commandes répondent par une vibration."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップやスワイプ、操作に振動で反応します。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Napautukset, pyyhkäisyt ja säätimet antavat värinäpalautetta."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дотики, жести й елементи керування відповідають вібрацією."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点按、轻扫和控件操作会提供振动反馈。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按、滑動和控制項操作會提供震動回饋。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Taps, swipes and controls answer back with a vibration. Strength sets how hard they land — each control keeps its own character at every level." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taps, swipes and controls answer back with a vibration. Strength sets how hard they land — each control keeps its own character at every level."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippen, Wischen und Bedienelemente geben eine Vibration zurück. Die Stärke bestimmt die Intensität; jede Aktion behält ihren eigenen Charakter."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les gestes et commandes répondent par une vibration. La force règle leur intensité tout en conservant le caractère de chaque commande."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップやスワイプ、操作に振動で反応します。強さを変えても、それぞれの操作に固有の振動パターンは維持されます。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Napautukset, pyyhkäisyt ja säätimet antavat värinäpalautetta. Voimakkuus säätää tehoa ja säilyttää kunkin toiminnon oman tuntuman."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дотики, жести й елементи керування відповідають вібрацією. Сила змінює інтенсивність, зберігаючи характер кожної дії."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点按、轻扫和控件操作会提供振动反馈。强度决定振动的力度，同时保留各控件独有的触感。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按、滑動和控制項操作會提供震動回饋。強度決定震動的力道，同時保留各控制項獨有的觸感。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Tech Stack" : {
       "localizations" : {
@@ -20908,7 +26368,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The developer menu and related features will be hidden until you turn developer mode back on."
+            "value" : "Das Entwicklermenü und zugehörige Funktionen werden bis zur erneuten Aktivierung ausgeblendet. Debug-Protokollierung wird deaktiviert."
           }
         },
         "en" : {
@@ -20920,40 +26380,42 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The developer menu and related features will be hidden until you turn developer mode back on."
+            "value" : "Kehittäjävalikko ja sen toiminnot piilotetaan, kunnes otat kehittäjätilan taas käyttöön. Virheenkorjausloki poistetaan käytöstä."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The developer menu and related features will be hidden until you turn developer mode back on."
+            "value" : "Le menu développeur et ses fonctions seront masqués jusqu’à réactivation. La journalisation de débogage sera désactivée."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The developer menu and related features will be hidden until you turn developer mode back on."
+            "value" : "開発者モードを再度有効にするまで、開発者メニューと関連機能を非表示にします。デバッグログも無効にします。"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The developer menu and related features will be hidden until you turn developer mode back on."
+            "value" : "Меню розробника та пов’язані функції буде приховано до повторного ввімкнення режиму розробника. Журнал налагодження буде вимкнено."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开发者菜单和相关功能将隐藏，直至再次开启开发者模式。"
+            "value" : "重新启用开发者模式前，将隐藏开发者菜单和相关功能，并关闭调试日志。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "開發者選單和相關功能將會隱藏，直到再次開啟開發者模式。"
+            "value" : "重新啟用開發者模式前，將隱藏開發者選單和相關功能，並關閉偵錯日誌。"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "The live station isn't reachable right now." : {
 
@@ -21018,7 +26480,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Theme"
+            "value" : "Design"
           }
         },
         "en" : {
@@ -21030,25 +26492,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Theme"
+            "value" : "Teema"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Theme"
+            "value" : "Thème"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Theme"
+            "value" : "テーマ"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Theme"
+            "value" : "Тема"
           }
         },
         "zh-Hans" : {
@@ -21063,7 +26525,9 @@
             "value" : "主題"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "There's nothing loaded to play on this watch." : {
 
@@ -21234,7 +26698,58 @@
       }
     },
     "Try Again" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erneut versuchen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yritä uudelleen"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спробувати знову"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Try another song title or artist." : {
 
@@ -21307,7 +26822,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn On"
+            "value" : "Aktivieren"
           }
         },
         "en" : {
@@ -21319,25 +26834,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn On"
+            "value" : "Ota käyttöön"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn On"
+            "value" : "Activer"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn On"
+            "value" : "有効にする"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn On"
+            "value" : "Увімкнути"
           }
         },
         "zh-Hans" : {
@@ -21352,14 +26867,16 @@
             "value" : "開啟"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Turn on auto-analyze during playback?" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn on auto-analyze during playback?"
+            "value" : "Automatische Analyse während der Wiedergabe aktivieren?"
           }
         },
         "en" : {
@@ -21371,48 +26888,154 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn on auto-analyze during playback?"
+            "value" : "Otetaanko automaattinen analyysi käyttöön toiston aikana?"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn on auto-analyze during playback?"
+            "value" : "Activer l’analyse automatique pendant la lecture ?"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn on auto-analyze during playback?"
+            "value" : "再生中の自動解析を有効にしますか？"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Turn on auto-analyze during playback?"
+            "value" : "Увімкнути автоаналіз під час відтворення?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "是否在播放时开启自动分析？"
+            "value" : "开启播放时自动分析？"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "是否在播放時開啟自動分析？"
+            "value" : "開啟播放時自動分析？"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Turn on Experiments to access early, in-progress features before they're finished." : {
       "comment" : "A footer for the \"Experiments\" section of the settings view.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turn on Experiments to access early, in-progress features before they're finished."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiviere Experimente, um Funktionen schon während ihrer Entwicklung zu nutzen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activez les expériences pour accéder aux fonctions encore en développement."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実験的機能を有効にすると、開発途中の機能を試せます。"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ota kokeilut käyttöön kokeillaksesi keskeneräisiä toimintoja."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увімкніть експерименти, щоб спробувати функції ще під час розробки."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用实验功能以体验尚在开发中的功能。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用實驗功能以體驗尚在開發中的功能。"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Turn On Experiments?" : {
       "comment" : "A button that turns on experimental features.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turn On Experiments?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente aktivieren?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer les expériences ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実験的機能を有効にしますか？"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otetaanko kokeilut käyttöön?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увімкнути експерименти?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用实验功能？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用實驗功能？"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Turn the Digital Crown or swipe up and down to adjust." : {
       "extractionState" : "stale",
@@ -22173,11 +27796,115 @@
     },
     "Use All" : {
       "comment" : "A button that selects all characters to spawn.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use All"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle verwenden"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout utiliser"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて使用"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Käytä kaikkia"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Використовувати всіх"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部启用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部啟用"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Use None" : {
       "comment" : "A button that clears all characters from the list.",
-      "isCommentAutoGenerated" : true
+      "isCommentAutoGenerated" : true,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use None"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine verwenden"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout désactiver"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて無効"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Älä käytä mitään"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не використовувати нікого"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部停用"
+          }
+        }
+      },
+      "generatesSymbol" : false
     },
     "Use the playback controls below." : {
       "localizations" : {
@@ -22663,7 +28390,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Enhance"
+            "value" : "Gesang verstärken"
           }
         },
         "en" : {
@@ -22675,25 +28402,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Enhance"
+            "value" : "Korosta laulua"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Enhance"
+            "value" : "Renforcer la voix"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Enhance"
+            "value" : "ボーカルを強調"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Enhance"
+            "value" : "Підсилення вокалу"
           }
         },
         "zh-Hans" : {
@@ -22708,14 +28435,16 @@
             "value" : "人聲增強"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Vocal Removal" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Removal"
+            "value" : "Gesang entfernen"
           }
         },
         "en" : {
@@ -22727,25 +28456,25 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Removal"
+            "value" : "Laulun poisto"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Removal"
+            "value" : "Suppression de la voix"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Removal"
+            "value" : "ボーカル除去"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocal Removal"
+            "value" : "Видалення вокалу"
           }
         },
         "zh-Hans" : {
@@ -22760,7 +28489,9 @@
             "value" : "人聲消除"
           }
         }
-      }
+      },
+      "extractionState" : "manual",
+      "generatesSymbol" : false
     },
     "Vocal removal controls" : {
 

--- a/TwinskaraokeShared/Localization/Localizable.xcstrings
+++ b/TwinskaraokeShared/Localization/Localizable.xcstrings
@@ -1,2719 +1,29 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Vocal Removal Level" : {
-      "extractionState" : "manual",
-      "generatesSymbol" : false,
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocal Removal Level"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stärke der Gesangsentfernung"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niveau de suppression de la voix"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーカル除去レベル"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laulun poiston voimakkuus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Рівень видалення вокалу"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人声消除程度"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人聲消除程度"
-          }
-        }
-      }
-    },
-    "Bass Enhance Strength" : {
-      "extractionState" : "manual",
-      "generatesSymbol" : false,
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bass Enhance Strength"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stärke der Bassverstärkung"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Force du renforcement des basses"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低音強調の強さ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bassokorostuksen voimakkuus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сила підсилення басів"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低音增强强度"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低音增強強度"
-          }
-        }
-      }
-    },
-    "Vocal Enhance Strength" : {
-      "extractionState" : "manual",
-      "generatesSymbol" : false,
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocal Enhance Strength"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stärke der Gesangsverstärkung"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Force du renforcement de la voix"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーカル強調の強さ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laulukorostuksen voimakkuus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сила підсилення вокалу"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人声增强强度"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人聲增強強度"
-          }
-        }
-      }
-    },
-    "Instrumental Enhance Strength" : {
-      "extractionState" : "manual",
-      "generatesSymbol" : false,
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instrumental Enhance Strength"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stärke der Instrumentenverstärkung"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Force du renforcement instrumental"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "伴奏強調の強さ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Säestyksen korostuksen voimakkuus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сила підсилення інструменталу"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "伴奏增强强度"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "伴奏增強強度"
-          }
-        }
-      }
-    },
-    "%@, %lld percent" : {
-      "extractionState" : "manual",
-      "generatesSymbol" : false,
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@, %lld percent"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@, %lld Prozent"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@, %lld pour cent"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@、%lld パーセント"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@, %lld prosenttia"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@, %lld відсотків"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@，百分之 %lld"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@，百分之 %lld"
-          }
-        }
-      }
-    },
-    "Autoplay" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoplay"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatische Wiedergabe"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lecture automatique"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動再生"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automaattinen toisto"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автовідтворення"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动播放"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動播放"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "System" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Système"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Järjestelmä"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Системна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跟随系统"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跟隨系統"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Light" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leicht"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Léger"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "弱"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kevyt"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Легка"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "轻"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "輕"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Dark" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dunkel"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sombre"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダーク"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tumma"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Темна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "深色"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "深色"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Medium" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medium"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mittel"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moyen"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keskitaso"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Середня"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Strong" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Strong"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stark"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fort"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "強"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voimakas"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сильна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "强"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "強"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Heavy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heavy"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sehr stark"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Très fort"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "非常に強い"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erittäin voimakas"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дуже сильна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "很强"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "很強"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Maximum" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximum"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximum"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximum"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suurin"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Максимум"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Almost off" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Almost off"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fast aus"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Presque désactivé"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ほぼオフ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähes pois"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Майже вимкнено"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "几乎关闭"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "幾乎關閉"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Nwero" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Could Not Clear Storage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could Not Clear Storage"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicher konnte nicht geleert werden"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de vider le stockage"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ストレージを消去できませんでした"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallennustilaa ei voitu tyhjentää"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося очистити сховище"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法清理存储"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法清理儲存空間"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Could Not Enable Notifications" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could Not Enable Notifications"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mitteilungen konnten nicht aktiviert werden"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d’activer les notifications"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知を有効にできませんでした"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ilmoituksia ei voitu ottaa käyttöön"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося ввімкнути сповіщення"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法启用通知"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法啟用通知"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Download Notifications" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download Notifications"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download-Mitteilungen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications de téléchargement"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロード通知"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Latausilmoitukset"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сповіщення про завантаження"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载通知"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下載通知"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Open Notification Settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Notification Settings"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mitteilungseinstellungen öffnen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir les réglages des notifications"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知設定を開く"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaa ilmoitusasetukset"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрити налаштування сповіщень"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开通知设置"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟通知設定"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Please try again." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please try again."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte erneut versuchen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veuillez réessayer."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "もう一度お試しください。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yritä uudelleen."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Спробуйте ще раз."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请重试。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請重試。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Some files could not be removed. Please try again." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Some files could not be removed. Please try again."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einige Dateien konnten nicht entfernt werden. Bitte erneut versuchen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certains fichiers n’ont pas pu être supprimés. Veuillez réessayer."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一部のファイルを削除できませんでした。もう一度お試しください。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Joitakin tiedostoja ei voitu poistaa. Yritä uudelleen."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Деякі файли не вдалося видалити. Спробуйте ще раз."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "部分文件无法移除。请重试。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "部分檔案無法移除。請重試。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Image Cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image Cache"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildcache"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache d’images"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像キャッシュ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kuvavälimuisti"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кеш зображень"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖片快取"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Music Cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Music Cache"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Musikcache"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache musical"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音楽キャッシュ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Musiikkivälimuisti"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кеш музики"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音乐缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音樂快取"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Lyrics Cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyrics Cache"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liedtextcache"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache des paroles"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歌詞キャッシュ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sanoitusvälimuisti"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кеш текстів пісень"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歌词缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歌詞快取"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear image cache?" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear image cache?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildcache leeren?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache d’images ?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像キャッシュを消去しますか？"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennetäänkö kuvavälimuisti?"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити кеш зображень?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除图片缓存？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除圖片快取？"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear music cache?" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear music cache?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Musikcache leeren?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache musical ?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音楽キャッシュを消去しますか？"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennetäänkö musiikkivälimuisti?"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити кеш музики?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除音乐缓存？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除音樂快取？"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear lyrics cache?" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear lyrics cache?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liedtextcache leeren?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache des paroles ?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歌詞キャッシュを消去しますか？"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennetäänkö sanoitusvälimuisti?"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити кеш текстів пісень?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除歌词缓存？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除歌詞快取？"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear recently played history?" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear recently played history?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiedergabeverlauf löschen?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Effacer l’historique d’écoute ?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再生履歴を消去しますか？"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennetäänkö kuunteluhistoria?"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити історію прослуховувань?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除最近播放记录？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除最近播放記錄？"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Remove All Downloads" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove All Downloads"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Downloads entfernen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer tous les téléchargements"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべてのダウンロードを削除"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista kaikki lataukset"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити всі завантаження"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除所有下载"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除所有下載"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear Image Cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Image Cache"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildcache leeren"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache d’images"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像キャッシュを消去"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä kuvavälimuisti"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити кеш зображень"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除图片缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除圖片快取"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear Music Cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Music Cache"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Musikcache leeren"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache musical"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音楽キャッシュを消去"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä musiikkivälimuisti"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити кеш музики"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除音乐缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除音樂快取"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear Lyrics Cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Lyrics Cache"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liedtextcache leeren"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache des paroles"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歌詞キャッシュを消去"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä sanoitusvälimuisti"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити кеш текстів пісень"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除歌词缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除歌詞快取"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Clear Recently Played" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Recently Played"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiedergabeverlauf löschen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Effacer l’historique d’écoute"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再生履歴を消去"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä kuunteluhistoria"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистити історію прослуховувань"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除最近播放记录"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除最近播放記錄"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Offline songs on this device" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline songs on this device"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline-Songs auf diesem Gerät"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titres hors ligne sur cet appareil"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このデバイスのオフライン曲"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tämän laitteen offline-kappaleet"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Офлайн-пісні на цьому пристрої"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此设备上的离线歌曲"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此裝置上的離線歌曲"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Listening history on this device" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listening history on this device"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiedergabeverlauf auf diesem Gerät"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Historique d’écoute sur cet appareil"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このデバイスの再生履歴"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tämän laitteen kuunteluhistoria"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Історія прослуховувань на цьому пристрої"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此设备上的播放记录"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此裝置上的播放記錄"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Flat" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flat"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neutral"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neutre"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フラット"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tasainen"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Рівна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "平直"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "平直"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Bass Boost" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bass Boost"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bassverstärkung"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basses renforcées"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低音強調"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bassokorostus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Підсилення басів"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低音增强"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低音增強"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Treble Boost" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Treble Boost"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Höhenverstärkung"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aigus renforcés"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "高音強調"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diskanttikorostus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Підсилення високих частот"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "高音增强"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "高音增強"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Vocal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocal"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gesang"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voix"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーカル"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laulu"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вокал"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人声"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人聲"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Rock" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rock"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rock"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rock"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ロック"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rock"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Рок"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "摇滚"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搖滾"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Pop" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pop"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pop"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pop"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポップ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pop"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поп"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "流行"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "流行"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Jazz" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jazz"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jazz"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jazz"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ジャズ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jazz"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Джаз"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "爵士"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "爵士"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Electronic" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Electronic"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elektronisch"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Électronique"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エレクトロニック"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elektroninen"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Електронна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "电子"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "電子"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Classical" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Classical"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klassik"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Classique"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クラシック"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klassinen"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Класична"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "古典"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "古典"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Hip-Hop" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hip-Hop"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hip-Hop"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hip-hop"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヒップホップ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hip-hop"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хіп-хоп"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "嘻哈"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "嘻哈"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Loudness" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loudness"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loudness"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Correction physiologique"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ラウドネス"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loudness"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Тонкомпенсація"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "响度"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "響度"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Custom" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerdefiniert"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personnalisé"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カスタム"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mukautettu"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Власна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自定义"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自訂"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "%lld s" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld s"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld s"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld s"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld 秒"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld s"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld с"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld 秒"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld 秒"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "%lld Hz Equalizer" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Hz Equalizer"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld-Hz-Equalizer"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Égaliseur %lld Hz"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Hz イコライザ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Hz:n taajuuskorjain"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Еквалайзер %lld Гц"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Hz 均衡器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Hz 等化器"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "%lld decibels" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld decibels"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Dezibel"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld décibels"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld デシベル"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld desibeliä"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld децибел"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld 分贝"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld 分貝"
-          }
-        }
-      },
-      "generatesSymbol" : false
+    "" : {
+
     },
     ", %lld percent" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", %lld Prozent"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : ", %lld percent"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : ", %lld Prozent"
+            "value" : ", %lld prosenttia"
           }
         },
         "fr" : {
@@ -2726,12 +36,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "、%lld パーセント"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", %lld prosenttia"
           }
         },
         "uk" : {
@@ -2752,1115 +56,7 @@
             "value" : "，百分之 %lld"
           }
         }
-      },
-      "generatesSymbol" : false
-    },
-    "Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose. Autoplay continues with account recommendations, or trending songs when recommendations are unavailable. These features do not apply to radio." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose. Autoplay continues with account recommendations, or trending songs when recommendations are unavailable. These features do not apply to radio."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Mix mischt passende Songs automatisch. Crossfade nutzt die gewählte Dauer. Autoplay spielt Kontoempfehlungen oder beliebte Songs weiter. Diese Funktionen gelten nicht für Radio."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Mix mélange automatiquement les titres compatibles. Le fondu enchaîné utilise la durée choisie. La lecture automatique poursuit avec vos recommandations, ou des titres populaires à défaut. Ces fonctions ne s’appliquent pas à la radio."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Mixは相性のよい曲を自動でミックスします。クロスフェードは指定した長さで切り替えます。自動再生はアカウントのおすすめ曲、取得できない場合は人気曲を再生します。ラジオには適用されません。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Mix yhdistää yhteensopivat kappaleet automaattisesti. Ristiinhäivytys käyttää valittua kestoa. Automaattinen toisto jatkuu tilin suosituksilla tai suosituilla kappaleilla, jos suosituksia ei ole. Toiminnot eivät koske radiota."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto Mix автоматично змішує сумісні пісні. Перехресне згасання використовує вибрану тривалість. Автовідтворення продовжує рекомендованими для облікового запису або популярними піснями. Ці функції не застосовуються до радіо."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动混音会混合适合的歌曲。交叉淡化使用所选时长。自动播放会继续播放账号推荐歌曲；无法获取推荐时则播放热门歌曲。这些功能不适用于电台。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動混音會混合適合的歌曲。交叉淡化使用所選時長。自動播放會繼續播放帳號推薦歌曲；無法取得推薦時則播放熱門歌曲。這些功能不適用於電台。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "When enabled, the current song and songs you play next are saved for offline listening. This may use cellular data. Turning this off leaves existing downloads and downloads already in progress intact." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When enabled, the current song and songs you play next are saved for offline listening. This may use cellular data. Turning this off leaves existing downloads and downloads already in progress intact."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speichert den aktuellen Song und danach gespielte Songs zum Offline-Hören. Dabei können mobile Daten verwendet werden. Ausschalten behält vorhandene und bereits laufende Downloads bei."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistre le titre actuel et les suivants pour une écoute hors ligne. Cela peut utiliser les données mobiles. La désactivation conserve les téléchargements existants et ceux en cours."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効にすると、現在の曲と次に再生する曲をオフライン用に保存します。モバイルデータを使用する場合があります。無効にしても、保存済みや進行中のダウンロードはそのまま残ります。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallentaa nykyisen ja seuraavaksi toistettavat kappaleet offline-kuuntelua varten. Tämä voi käyttää mobiilidataa. Pois kytkeminen säilyttää valmiit ja käynnissä olevat lataukset."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зберігає поточну й наступні пісні для офлайн-прослуховування. Можливе використання мобільних даних. Вимкнення зберігає наявні й уже розпочаті завантаження."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用后会保存当前及之后播放的歌曲，供离线收听。这可能使用蜂窝数据。关闭不会移除已有下载或取消正在进行的下载。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "啟用後會儲存目前及之後播放的歌曲，供離線聆聽。這可能使用行動數據。關閉不會移除已有下載或取消正在進行的下載。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "10-band parametric EQ. Drag each band between -12 dB and +12 dB. Equalizer and AI audio effects apply to songs, not radio." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10-band parametric EQ. Drag each band between -12 dB and +12 dB. Equalizer and AI audio effects apply to songs, not radio."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parametrischer 10-Band-EQ. Jedes Band ist von −12 bis +12 dB einstellbar. Equalizer und KI-Audioeffekte gelten für Songs, nicht für Radio."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Égaliseur paramétrique à 10 bandes, réglables de −12 à +12 dB. L’égaliseur et les effets audio IA s’appliquent aux titres, pas à la radio."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10バンドのパラメトリックEQ。各バンドを−12〜+12 dBで調整できます。イコライザとAIエフェクトは曲に適用され、ラジオには適用されません。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10-kaistainen parametrinen taajuuskorjain. Säädä kaistoja välillä −12 ja +12 dB. Taajuuskorjain ja tekoälytehosteet koskevat kappaleita, eivät radiota."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10-смуговий параметричний еквалайзер. Кожна смуга регулюється від −12 до +12 дБ. Еквалайзер та ШІ-ефекти застосовуються до пісень, але не до радіо."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10 段参数均衡器，每段可在 −12 至 +12 dB 之间调节。均衡器和 AI 音频效果适用于歌曲，不适用于电台。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10 段參數等化器，每段可在 −12 至 +12 dB 之間調節。等化器和 AI 音訊效果適用於歌曲，不適用於電台。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 64 MB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 64 MB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippe auf eine Anzeige, um den Cache zu leeren. Limits: Bilder 2 GB, Musik einschließlich KI-Spuren 4 GB, Liedtexte 64 MB. Einträge über 6 Monate werden automatisch entfernt. Downloads sind ausgenommen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Touchez un indicateur pour vider le cache. Limites : images 2 Go, musique avec pistes IA 4 Go, paroles 64 Mo. Les éléments de plus de 6 mois sont supprimés automatiquement. Les téléchargements sont exclus."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "項目をタップするとキャッシュを消去します。上限は画像2 GB、AI分離音源を含む音楽4 GB、歌詞64 MBです。6か月を超えた項目は自動削除されます。ダウンロードは対象外です。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä välimuisti napauttamalla sen riviä. Rajat: kuvat 2 Gt, musiikki ja tekoälyraidat 4 Gt, sanoitukset 64 Mt. Yli 6 kuukauden ikäiset kohteet poistetaan automaattisesti. Rajat eivät koske latauksia."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Торкніться показника, щоб очистити кеш. Ліміти: зображення — 2 ГБ, музика зі ШІ-доріжками — 4 ГБ, тексти — 64 МБ. Дані старші за 6 місяців видаляються автоматично. Завантаження не обмежуються цими лімітами."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "点按项目可清除相应缓存。图片缓存上限为 2 GB，音乐缓存（包括 AI 分离音轨）为 4 GB，歌词缓存为 64 MB。超过 6 个月的项目会自动清理。离线下载不受这些限制。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "點按項目可清除相應快取。圖片快取上限為 2 GB，音樂快取（包括 AI 分離音軌）為 4 GB，歌詞快取為 64 MB。超過 6 個月的項目會自動清理。離線下載不受這些限制。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "All offline downloads on this device will be removed." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All offline downloads on this device will be removed."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Offline-Downloads auf diesem Gerät werden entfernt."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tous les téléchargements hors ligne de cet appareil seront supprimés."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このデバイスのオフラインダウンロードをすべて削除します。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaikki tämän laitteen offline-lataukset poistetaan."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Усі офлайн-завантаження на цьому пристрої буде видалено."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将移除此设备上的所有离线下载。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將移除此裝置上的所有離線下載。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Cached artwork and images will be removed. They will download again as you use the app." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cached artwork and images will be removed. They will download again as you use the app."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zwischengespeicherte Bilder werden entfernt und bei Bedarf erneut geladen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les illustrations et images en cache seront supprimées puis téléchargées à nouveau au besoin."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャッシュされた画像を削除します。アプリの使用時に必要に応じて再ダウンロードされます。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Välimuistin kuvat poistetaan. Ne ladataan tarvittaessa uudelleen."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кешовані зображення буде видалено. Вони завантажаться знову під час використання застосунку."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将移除缓存的封面和图片，使用应用时会重新下载。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將移除快取的封面和圖片，使用 App 時會重新下載。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Cached audio files and AI stems will be removed. Songs may buffer again the next time you play them." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cached audio files and AI stems will be removed. Songs may buffer again the next time you play them."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zwischengespeicherte Audiodateien und KI-Spuren werden entfernt. Songs müssen beim nächsten Abspielen eventuell erneut laden."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les fichiers audio et pistes IA en cache seront supprimés. Les titres pourront nécessiter un chargement à la prochaine écoute."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャッシュされた音声とAI分離音源を削除します。次回再生時に読み込みが必要になる場合があります。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Välimuistin ääni ja tekoälyraidat poistetaan. Seuraava toisto voi vaatia puskurointia."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кешовані аудіофайли та ШІ-доріжки буде видалено. Під час наступного відтворення може знадобитися буферизація."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将移除缓存的音频文件和 AI 分离音轨。下次播放时可能需要重新缓冲。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將移除快取的音訊檔案和 AI 分離音軌。下次播放時可能需要重新緩衝。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Cached lyrics and lyric translations will be removed." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cached lyrics and lyric translations will be removed."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zwischengespeicherte Liedtexte und Übersetzungen werden entfernt."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les paroles et leurs traductions en cache seront supprimées."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャッシュされた歌詞と翻訳を削除します。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Välimuistin sanoitukset ja käännökset poistetaan."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кешовані тексти пісень та переклади буде видалено."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将移除缓存的歌词和歌词翻译。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將移除快取的歌詞和歌詞翻譯。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Your recently played history will be removed from this device." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your recently played history will be removed from this device."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Wiedergabeverlauf wird von diesem Gerät entfernt."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Votre historique d’écoute sera supprimé de cet appareil."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このデバイスの再生履歴を削除します。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kuunteluhistoria poistetaan tältä laitteelta."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Історію прослуховувань буде видалено з цього пристрою."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将从此设备移除最近播放记录。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將從此裝置移除最近播放記錄。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Notify when downloads finish while the app is in the background." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notify when downloads finish while the app is in the background."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigt, wenn Downloads abgeschlossen sind und die App im Hintergrund ist."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recevoir une notification à la fin des téléchargements lorsque l’app est en arrière-plan."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリがバックグラウンドのときにダウンロード完了を通知します。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ilmoita latausten valmistumisesta sovelluksen ollessa taustalla."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сповіщати про завершення завантажень, коли застосунок у фоні."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用在后台时，下载完成后发送通知。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App 在背景執行時，下載完成後傳送通知。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Notifications are disabled in system settings. Allow notifications there to receive download updates." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications are disabled in system settings. Allow notifications there to receive download updates."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mitteilungen sind in den Systemeinstellungen deaktiviert. Aktiviere sie dort für Download-Mitteilungen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les notifications sont désactivées dans les réglages système. Autorisez-les pour recevoir les mises à jour des téléchargements."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム設定で通知が無効になっています。ダウンロード通知を受け取るには、そこで通知を許可してください。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ilmoitukset on poistettu käytöstä järjestelmäasetuksissa. Salli ne saadaksesi latausilmoituksia."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сповіщення вимкнено в системних налаштуваннях. Дозвольте їх, щоб отримувати сповіщення про завантаження."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统设置中已禁用通知。请在其中允许通知，以接收下载更新。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系統設定中已停用通知。請在其中允許通知，以接收下載更新。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Your songs are ready for offline listening." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your songs are ready for offline listening."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Songs sind zum Offline-Hören bereit."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vos titres sont prêts pour une écoute hors ligne."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "曲をオフラインで再生できるようになりました。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kappaleesi ovat valmiina offline-kuunteluun."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ваші пісні готові до офлайн-прослуховування."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歌曲已可供离线收听。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歌曲已可供離線聆聽。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Some songs could not be downloaded. Open the app to retry." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Some songs could not be downloaded. Open the app to retry."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einige Songs konnten nicht geladen werden. Öffne die App, um es erneut zu versuchen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certains titres n’ont pas pu être téléchargés. Ouvrez l’app pour réessayer."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一部の曲をダウンロードできませんでした。アプリを開いて再試行してください。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Joitakin kappaleita ei voitu ladata. Avaa sovellus ja yritä uudelleen."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Деякі пісні не вдалося завантажити. Відкрийте застосунок і спробуйте знову."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "部分歌曲无法下载。请打开应用重试。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "部分歌曲無法下載。請開啟 App 重試。"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Theme.system" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Système"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Järjestelmä"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Системна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跟随系统"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跟隨系統"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Theme.light" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hell"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clair"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ライト"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vaalea"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Світла"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浅色"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "淺色"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Theme.dark" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dunkel"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sombre"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダーク"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tumma"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Темна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "深色"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "深色"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "Theme.nwero" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nwero"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "%@ / 2 GB" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 2 GB"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "%@ / 4 GB" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 4 GB"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "%@ / 64 MB" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / 64 MB"
-          }
-        }
-      },
-      "generatesSymbol" : false
-    },
-    "%lld minutes" : {
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "%lld Minuten" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%lld minutes" } }
       }
-    },
-    "Cancel Sleep Timer" : {
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Schlaftimer abbrechen" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel Sleep Timer" } }
-      }
-    },
-    "Sleep Timer" : {
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Schlaftimer" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sleep Timer" } }
-      }
-    },
-    "Sleep timer remaining" : {
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Verbleibende Zeit des Schlaftimers" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sleep timer remaining" } }
-      }
-    },
-    "" : {
-
     },
     "·" : {
       "localizations" : {
@@ -3916,6 +112,168 @@
     },
     "@%@" : {
 
+    },
+    "%@ / 2 GB" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 2 GB"
+          }
+        }
+      }
+    },
+    "%@ / 4 GB" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 4 GB"
+          }
+        }
+      }
+    },
+    "%@ / 64 MB" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ / 64 MB"
+          }
+        }
+      }
     },
     "%@ artwork" : {
       "localizations" : {
@@ -4039,18 +397,26 @@
     },
     "%@ ready — %lld characters" : {
       "comment" : "A label that displays the name of the resource pack and a checkmark.",
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ bereit — %lld Figuren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ready — %lld characters"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ bereit — %lld Figuren"
+            "value" : "%@ valmis — %lld hahmoa"
           }
         },
         "fr" : {
@@ -4063,12 +429,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 準備完了 — %lld キャラクター"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ valmis — %lld hahmoa"
           }
         },
         "uk" : {
@@ -4089,9 +449,7 @@
             "value" : "%@ 已就緒 — %lld 個角色"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "%@ views" : {
 
@@ -4258,6 +616,60 @@
         }
       }
     },
+    "%@, %lld percent" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld Prozent"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld percent"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld prosenttia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld pour cent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@、%lld パーセント"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, %lld відсотків"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@，百分之 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@，百分之 %lld"
+          }
+        }
+      }
+    },
     "%lld" : {
       "localizations" : {
         "de" : {
@@ -4410,6 +822,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 藝術作品"
+          }
+        }
+      }
+    },
+    "%lld decibels" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Dezibel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld decibels"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld desibeliä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld décibels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld デシベル"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld децибел"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 分贝"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 分貝"
+          }
+        }
+      }
+    },
+    "%lld Hz Equalizer" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld-Hz-Equalizer"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz Equalizer"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz:n taajuuskorjain"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Égaliseur %lld Hz"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz イコライザ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Еквалайзер %lld Гц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz 均衡器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Hz 等化器"
           }
         }
       }
@@ -4570,8 +1090,25 @@
         }
       }
     },
+    "%lld minutes" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Minuten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld minutes"
+          }
+        }
+      }
+    },
     "%lld percent" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -4621,8 +1158,7 @@
             "value" : "百分之 %lld"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "%lld playlists" : {
       "localizations" : {
@@ -4672,6 +1208,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 播放歌單"
+          }
+        }
+      }
+    },
+    "%lld s" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld с"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
           }
         }
       }
@@ -5327,6 +1917,7 @@
       }
     },
     "10-band parametric EQ. Drag each band between -12 dB and +12 dB." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -5374,6 +1965,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "10 段參數等化器。拖曳每個頻段在 -12 dB 到 +12 dB 之間調整。"
+          }
+        }
+      }
+    },
+    "10-band parametric EQ. Drag each band between -12 dB and +12 dB. Equalizer and AI audio effects apply to songs, not radio." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parametrischer 10-Band-EQ. Jedes Band ist von −12 bis +12 dB einstellbar. Equalizer und KI-Audioeffekte gelten für Songs, nicht für Radio."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-band parametric EQ. Drag each band between -12 dB and +12 dB. Equalizer and AI audio effects apply to songs, not radio."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-kaistainen parametrinen taajuuskorjain. Säädä kaistoja välillä −12 ja +12 dB. Taajuuskorjain ja tekoälytehosteet koskevat kappaleita, eivät radiota."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Égaliseur paramétrique à 10 bandes, réglables de −12 à +12 dB. L’égaliseur et les effets audio IA s’appliquent aux titres, pas à la radio."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10バンドのパラメトリックEQ。各バンドを−12〜+12 dBで調整できます。イコライザとAIエフェクトは曲に適用され、ラジオには適用されません。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-смуговий параметричний еквалайзер. Кожна смуга регулюється від −12 до +12 дБ. Еквалайзер та ШІ-ефекти застосовуються до пісень, але не до радіо."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 段参数均衡器，每段可在 −12 至 +12 dB 之间调节。均衡器和 AI 音频效果适用于歌曲，不适用于电台。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 段參數等化器，每段可在 −12 至 +12 dB 之間調節。等化器和 AI 音訊效果適用於歌曲，不適用於電台。"
           }
         }
       }
@@ -5802,6 +2447,7 @@
 
     },
     "Add Favorite Songs" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -5854,6 +2500,7 @@
       }
     },
     "Add Playlist Songs" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -5967,6 +2614,7 @@
 
     },
     "Add songs to your library when you add them to playlists or favorite them. Sync keeps library changes available across this app on your devices." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -6236,6 +2884,8 @@
 
     },
     "AI Audio" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -6285,11 +2935,11 @@
             "value" : "AI 音訊"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "AI Audio Processing" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -6339,9 +2989,7 @@
             "value" : "AI 音訊處理"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "AirPlay" : {
       "localizations" : {
@@ -6447,6 +3095,60 @@
         }
       }
     },
+    "All offline downloads on this device will be removed." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Offline-Downloads auf diesem Gerät werden entfernt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All offline downloads on this device will be removed."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaikki tämän laitteen offline-lataukset poistetaan."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les téléchargements hors ligne de cet appareil seront supprimés."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスのオフラインダウンロードをすべて削除します。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Усі офлайн-завантаження на цьому пристрої буде видалено."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除此设备上的所有离线下载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除此裝置上的所有離線下載。"
+          }
+        }
+      }
+    },
     "All offline songs on this device will be removed. You can download them again from song menus." : {
       "localizations" : {
         "de" : {
@@ -6502,10 +3204,66 @@
     "All Videos" : {
 
     },
+    "Almost off" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fast aus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almost off"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lähes pois"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presque désactivé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ほぼオフ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Майже вимкнено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "几乎关闭"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "幾乎關閉"
+          }
+        }
+      }
+    },
     "Already added" : {
 
     },
     "Always Trigger" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -6555,11 +3313,11 @@
             "value" : "一律觸發"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Animated lyrics and transitions follow your motion preference." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -6609,9 +3367,7 @@
             "value" : "動態歌詞和過場動畫會遵循你的動態效果偏好。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Anyone can find it" : {
 
@@ -6620,6 +3376,8 @@
 
     },
     "Appearance" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -6669,9 +3427,7 @@
             "value" : "外觀"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Approving signs in %@ on the device showing this QR code." : {
       "localizations" : {
@@ -6940,6 +3696,8 @@
 
     },
     "Audio" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -6989,23 +3747,28 @@
             "value" : "音訊"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Audio Effects" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audioeffekte"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Audio Effects"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Audioeffekte"
+            "value" : "Äänitehosteet"
           }
         },
         "fr" : {
@@ -7018,12 +3781,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "オーディオエフェクト"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Äänitehosteet"
           }
         },
         "uk" : {
@@ -7044,10 +3801,11 @@
             "value" : "音訊效果"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Audio effects use on-device AI to separate vocals and instrumentals in real time. For best results, use headphones or external speakers." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7097,11 +3855,10 @@
             "value" : "音訊效果使用裝置端 AI 即時分離人聲和伴奏。建議使用耳機或外接揚聲器以獲得最佳效果。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Audio Quality" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7206,6 +3963,7 @@
       }
     },
     "Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7257,7 +4015,63 @@
         }
       }
     },
+    "Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose. Autoplay continues with account recommendations, or trending songs when recommendations are unavailable. These features do not apply to radio." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix mischt passende Songs automatisch. Crossfade nutzt die gewählte Dauer. Autoplay spielt Kontoempfehlungen oder beliebte Songs weiter. Diese Funktionen gelten nicht für Radio."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix blends compatible songs automatically. Crossfade uses the fixed duration you choose. Autoplay continues with account recommendations, or trending songs when recommendations are unavailable. These features do not apply to radio."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix yhdistää yhteensopivat kappaleet automaattisesti. Ristiinhäivytys käyttää valittua kestoa. Automaattinen toisto jatkuu tilin suosituksilla tai suosituilla kappaleilla, jos suosituksia ei ole. Toiminnot eivät koske radiota."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix mélange automatiquement les titres compatibles. Le fondu enchaîné utilise la durée choisie. La lecture automatique poursuit avec vos recommandations, ou des titres populaires à défaut. Ces fonctions ne s’appliquent pas à la radio."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mixは相性のよい曲を自動でミックスします。クロスフェードは指定した長さで切り替えます。自動再生はアカウントのおすすめ曲、取得できない場合は人気曲を再生します。ラジオには適用されません。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Mix автоматично змішує сумісні пісні. Перехресне згасання використовує вибрану тривалість. Автовідтворення продовжує рекомендованими для облікового запису або популярними піснями. Ці функції не застосовуються до радіо."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动混音会混合适合的歌曲。交叉淡化使用所选时长。自动播放会继续播放账号推荐歌曲；无法获取推荐时则播放热门歌曲。这些功能不适用于电台。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動混音會混合適合的歌曲。交叉淡化使用所選時長。自動播放會繼續播放帳號推薦歌曲；無法取得推薦時則播放熱門歌曲。這些功能不適用於電台。"
+          }
+        }
+      }
+    },
     "Auto-Analyze During Playback" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7307,11 +4121,11 @@
             "value" : "播放時自動分析"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Auto-Download Played Songs" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7361,11 +4175,64 @@
             "value" : "自動下載播放的歌曲"
           }
         }
-      },
+      }
+    },
+    "Autoplay" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatische Wiedergabe"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoplay"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automaattinen toisto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture automatique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動再生"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автовідтворення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动播放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動播放"
+          }
+        }
+      }
     },
     "Autoplay Similar Songs" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7418,6 +4285,8 @@
       }
     },
     "Available after background processing finishes for the current song." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7467,9 +4336,7 @@
             "value" : "目前歌曲的背景處理完成後即可使用。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Badges" : {
       "localizations" : {
@@ -7575,7 +4442,63 @@
         }
       }
     },
+    "Bass Boost" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bassverstärkung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bass Boost"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bassokorostus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basses renforcées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音強調"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підсилення басів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增強"
+          }
+        }
+      }
+    },
     "Bass Enhance" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7625,23 +4548,82 @@
             "value" : "低音增強"
           }
         }
-      },
+      }
+    },
+    "Bass Enhance Strength" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Bassverstärkung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bass Enhance Strength"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bassokorostuksen voimakkuus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force du renforcement des basses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音強調の強さ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сила підсилення басів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增强强度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低音增強強度"
+          }
+        }
+      }
     },
     "Behavior" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verhalten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Behavior"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verhalten"
+            "value" : "Toiminta"
           }
         },
         "fr" : {
@@ -7654,12 +4636,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "動作"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toiminta"
           }
         },
         "uk" : {
@@ -7680,8 +4656,7 @@
             "value" : "行為"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Best New Songs" : {
 
@@ -7842,6 +4817,168 @@
         }
       }
     },
+    "Cached artwork and images will be removed. They will download again as you use the app." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Bilder werden entfernt und bei Bedarf erneut geladen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached artwork and images will be removed. They will download again as you use the app."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välimuistin kuvat poistetaan. Ne ladataan tarvittaessa uudelleen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les illustrations et images en cache seront supprimées puis téléchargées à nouveau au besoin."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュされた画像を削除します。アプリの使用時に必要に応じて再ダウンロードされます。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кешовані зображення буде видалено. Вони завантажаться знову під час використання застосунку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除缓存的封面和图片，使用应用时会重新下载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除快取的封面和圖片，使用 App 時會重新下載。"
+          }
+        }
+      }
+    },
+    "Cached audio files and AI stems will be removed. Songs may buffer again the next time you play them." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Audiodateien und KI-Spuren werden entfernt. Songs müssen beim nächsten Abspielen eventuell erneut laden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached audio files and AI stems will be removed. Songs may buffer again the next time you play them."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välimuistin ääni ja tekoälyraidat poistetaan. Seuraava toisto voi vaatia puskurointia."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les fichiers audio et pistes IA en cache seront supprimés. Les titres pourront nécessiter un chargement à la prochaine écoute."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュされた音声とAI分離音源を削除します。次回再生時に読み込みが必要になる場合があります。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кешовані аудіофайли та ШІ-доріжки буде видалено. Під час наступного відтворення може знадобитися буферизація."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除缓存的音频文件和 AI 分离音轨。下次播放时可能需要重新缓冲。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除快取的音訊檔案和 AI 分離音軌。下次播放時可能需要重新緩衝。"
+          }
+        }
+      }
+    },
+    "Cached lyrics and lyric translations will be removed." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Liedtexte und Übersetzungen werden entfernt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached lyrics and lyric translations will be removed."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välimuistin sanoitukset ja käännökset poistetaan."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les paroles et leurs traductions en cache seront supprimées."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュされた歌詞と翻訳を削除します。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кешовані тексти пісень та переклади буде видалено."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将移除缓存的歌词和歌词翻译。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將移除快取的歌詞和歌詞翻譯。"
+          }
+        }
+      }
+    },
     "Camera Access Is Off" : {
       "localizations" : {
         "de" : {
@@ -7898,6 +5035,8 @@
 
     },
     "Cancel" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7947,9 +5086,7 @@
             "value" : "取消"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Cancel Download" : {
       "localizations" : {
@@ -8003,24 +5140,47 @@
         }
       }
     },
+    "Cancel Sleep Timer" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlaftimer abbrechen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel Sleep Timer"
+          }
+        }
+      }
+    },
     "Changes the language used on this watch." : {
 
     },
     "Characters" : {
       "comment" : "A section of the settings view that lists the characters that can spawn.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Figuren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Characters"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Figuren"
+            "value" : "Hahmot"
           }
         },
         "fr" : {
@@ -8033,12 +5193,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "キャラクター"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hahmot"
           }
         },
         "uk" : {
@@ -8059,8 +5213,7 @@
             "value" : "角色"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Check this code matches the one on your phone before approving." : {
 
@@ -8174,19 +5327,26 @@
     },
     "Choose which characters can spawn. They walk, climb, sit on the tab bar, and can be dragged around the screen." : {
       "comment" : "A footer for the characters section of the Shimeji settings.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle die Figuren, die erscheinen dürfen. Sie laufen, klettern, sitzen auf der Tableiste und lassen sich über den Bildschirm ziehen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Choose which characters can spawn. They walk, climb, sit on the tab bar, and can be dragged around the screen."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wähle die Figuren, die erscheinen dürfen. Sie laufen, klettern, sitzen auf der Tableiste und lassen sich über den Bildschirm ziehen."
+            "value" : "Valitse ilmestyvät hahmot. Ne kävelevät, kiipeävät, istuvat välilehtipalkilla ja niitä voi vetää näytöllä."
           }
         },
         "fr" : {
@@ -8199,12 +5359,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "出現するキャラクターを選びます。歩いたり登ったり、タブバーに座ったりします。ドラッグして移動することもできます。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valitse ilmestyvät hahmot. Ne kävelevät, kiipeävät, istuvat välilehtipalkilla ja niitä voi vetää näytöllä."
           }
         },
         "uk" : {
@@ -8225,8 +5379,61 @@
             "value" : "選擇可以產生的角色。它們會行走、攀爬、坐在標籤列上，也可以在螢幕上拖動。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
+    },
+    "Classical" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassik"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classical"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klassinen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クラシック"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Класична"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "古典"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "古典"
+          }
+        }
+      }
     },
     "Clear" : {
       "localizations" : {
@@ -8289,6 +5496,330 @@
     "Clear cached audio?" : {
 
     },
+    "Clear Image Cache" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildcache leeren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Image Cache"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä kuvavälimuisti"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache d’images"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像キャッシュを消去"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш зображень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除图片缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除圖片快取"
+          }
+        }
+      }
+    },
+    "Clear image cache?" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildcache leeren?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear image cache?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö kuvavälimuisti?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache d’images ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像キャッシュを消去しますか？"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш зображень?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除图片缓存？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除圖片快取？"
+          }
+        }
+      }
+    },
+    "Clear Lyrics Cache" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liedtextcache leeren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Lyrics Cache"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä sanoitusvälimuisti"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache des paroles"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞キャッシュを消去"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш текстів пісень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌词缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌詞快取"
+          }
+        }
+      }
+    },
+    "Clear lyrics cache?" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liedtextcache leeren?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear lyrics cache?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö sanoitusvälimuisti?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache des paroles ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞キャッシュを消去しますか？"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш текстів пісень?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌词缓存？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歌詞快取？"
+          }
+        }
+      }
+    },
+    "Clear Music Cache" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musikcache leeren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Music Cache"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä musiikkivälimuisti"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache musical"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音楽キャッシュを消去"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш музики"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音乐缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音樂快取"
+          }
+        }
+      }
+    },
+    "Clear music cache?" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musikcache leeren?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear music cache?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö musiikkivälimuisti?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache musical ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音楽キャッシュを消去しますか？"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити кеш музики?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音乐缓存？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除音樂快取？"
+          }
+        }
+      }
+    },
     "Clear queue" : {
       "localizations" : {
         "de" : {
@@ -8337,6 +5868,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清空佇列"
+          }
+        }
+      }
+    },
+    "Clear Recently Played" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabeverlauf löschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Recently Played"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä kuunteluhistoria"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer l’historique d’écoute"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生履歴を消去"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити історію прослуховувань"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放記錄"
+          }
+        }
+      }
+    },
+    "Clear recently played history?" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabeverlauf löschen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear recently played history?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennetäänkö kuunteluhistoria?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer l’historique d’écoute ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生履歴を消去しますか？"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистити історію прослуховувань?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放记录？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近播放記錄？"
           }
         }
       }
@@ -8447,17 +6086,24 @@
     },
     "Climbing" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klettern"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Climbing"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Klettern"
+            "value" : "Kiipeily"
           }
         },
         "fr" : {
@@ -8470,12 +6116,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登る"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiipeily"
           }
         },
         "uk" : {
@@ -8496,24 +6136,30 @@
             "value" : "攀爬"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Climbing lets them scale the screen edges instead of just turning around." : {
       "comment" : "A description of the climbing behavior of Shimeji.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt Figuren, an den Bildschirmrändern hochzuklettern."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Climbing lets them scale the screen edges instead of just turning around."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erlaubt Figuren, an den Bildschirmrändern hochzuklettern."
+            "value" : "Antaa hahmojen kiivetä näytön reunoja pitkin."
           }
         },
         "fr" : {
@@ -8526,12 +6172,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "キャラクターが画面の端を登れるようにします。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Antaa hahmojen kiivetä näytön reunoja pitkin."
           }
         },
         "uk" : {
@@ -8552,8 +6192,7 @@
             "value" : "允許角色沿螢幕邊緣攀爬。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Close" : {
       "localizations" : {
@@ -9090,6 +6729,114 @@
         }
       }
     },
+    "Could Not Clear Storage" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicher konnte nicht geleert werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could Not Clear Storage"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallennustilaa ei voitu tyhjentää"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de vider le stockage"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストレージを消去できませんでした"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося очистити сховище"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法清理存储"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法清理儲存空間"
+          }
+        }
+      }
+    },
+    "Could Not Enable Notifications" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitteilungen konnten nicht aktiviert werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could Not Enable Notifications"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ilmoituksia ei voitu ottaa käyttöön"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’activer les notifications"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知を有効にできませんでした"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося ввімкнути сповіщення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法启用通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法啟用通知"
+          }
+        }
+      }
+    },
     "Couldn’t add the song to “%@”. Try again." : {
 
     },
@@ -9399,6 +7146,8 @@
       }
     },
     "Crossfade Duration" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -9448,9 +7197,7 @@
             "value" : "交叉淡化時長"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Current song" : {
       "extractionState" : "stale",
@@ -9470,6 +7217,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Current user"
+          }
+        }
+      }
+    },
+    "Custom" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefiniert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mukautettu"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Власна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂"
           }
         }
       }
@@ -9526,7 +7327,63 @@
         }
       }
     },
+    "Dark" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dunkel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tumma"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダーク"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Темна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        }
+      }
+    },
     "Debug Logging" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -9576,9 +7433,7 @@
             "value" : "偵錯日誌"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Delete %lld Selected Songs" : {
 
@@ -9593,6 +7448,8 @@
 
     },
     "Developer" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -9642,11 +7499,11 @@
             "value" : "開發者"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Disable Developer Mode" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -9696,11 +7553,11 @@
             "value" : "停用開發者模式"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Disable developer mode?" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -9750,9 +7607,7 @@
             "value" : "停用開發者模式？"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Dismiss" : {
 
@@ -10495,6 +8350,8 @@
       }
     },
     "Download" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -10544,9 +8401,61 @@
             "value" : "下載"
           }
         }
-      },
+      }
+    },
+    "Download Notifications" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download-Mitteilungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download Notifications"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latausilmoitukset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications de téléchargement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード通知"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сповіщення про завантаження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載通知"
+          }
+        }
+      }
     },
     "Downloaded" : {
       "localizations" : {
@@ -10706,19 +8615,26 @@
     },
     "Downloading Shimeji pack…" : {
       "comment" : "A label displayed when the Shimeji resource pack is downloading.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-Paket wird geladen…"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Downloading Shimeji pack…"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Shimeji-Paket wird geladen…"
+            "value" : "Ladataan Shimeji-pakettia…"
           }
         },
         "fr" : {
@@ -10731,12 +8647,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "しめじパックをダウンロード中…"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ladataan Shimeji-pakettia…"
           }
         },
         "uk" : {
@@ -10757,10 +8667,11 @@
             "value" : "正在下載 Shimeji 套件…"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Downloads" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -10810,11 +8721,11 @@
             "value" : "下載"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Duration" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -10864,11 +8775,11 @@
             "value" : "時長"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Easter Eggs" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -10918,28 +8829,87 @@
             "value" : "彩蛋"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Edit Playlist" : {
 
     },
+    "Electronic" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elektronisch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Electronic"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elektroninen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Électronique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エレクトロニック"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Електронна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电子"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電子"
+          }
+        }
+      }
+    },
     "Enable" : {
       "comment" : "A button that enables an experimental feature.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enable"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktivieren"
+            "value" : "Ota käyttöön"
           }
         },
         "fr" : {
@@ -10952,12 +8922,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有効にする"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ota käyttöön"
           }
         },
         "uk" : {
@@ -10978,10 +8942,11 @@
             "value" : "啟用"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Enable AI Audio Processing to access vocal removal, bass enhance, and other AI-powered audio features." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -11031,9 +8996,7 @@
             "value" : "啟用 AI 音訊處理以使用人聲消除、低音增強等 AI 音訊功能。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Enable camera access in Settings to scan a sign-in code." : {
       "localizations" : {
@@ -11089,19 +9052,26 @@
     },
     "Enable Experiments" : {
       "comment" : "A toggle that enables or disables experimental features.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente aktivieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enable Experiments"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimente aktivieren"
+            "value" : "Ota kokeilut käyttöön"
           }
         },
         "fr" : {
@@ -11114,12 +9084,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実験的機能を有効にする"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ota kokeilut käyttöön"
           }
         },
         "uk" : {
@@ -11140,13 +9104,14 @@
             "value" : "啟用實驗功能"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Enter full screen" : {
 
     },
     "Equalizer" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -11196,28 +9161,33 @@
             "value" : "等化器"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Exit full screen" : {
 
     },
     "Experimental Themes" : {
       "comment" : "A toggle that enables experimental themes.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimentelle Designs"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Experimental Themes"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimentelle Designs"
+            "value" : "Kokeelliset teemat"
           }
         },
         "fr" : {
@@ -11230,12 +9200,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実験的テーマ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kokeelliset teemat"
           }
         },
         "uk" : {
@@ -11256,24 +9220,30 @@
             "value" : "實驗性主題"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Experimental Themes adds early, in-progress themes to the theme picker above. Shimeji adds tiny animated characters that wander around on top of the app." : {
       "comment" : "A description of the experimental features that can be enabled in the settings.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimentelle Designs ergänzt den Designwähler um unfertige Designs. Shimeji zeigt kleine animierte Figuren über der App."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Experimental Themes adds early, in-progress themes to the theme picker above. Shimeji adds tiny animated characters that wander around on top of the app."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimentelle Designs ergänzt den Designwähler um unfertige Designs. Shimeji zeigt kleine animierte Figuren über der App."
+            "value" : "Kokeelliset teemat lisäävät keskeneräisiä teemoja valikkoon. Shimeji lisää sovelluksen päällä liikkuvia pieniä hahmoja."
           }
         },
         "fr" : {
@@ -11286,12 +9256,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実験的テーマを有効にすると、開発中のテーマが選択肢に追加されます。しめじはアプリ上を歩き回る小さなキャラクターを表示します。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kokeelliset teemat lisäävät keskeneräisiä teemoja valikkoon. Shimeji lisää sovelluksen päällä liikkuvia pieniä hahmoja."
           }
         },
         "uk" : {
@@ -11312,24 +9276,30 @@
             "value" : "實驗性主題會在上方主題選擇器中加入開發中的主題。Shimeji 會在 App 上方顯示四處走動的小型動畫角色。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Experiments" : {
       "comment" : "A section in the settings view that lets users enable or disable experimental features.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Experiments"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimente"
+            "value" : "Kokeilut"
           }
         },
         "fr" : {
@@ -11342,12 +9312,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実験的機能"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kokeilut"
           }
         },
         "uk" : {
@@ -11368,24 +9332,30 @@
             "value" : "實驗功能"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Experiments are early, unfinished features. They may be unstable, change without notice, or be removed in a future update." : {
       "comment" : "A description of the effects of enabling experiments.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente sind frühe, unfertige Funktionen. Sie können instabil sein, sich ohne Vorankündigung ändern oder später entfernt werden."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Experiments are early, unfinished features. They may be unstable, change without notice, or be removed in a future update."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimente sind frühe, unfertige Funktionen. Sie können instabil sein, sich ohne Vorankündigung ändern oder später entfernt werden."
+            "value" : "Kokeilut ovat keskeneräisiä toimintoja. Ne voivat olla epävakaita, muuttua ilmoittamatta tai poistua myöhemmässä päivityksessä."
           }
         },
         "fr" : {
@@ -11398,12 +9368,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実験的機能は開発途中です。不安定な場合があり、予告なく変更されたり、今後の更新で削除されたりすることがあります。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kokeilut ovat keskeneräisiä toimintoja. Ne voivat olla epävakaita, muuttua ilmoittamatta tai poistua myöhemmässä päivityksessä."
           }
         },
         "uk" : {
@@ -11424,8 +9388,7 @@
             "value" : "實驗功能尚未完成，可能不穩定、隨時變更，或在後續更新中移除。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Explore" : {
       "localizations" : {
@@ -11532,6 +9495,8 @@
       }
     },
     "Export Debug Logs" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -11581,9 +9546,7 @@
             "value" : "匯出偵錯日誌"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Favorite" : {
       "localizations" : {
@@ -12016,6 +9979,60 @@
     "Find Songs" : {
 
     },
+    "Flat" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neutral"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flat"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tasainen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neutre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フラット"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рівна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平直"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平直"
+          }
+        }
+      }
+    },
     "Follow the artist gallery for new covers as they arrive." : {
       "localizations" : {
         "de" : {
@@ -12282,17 +10299,24 @@
     },
     "Haptic Feedback" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptisches Feedback"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Haptic Feedback"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Haptisches Feedback"
+            "value" : "Värinäpalaute"
           }
         },
         "fr" : {
@@ -12305,12 +10329,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "触覚フィードバック"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Värinäpalaute"
           }
         },
         "uk" : {
@@ -12331,22 +10349,28 @@
             "value" : "觸覺回饋"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Haptics" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptik"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Haptics"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Haptik"
+            "value" : "Värinä"
           }
         },
         "fr" : {
@@ -12359,12 +10383,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "触覚"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Värinä"
           }
         },
         "uk" : {
@@ -12385,8 +10403,61 @@
             "value" : "觸覺"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
+    },
+    "Heavy" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sehr stark"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heavy"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erittäin voimakas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Très fort"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非常に強い"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дуже сильна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "很强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "很強"
+          }
+        }
+      }
     },
     "Hidden" : {
       "localizations" : {
@@ -12649,6 +10720,7 @@
       }
     },
     "High Efficiency" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -12701,6 +10773,7 @@
       }
     },
     "High Quality" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -12748,6 +10821,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高音質"
+          }
+        }
+      }
+    },
+    "Hip-Hop" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-Hop"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-Hop"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-hop"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hip-hop"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヒップホップ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хіп-хоп"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "嘻哈"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "嘻哈"
           }
         }
       }
@@ -12856,7 +10983,63 @@
         }
       }
     },
+    "Image Cache" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildcache"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image Cache"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kuvavälimuisti"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache d’images"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像キャッシュ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кеш зображень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖片快取"
+          }
+        }
+      }
+    },
     "Instrumental Enhance" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -12906,9 +11089,61 @@
             "value" : "伴奏增強"
           }
         }
-      },
+      }
+    },
+    "Instrumental Enhance Strength" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Instrumentenverstärkung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instrumental Enhance Strength"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Säestyksen korostuksen voimakkuus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force du renforcement instrumental"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伴奏強調の強さ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сила підсилення інструменталу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伴奏增强强度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伴奏增強強度"
+          }
+        }
+      }
     },
     "Internal Testing & Metadata" : {
       "localizations" : {
@@ -13120,6 +11355,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "歡迎在 GitHub 上提交 Issue 和 Pull Request。本儲存庫包含建置指南以及專案的程式碼規範。"
+          }
+        }
+      }
+    },
+    "Jazz" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jazz"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジャズ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Джаз"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "爵士"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "爵士"
           }
         }
       }
@@ -13496,6 +11785,8 @@
       }
     },
     "Language" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -13545,9 +11836,7 @@
             "value" : "語言"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Language Support" : {
 
@@ -13821,6 +12110,60 @@
         }
       }
     },
+    "Light" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leicht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kevyt"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Léger"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弱"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Легка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輕"
+          }
+        }
+      }
+    },
     "Listen Live" : {
 
     },
@@ -13872,6 +12215,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "立即聆聽"
+          }
+        }
+      }
+    },
+    "Listening history on this device" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabeverlauf auf diesem Gerät"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listening history on this device"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tämän laitteen kuunteluhistoria"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historique d’écoute sur cet appareil"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスの再生履歴"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Історія прослуховувань на цьому пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的播放记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此裝置上的播放記錄"
           }
         }
       }
@@ -15049,6 +13446,8 @@
       }
     },
     "Logging" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -15098,11 +13497,10 @@
             "value" : "日誌"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Lossless" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -15150,6 +13548,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無損音質"
+          }
+        }
+      }
+    },
+    "Loudness" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loudness"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loudness"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loudness"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correction physiologique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラウドネス"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тонкомпенсація"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "响度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "響度"
           }
         }
       }
@@ -15207,6 +13659,8 @@
       }
     },
     "Lyrics" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -15256,12 +13710,172 @@
             "value" : "歌詞"
           }
         }
-      },
+      }
+    },
+    "Lyrics Cache" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liedtextcache"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyrics Cache"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sanoitusvälimuisti"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache des paroles"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞キャッシュ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кеш текстів пісень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌词缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞快取"
+          }
+        }
+      }
     },
     "Made for You" : {
 
+    },
+    "Maximum" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suurin"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимум"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        }
+      }
+    },
+    "Medium" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mittel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medium"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keskitaso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moyen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Середня"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        }
+      }
     },
     "More" : {
       "localizations" : {
@@ -15478,6 +14092,8 @@
       }
     },
     "Music" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -15527,9 +14143,61 @@
             "value" : "音樂"
           }
         }
-      },
+      }
+    },
+    "Music Cache" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musikcache"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Music Cache"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Musiikkivälimuisti"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache musical"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音楽キャッシュ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кеш музики"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音乐缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音樂快取"
+          }
+        }
+      }
     },
     "NEUROKARAOKE.COM • EVILKARAOKE.COM • TWINSKARAOKE.COM" : {
       "localizations" : {
@@ -16340,17 +15008,24 @@
     },
     "Not downloaded" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht heruntergeladen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Not downloaded"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nicht heruntergeladen"
+            "value" : "Ei ladattu"
           }
         },
         "fr" : {
@@ -16363,12 +15038,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未ダウンロード"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei ladattu"
           }
         },
         "uk" : {
@@ -16389,8 +15058,7 @@
             "value" : "未下載"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Not signed in" : {
       "extractionState" : "stale",
@@ -16446,6 +15114,8 @@
       }
     },
     "Notifications" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -16495,9 +15165,115 @@
             "value" : "通知"
           }
         }
-      },
+      }
+    },
+    "Notifications are disabled in system settings. Allow notifications there to receive download updates." : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitteilungen sind in den Systemeinstellungen deaktiviert. Aktiviere sie dort für Download-Mitteilungen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications are disabled in system settings. Allow notifications there to receive download updates."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ilmoitukset on poistettu käytöstä järjestelmäasetuksissa. Salli ne saadaksesi latausilmoituksia."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les notifications sont désactivées dans les réglages système. Autorisez-les pour recevoir les mises à jour des téléchargements."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム設定で通知が無効になっています。ダウンロード通知を受け取るには、そこで通知を許可してください。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сповіщення вимкнено в системних налаштуваннях. Дозвольте їх, щоб отримувати сповіщення про завантаження."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统设置中已禁用通知。请在其中允许通知，以接收下载更新。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統設定中已停用通知。請在其中允許通知，以接收下載更新。"
+          }
+        }
+      }
+    },
+    "Notify when downloads finish while the app is in the background." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benachrichtigt, wenn Downloads abgeschlossen sind und die App im Hintergrund ist."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notify when downloads finish while the app is in the background."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ilmoita latausten valmistumisesta sovelluksen ollessa taustalla."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recevoir une notification à la fin des téléchargements lorsque l’app est en arrière-plan."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリがバックグラウンドのときにダウンロード完了を通知します。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сповіщати про завершення завантажень, коли застосунок у фоні."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用在后台时，下载完成后发送通知。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App 在背景執行時，下載完成後傳送通知。"
+          }
+        }
+      }
     },
     "Now playing" : {
       "localizations" : {
@@ -16603,6 +15379,60 @@
         }
       }
     },
+    "Nwero" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        }
+      }
+    },
     "Off" : {
       "localizations" : {
         "de" : {
@@ -16655,16 +15485,77 @@
         }
       }
     },
+    "Offline songs on this device" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Songs auf diesem Gerät"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline songs on this device"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tämän laitteen offline-kappaleet"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titres hors ligne sur cet appareil"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスのオフライン曲"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн-пісні на цьому пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的离线歌曲"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此裝置上的離線歌曲"
+          }
+        }
+      }
+    },
     "OK" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
@@ -16677,12 +15568,6 @@
           }
         },
         "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "fi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
@@ -16706,8 +15591,7 @@
             "value" : "好"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "On" : {
       "localizations" : {
@@ -16867,19 +15751,26 @@
     },
     "On Screen At Once" : {
       "comment" : "A label displayed in a stepper that shows the number of Shimeji that can be on screen at once.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gleichzeitig auf dem Bildschirm"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "On Screen At Once"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gleichzeitig auf dem Bildschirm"
+            "value" : "Näytöllä kerrallaan"
           }
         },
         "fr" : {
@@ -16892,12 +15783,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同時に表示する数"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytöllä kerrallaan"
           }
         },
         "uk" : {
@@ -16918,8 +15803,7 @@
             "value" : "同時顯示數量"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Only you can edit this playlist" : {
       "localizations" : {
@@ -17024,6 +15908,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟 %@"
+          }
+        }
+      }
+    },
+    "Open Notification Settings" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitteilungseinstellungen öffnen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Notification Settings"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avaa ilmoitusasetukset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir les réglages des notifications"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知設定を開く"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відкрити налаштування сповіщень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开通知设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟通知設定"
           }
         }
       }
@@ -19084,6 +18022,60 @@
     "Plays this video from the beginning" : {
 
     },
+    "Please try again." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitte erneut versuchen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please try again."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yritä uudelleen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veuillez réessayer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "もう一度お試しください。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спробуйте ще раз."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請重試。"
+          }
+        }
+      }
+    },
     "Point the camera at the QR code shown on twinskaraoke.com." : {
       "localizations" : {
         "de" : {
@@ -19136,21 +18128,82 @@
         }
       }
     },
+    "Pop" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pop"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ポップ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поп"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流行"
+          }
+        }
+      }
+    },
     "Population" : {
       "comment" : "A section in the Shimeji settings view that allows the user to adjust the number of Shimeji that can be on screen at once.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anzahl"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Population"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anzahl"
+            "value" : "Määrä"
           }
         },
         "fr" : {
@@ -19163,12 +18216,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Määrä"
           }
         },
         "uk" : {
@@ -19189,10 +18236,11 @@
             "value" : "數量"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Powered by on-device AI. Audio is separated into vocals and instrumentals using a neural network model." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -19242,11 +18290,10 @@
             "value" : "由裝置端 AI 驅動，使用神經網路模型將音訊分離為人聲和伴奏。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Preferences are saved on this device and use the same account settings style as Music." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -19358,6 +18405,8 @@
 
     },
     "Preset" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -19407,9 +18456,7 @@
             "value" : "預設"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Previous" : {
 
@@ -20926,6 +19973,8 @@
 
     },
     "Removal Level" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -20975,9 +20024,7 @@
             "value" : "消除程度"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Remove" : {
       "localizations" : {
@@ -21031,7 +20078,63 @@
         }
       }
     },
+    "Remove All Downloads" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Downloads entfernen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove All Downloads"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poista kaikki lataukset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer tous les téléchargements"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのダウンロードを削除"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити всі завантаження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所有下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所有下載"
+          }
+        }
+      }
+    },
     "Remove all downloads?" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -21081,9 +20184,7 @@
             "value" : "移除所有下載？"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Remove Download" : {
       "localizations" : {
@@ -21139,19 +20240,26 @@
     },
     "Remove Downloaded Pack" : {
       "comment" : "A button that deletes the downloaded Shimeji resource pack.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladenes Paket entfernen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Remove Downloaded Pack"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Heruntergeladenes Paket entfernen"
+            "value" : "Poista ladattu paketti"
           }
         },
         "fr" : {
@@ -21164,12 +20272,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロード済みパックを削除"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista ladattu paketti"
           }
         },
         "uk" : {
@@ -21190,8 +20292,7 @@
             "value" : "移除已下載的套件"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Remove Downloads" : {
       "localizations" : {
@@ -21628,6 +20729,8 @@
       }
     },
     "Reset Equalizer" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -21677,25 +20780,30 @@
             "value" : "重設等化器"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Resource Pack" : {
       "comment" : "The title of the section that displays the current state of the resource pack.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ressourcenpaket"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resource Pack"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ressourcenpaket"
+            "value" : "Resurssipaketti"
           }
         },
         "fr" : {
@@ -21708,12 +20816,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "リソースパック"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resurssipaketti"
           }
         },
         "uk" : {
@@ -21734,8 +20836,7 @@
             "value" : "資源包"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Resources" : {
       "localizations" : {
@@ -21791,19 +20892,26 @@
     },
     "Respawn clears everyone currently on screen and brings in a fresh set." : {
       "comment" : "A description of the \"Respawn\" button.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ersetzt alle Figuren auf dem Bildschirm durch eine neue Auswahl."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Respawn clears everyone currently on screen and brings in a fresh set."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ersetzt alle Figuren auf dem Bildschirm durch eine neue Auswahl."
+            "value" : "Korvaa kaikki näytöllä olevat hahmot uudella joukolla."
           }
         },
         "fr" : {
@@ -21816,12 +20924,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "画面上のキャラクターを消し、新しい組み合わせで再出現させます。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Korvaa kaikki näytöllä olevat hahmot uudella joukolla."
           }
         },
         "uk" : {
@@ -21842,24 +20944,30 @@
             "value" : "重新產生會清除螢幕上的所有角色，並產生一組新角色。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Respawn Now" : {
       "comment" : "A button that respawns all Shimeji characters.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt neu erscheinen lassen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Respawn Now"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Jetzt neu erscheinen lassen"
+            "value" : "Luo hahmot uudelleen"
           }
         },
         "fr" : {
@@ -21872,12 +20980,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "再出現させる"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luo hahmot uudelleen"
           }
         },
         "uk" : {
@@ -21898,10 +21000,11 @@
             "value" : "立即重新產生"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Respect Reduce Motion" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -21951,9 +21054,7 @@
             "value" : "遵循「減少動態效果」"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Results for \"%@\"" : {
       "localizations" : {
@@ -22269,6 +21370,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示完整的訪客ID"
+          }
+        }
+      }
+    },
+    "Rock" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rock"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロック"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рок"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摇滚"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搖滾"
           }
         }
       }
@@ -23023,19 +22178,26 @@
     },
     "Setting up…" : {
       "comment" : "A message displayed when the Shimeji resource pack is being set up.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird eingerichtet…"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Setting up…"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wird eingerichtet…"
+            "value" : "Valmistellaan…"
           }
         },
         "fr" : {
@@ -23048,12 +22210,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定中…"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valmistellaan…"
           }
         },
         "uk" : {
@@ -23074,10 +22230,11 @@
             "value" : "正在設定…"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Settings" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -23127,9 +22284,7 @@
             "value" : "設定"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Share artwork" : {
       "extractionState" : "stale",
@@ -23342,16 +22497,23 @@
     },
     "Shimeji" : {
       "comment" : "A toggle that enables Shimeji, a feature that adds tiny animated characters that wander around on top of the app.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shimeji"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shimeji"
@@ -23367,12 +22529,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "しめじ"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shimeji"
           }
         },
         "uk" : {
@@ -23393,24 +22549,30 @@
             "value" : "Shimeji"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Shimeji Characters" : {
       "comment" : "A label for a view that lets users configure Shimeji.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-Figuren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shimeji Characters"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Shimeji-Figuren"
+            "value" : "Shimeji-hahmot"
           }
         },
         "fr" : {
@@ -23423,12 +22585,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "しめじキャラクター"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shimeji-hahmot"
           }
         },
         "uk" : {
@@ -23449,24 +22605,30 @@
             "value" : "Shimeji 角色"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Shimeji characters and animations are downloaded separately from the app so new ones can be added later." : {
       "comment" : "A description of the Shimeji resource pack.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shimeji-Figuren und Animationen werden separat geladen, damit später neue hinzukommen können."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shimeji characters and animations are downloaded separately from the app so new ones can be added later."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Shimeji-Figuren und Animationen werden separat geladen, damit später neue hinzukommen können."
+            "value" : "Shimeji-hahmot ja animaatiot ladataan erikseen, jotta niitä voidaan lisätä myöhemmin."
           }
         },
         "fr" : {
@@ -23479,12 +22641,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "しめじのキャラクターとアニメーションは、後から追加できるようアプリとは別にダウンロードします。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shimeji-hahmot ja animaatiot ladataan erikseen, jotta niitä voidaan lisätä myöhemmin."
           }
         },
         "uk" : {
@@ -23505,8 +22661,7 @@
             "value" : "Shimeji 角色和動畫獨立於 App 下載，以便之後加入新內容。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Show Less" : {
 
@@ -25107,6 +24262,146 @@
         }
       }
     },
+    "Sleep Timer" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlaftimer"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sleep Timer"
+          }
+        }
+      }
+    },
+    "Sleep timer remaining" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbleibende Zeit des Schlaftimers"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sleep timer remaining"
+          }
+        }
+      }
+    },
+    "Some files could not be removed. Please try again." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einige Dateien konnten nicht entfernt werden. Bitte erneut versuchen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some files could not be removed. Please try again."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Joitakin tiedostoja ei voitu poistaa. Yritä uudelleen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certains fichiers n’ont pas pu être supprimés. Veuillez réessayer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のファイルを削除できませんでした。もう一度お試しください。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Деякі файли не вдалося видалити. Спробуйте ще раз."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分文件无法移除。请重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分檔案無法移除。請重試。"
+          }
+        }
+      }
+    },
+    "Some songs could not be downloaded. Open the app to retry." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einige Songs konnten nicht geladen werden. Öffne die App, um es erneut zu versuchen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some songs could not be downloaded. Open the app to retry."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Joitakin kappaleita ei voitu ladata. Avaa sovellus ja yritä uudelleen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certains titres n’ont pas pu être téléchargés. Ouvrez l’app pour réessayer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部の曲をダウンロードできませんでした。アプリを開いて再試行してください。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Деякі пісні не вдалося завантажити. Відкрийте застосунок і спробуйте знову."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分歌曲无法下载。请打开应用重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分歌曲無法下載。請開啟 App 重試。"
+          }
+        }
+      }
+    },
     "Something went wrong" : {
 
     },
@@ -25718,6 +25013,8 @@
 
     },
     "Storage" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -25767,14 +25064,14 @@
             "value" : "儲存空間"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Storage & Limits" : {
 
     },
     "Strength" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -25824,11 +25121,65 @@
             "value" : "強度"
           }
         }
-      },
+      }
+    },
+    "Strong" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stark"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strong"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voimakas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fort"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сильна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強"
+          }
+        }
+      }
     },
     "Swipe up or down to adjust this band by one decibel." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -25878,9 +25229,7 @@
             "value" : "向上或向下滑動可將此頻段調節一分貝。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Swipe up or down to adjust vocal removal." : {
       "localizations" : {
@@ -25935,6 +25284,8 @@
       }
     },
     "Swipe up or down to adjust." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -25984,9 +25335,7 @@
             "value" : "向上或向下滑動以調節。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Swipe up or down to seek by 15 seconds." : {
       "localizations" : {
@@ -26097,6 +25446,7 @@
       }
     },
     "Sync Library" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26148,10 +25498,65 @@
         }
       }
     },
+    "System" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Järjestelmä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Système"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟随系统"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟隨系統"
+          }
+        }
+      }
+    },
     "Take-Down Requests" : {
 
     },
     "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 2 GB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26203,19 +25608,80 @@
         }
       }
     },
+    "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 64 MB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe auf eine Anzeige, um den Cache zu leeren. Limits: Bilder 2 GB, Musik einschließlich KI-Spuren 4 GB, Liedtexte 64 MB. Einträge über 6 Monate werden automatisch entfernt. Downloads sind ausgenommen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap an indicator to clear that cache. Image cache is limited to 2 GB, music cache (including AI stems) to 4 GB, and lyrics cache to 64 MB. Items older than 6 months are automatically cleaned. Downloads are exempt from these limits."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tyhjennä välimuisti napauttamalla sen riviä. Rajat: kuvat 2 Gt, musiikki ja tekoälyraidat 4 Gt, sanoitukset 64 Mt. Yli 6 kuukauden ikäiset kohteet poistetaan automaattisesti. Rajat eivät koske latauksia."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touchez un indicateur pour vider le cache. Limites : images 2 Go, musique avec pistes IA 4 Go, paroles 64 Mo. Les éléments de plus de 6 mois sont supprimés automatiquement. Les téléchargements sont exclus."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目をタップするとキャッシュを消去します。上限は画像2 GB、AI分離音源を含む音楽4 GB、歌詞64 MBです。6か月を超えた項目は自動削除されます。ダウンロードは対象外です。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Торкніться показника, щоб очистити кеш. Ліміти: зображення — 2 ГБ, музика зі ШІ-доріжками — 4 ГБ, тексти — 64 МБ. Дані старші за 6 місяців видаляються автоматично. Завантаження не обмежуються цими лімітами."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点按项目可清除相应缓存。图片缓存上限为 2 GB，音乐缓存（包括 AI 分离音轨）为 4 GB，歌词缓存为 64 MB。超过 6 个月的项目会自动清理。离线下载不受这些限制。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按項目可清除相應快取。圖片快取上限為 2 GB，音樂快取（包括 AI 分離音軌）為 4 GB，歌詞快取為 64 MB。超過 6 個月的項目會自動清理。離線下載不受這些限制。"
+          }
+        }
+      }
+    },
     "Taps, swipes and controls answer back with a vibration." : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippen, Wischen und Bedienelemente geben eine Vibration zurück."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Taps, swipes and controls answer back with a vibration."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tippen, Wischen und Bedienelemente geben eine Vibration zurück."
+            "value" : "Napautukset, pyyhkäisyt ja säätimet antavat värinäpalautetta."
           }
         },
         "fr" : {
@@ -26228,12 +25694,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "タップやスワイプ、操作に振動で反応します。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Napautukset, pyyhkäisyt ja säätimet antavat värinäpalautetta."
           }
         },
         "uk" : {
@@ -26254,22 +25714,28 @@
             "value" : "點按、滑動和控制項操作會提供震動回饋。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Taps, swipes and controls answer back with a vibration. Strength sets how hard they land — each control keeps its own character at every level." : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippen, Wischen und Bedienelemente geben eine Vibration zurück. Die Stärke bestimmt die Intensität; jede Aktion behält ihren eigenen Charakter."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Taps, swipes and controls answer back with a vibration. Strength sets how hard they land — each control keeps its own character at every level."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tippen, Wischen und Bedienelemente geben eine Vibration zurück. Die Stärke bestimmt die Intensität; jede Aktion behält ihren eigenen Charakter."
+            "value" : "Napautukset, pyyhkäisyt ja säätimet antavat värinäpalautetta. Voimakkuus säätää tehoa ja säilyttää kunkin toiminnon oman tuntuman."
           }
         },
         "fr" : {
@@ -26282,12 +25748,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "タップやスワイプ、操作に振動で反応します。強さを変えても、それぞれの操作に固有の振動パターンは維持されます。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Napautukset, pyyhkäisyt ja säätimet antavat värinäpalautetta. Voimakkuus säätää tehoa ja säilyttää kunkin toiminnon oman tuntuman."
           }
         },
         "uk" : {
@@ -26308,8 +25768,7 @@
             "value" : "點按、滑動和控制項操作會提供震動回饋。強度決定震動的力道，同時保留各控制項獨有的觸感。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Tech Stack" : {
       "localizations" : {
@@ -26364,6 +25823,8 @@
       }
     },
     "The developer menu and related features will be hidden until you turn developer mode back on." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26413,9 +25874,7 @@
             "value" : "重新啟用開發者模式前，將隱藏開發者選單和相關功能，並關閉偵錯日誌。"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "The live station isn't reachable right now." : {
 
@@ -26476,6 +25935,8 @@
       }
     },
     "Theme" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26525,9 +25986,223 @@
             "value" : "主題"
           }
         }
-      },
+      }
+    },
+    "Theme.dark" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dunkel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tumma"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダーク"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Темна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        }
+      }
+    },
+    "Theme.light" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hell"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaalea"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clair"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライト"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Світла"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浅色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "淺色"
+          }
+        }
+      }
+    },
+    "Theme.nwero" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nwero"
+          }
+        }
+      }
+    },
+    "Theme.system" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Järjestelmä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Système"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟随系统"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟隨系統"
+          }
+        }
+      }
     },
     "There's nothing loaded to play on this watch." : {
 
@@ -26592,6 +26267,60 @@
     },
     "Top Picks for You" : {
 
+    },
+    "Treble Boost" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Höhenverstärkung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Treble Boost"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diskanttikorostus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aigus renforcés"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高音強調"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підсилення високих частот"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高音增强"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高音增強"
+          }
+        }
+      }
     },
     "Trending" : {
       "localizations" : {
@@ -26699,17 +26428,24 @@
     },
     "Try Again" : {
       "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erneut versuchen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Try Again"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erneut versuchen"
+            "value" : "Yritä uudelleen"
           }
         },
         "fr" : {
@@ -26722,12 +26458,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "再試行"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yritä uudelleen"
           }
         },
         "uk" : {
@@ -26748,8 +26478,7 @@
             "value" : "重試"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Try another song title or artist." : {
 
@@ -26818,6 +26547,8 @@
       }
     },
     "Turn On" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26867,11 +26598,11 @@
             "value" : "開啟"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Turn on auto-analyze during playback?" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26921,25 +26652,30 @@
             "value" : "開啟播放時自動分析？"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Turn on Experiments to access early, in-progress features before they're finished." : {
       "comment" : "A footer for the \"Experiments\" section of the settings view.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiviere Experimente, um Funktionen schon während ihrer Entwicklung zu nutzen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Turn on Experiments to access early, in-progress features before they're finished."
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktiviere Experimente, um Funktionen schon während ihrer Entwicklung zu nutzen."
+            "value" : "Ota kokeilut käyttöön kokeillaksesi keskeneräisiä toimintoja."
           }
         },
         "fr" : {
@@ -26952,12 +26688,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実験的機能を有効にすると、開発途中の機能を試せます。"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ota kokeilut käyttöön kokeillaksesi keskeneräisiä toimintoja."
           }
         },
         "uk" : {
@@ -26978,24 +26708,30 @@
             "value" : "啟用實驗功能以體驗尚在開發中的功能。"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Turn On Experiments?" : {
       "comment" : "A button that turns on experimental features.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimente aktivieren?"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Turn On Experiments?"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimente aktivieren?"
+            "value" : "Otetaanko kokeilut käyttöön?"
           }
         },
         "fr" : {
@@ -27008,12 +26744,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実験的機能を有効にしますか？"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otetaanko kokeilut käyttöön?"
           }
         },
         "uk" : {
@@ -27034,8 +26764,7 @@
             "value" : "啟用實驗功能？"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Turn the Digital Crown or swipe up and down to adjust." : {
       "extractionState" : "stale",
@@ -27796,19 +27525,26 @@
     },
     "Use All" : {
       "comment" : "A button that selects all characters to spawn.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle verwenden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Use All"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alle verwenden"
+            "value" : "Käytä kaikkia"
           }
         },
         "fr" : {
@@ -27821,12 +27557,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "すべて使用"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Käytä kaikkia"
           }
         },
         "uk" : {
@@ -27847,24 +27577,30 @@
             "value" : "全部啟用"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Use None" : {
       "comment" : "A button that clears all characters from the list.",
-      "isCommentAutoGenerated" : true,
       "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "isCommentAutoGenerated" : true,
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine verwenden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Use None"
           }
         },
-        "de" : {
+        "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Keine verwenden"
+            "value" : "Älä käytä mitään"
           }
         },
         "fr" : {
@@ -27877,12 +27613,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "すべて無効"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Älä käytä mitään"
           }
         },
         "uk" : {
@@ -27903,8 +27633,7 @@
             "value" : "全部停用"
           }
         }
-      },
-      "generatesSymbol" : false
+      }
     },
     "Use the playback controls below." : {
       "localizations" : {
@@ -28385,7 +28114,63 @@
         }
       }
     },
+    "Vocal" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesang"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vocal"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laulu"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voix"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボーカル"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вокал"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人声"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人聲"
+          }
+        }
+      }
+    },
     "Vocal Enhance" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -28435,11 +28220,65 @@
             "value" : "人聲增強"
           }
         }
-      },
+      }
+    },
+    "Vocal Enhance Strength" : {
       "extractionState" : "manual",
-      "generatesSymbol" : false
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Gesangsverstärkung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vocal Enhance Strength"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laulukorostuksen voimakkuus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force du renforcement de la voix"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボーカル強調の強さ"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сила підсилення вокалу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人声增强强度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人聲增強強度"
+          }
+        }
+      }
     },
     "Vocal Removal" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -28489,9 +28328,7 @@
             "value" : "人聲消除"
           }
         }
-      },
-      "extractionState" : "manual",
-      "generatesSymbol" : false
+      }
     },
     "Vocal removal controls" : {
 
@@ -28544,6 +28381,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "人聲消除強度"
+          }
+        }
+      }
+    },
+    "Vocal Removal Level" : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärke der Gesangsentfernung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vocal Removal Level"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laulun poiston voimakkuus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau de suppression de la voix"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボーカル除去レベル"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рівень видалення вокалу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人声消除程度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人聲消除程度"
           }
         }
       }
@@ -28616,6 +28507,7 @@
 
     },
     "When enabled, songs you play are saved for offline listening." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -28663,6 +28555,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "啟用此功能後播放的歌曲將會儲存以供離線聆聽"
+          }
+        }
+      }
+    },
+    "When enabled, the current song and songs you play next are saved for offline listening. This may use cellular data. Turning this off leaves existing downloads and downloads already in progress intact." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichert den aktuellen Song und danach gespielte Songs zum Offline-Hören. Dabei können mobile Daten verwendet werden. Ausschalten behält vorhandene und bereits laufende Downloads bei."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When enabled, the current song and songs you play next are saved for offline listening. This may use cellular data. Turning this off leaves existing downloads and downloads already in progress intact."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallentaa nykyisen ja seuraavaksi toistettavat kappaleet offline-kuuntelua varten. Tämä voi käyttää mobiilidataa. Pois kytkeminen säilyttää valmiit ja käynnissä olevat lataukset."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistre le titre actuel et les suivants pour une écoute hors ligne. Cela peut utiliser les données mobiles. La désactivation conserve les téléchargements existants et ceux en cours."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効にすると、現在の曲と次に再生する曲をオフライン用に保存します。モバイルデータを使用する場合があります。無効にしても、保存済みや進行中のダウンロードはそのまま残ります。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зберігає поточну й наступні пісні для офлайн-прослуховування. Можливе використання мобільних даних. Вимкнення зберігає наявні й уже розпочаті завантаження."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后会保存当前及之后播放的歌曲，供离线收听。这可能使用蜂窝数据。关闭不会移除已有下载或取消正在进行的下载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後會儲存目前及之後播放的歌曲，供離線聆聽。這可能使用行動數據。關閉不會移除已有下載或取消正在進行的下載。"
           }
         }
       }
@@ -28889,6 +28835,114 @@
     },
     "Your karaoke profile,\nright on Apple TV." : {
 
+    },
+    "Your recently played history will be removed from this device." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Wiedergabeverlauf wird von diesem Gerät entfernt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your recently played history will be removed from this device."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kuunteluhistoria poistetaan tältä laitteelta."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre historique d’écoute sera supprimé de cet appareil."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスの再生履歴を削除します。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Історію прослуховувань буде видалено з цього пристрою."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将从此设备移除最近播放记录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將從此裝置移除最近播放記錄。"
+          }
+        }
+      }
+    },
+    "Your songs are ready for offline listening." : {
+      "extractionState" : "manual",
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Songs sind zum Offline-Hören bereit."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your songs are ready for offline listening."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kappaleesi ovat valmiina offline-kuunteluun."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos titres sont prêts pour une écoute hors ligne."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "曲をオフラインで再生できるようになりました。"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваші пісні готові до офлайн-прослуховування."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌曲已可供离线收听。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌曲已可供離線聆聽。"
+          }
+        }
+      }
     },
     "Yours" : {
 

--- a/TwinskaraokeShared/Services/DebugLogger.swift
+++ b/TwinskaraokeShared/Services/DebugLogger.swift
@@ -39,11 +39,7 @@ nonisolated enum DebugLogger {
     }()
 
     private static var isEnabled: Bool {
-        #if DEBUG
-            return true
-        #else
-            return UserDefaults.standard.bool(forKey: "nk.debugLogging")
-        #endif
+        UserDefaults.standard.bool(forKey: "nk.debugLogging")
     }
 
     private static let logQueue = DispatchQueue(label: "nk.debugLogger", qos: .utility)

--- a/TwinskaraokeTests/SettingsBehaviorTests.swift
+++ b/TwinskaraokeTests/SettingsBehaviorTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+import UserNotifications
+@testable import Twinskaraoke
+
+@MainActor
+@Suite("Settings behavior", .serialized)
+struct SettingsBehaviorTests {
+    @Test("Autoplay preserves recommendation order and excludes invalid or duplicate candidates")
+    func autoplayCandidates() {
+        let songs = [song("current"), song("first"), song("first"), song("missing", source: nil), song("second")]
+        #expect(AutoplaySelection.playableSongs(songs, excluding: "current").map(\.id) == ["first", "second"])
+        #expect(AutoplaySelection.playableSongs([song("current")], excluding: "current").isEmpty)
+    }
+
+    @Test("First Shimeji edit preserves the other default-enabled characters")
+    func shimejiDefaultSelection() {
+        var settings = ShimejiSpawnSettings(enabledCharacterIDs: [], maxCount: 3)
+        #expect(settings.enabledIDs(for: manifest) == ["a", "b"])
+        settings.setCharacter("a", enabled: false, manifest: manifest)
+        #expect(settings.enabledIDs(for: manifest) == ["b"])
+        settings.setCharacter("b", enabled: false, manifest: manifest)
+        #expect(settings.enabledIDs(for: manifest).isEmpty)
+        settings.setCharacter("a", enabled: true, manifest: manifest)
+        #expect(settings.enabledIDs(for: manifest) == ["a"])
+    }
+
+    @Test("Explicit empty and legacy nonempty Shimeji selections survive edits and encoding")
+    func shimejiPersistence() throws {
+        var settings = ShimejiSpawnSettings(enabledCharacterIDs: ["a"], maxCount: 3)
+        #expect(settings.enabledIDs(for: manifest) == ["a"])
+        settings.setCharacter("a", enabled: false, manifest: manifest)
+        let restored = try JSONDecoder().decode(ShimejiSpawnSettings.self, from: JSONEncoder().encode(settings))
+        #expect(restored.enabledIDs(for: manifest).isEmpty)
+    }
+
+    @Test("Out-of-range Shimeji counts cannot create an invalid spawn range", arguments: [-5, 0, 8, 100])
+    func shimejiCount(_ count: Int) {
+        let settings = ShimejiSpawnSettings(enabledCharacterIDs: [], maxCount: count)
+        #expect(ShimejiSpawnSettings.countRange.contains(settings.clampedCount))
+    }
+
+    @Test("Old inert notification preference does not silently opt the user in")
+    func notificationMigration() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: "nk.notifications.downloads")
+            let notifications = DownloadNotifications(defaults: defaults, center: FakeNotificationCenter())
+            #expect(!notifications.isEnabled)
+        }
+    }
+
+    @Test("Notification permission denial leaves the preference off")
+    func notificationDenial() async {
+        let suite = "settings-test-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let center = FakeNotificationCenter()
+        center.allowed = false
+        center.status = .denied
+        let notifications = DownloadNotifications(defaults: defaults, center: center)
+        await notifications.setEnabled(true)
+        #expect(!notifications.isEnabled)
+        #expect(notifications.permissionDenied)
+        #expect(!notifications.isUpdating)
+        #expect(!defaults.bool(forKey: DownloadNotifications.storageKey))
+    }
+
+    @Test("Notification opt-in persists, delivers completion, and disabling clears pending notifications")
+    func notificationLifecycle() async {
+        let suite = "settings-test-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let center = FakeNotificationCenter()
+        let notifications = DownloadNotifications(defaults: defaults, center: center)
+        defaults.set("de", forKey: AppLanguage.storageKey)
+        await notifications.sendCompletion(completed: 2, failed: 0)
+        #expect(center.requests.isEmpty)
+        await notifications.setEnabled(true)
+        #expect(DownloadNotifications(defaults: defaults, center: center).isEnabled)
+        await notifications.sendCompletion(completed: 0, failed: 0)
+        #expect(center.requests.isEmpty)
+        await notifications.sendCompletion(completed: 2, failed: 0)
+        #expect(center.requests.count == 1)
+        #expect(center.requests.first?.content.body == "Deine Songs sind zum Offline-Hören bereit.")
+        await notifications.setEnabled(false)
+        #expect(center.clearCount == 1)
+        #expect(!DownloadNotifications(defaults: defaults, center: center).isEnabled)
+        await notifications.sendCompletion(completed: 2, failed: 0)
+        #expect(center.requests.count == 1)
+    }
+
+    @Test("Turning notifications off during delivery clears the in-flight notification too")
+    func notificationDeliveryRace() async {
+        let suite = "settings-test-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let center = FakeNotificationCenter()
+        let notifications = DownloadNotifications(defaults: defaults, center: center)
+        await notifications.setEnabled(true)
+        center.onAdd = { await notifications.setEnabled(false) }
+        await notifications.sendCompletion(completed: 1, failed: 0)
+        #expect(!notifications.isEnabled)
+        #expect(center.clearCount == 2)
+        center.onAdd = nil
+    }
+
+    @Test("Permission errors are reported without leaving controls busy")
+    func notificationError() async {
+        let suite = "settings-test-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let center = FakeNotificationCenter()
+        center.shouldThrow = true
+        let notifications = DownloadNotifications(defaults: defaults, center: center)
+        await notifications.setEnabled(true)
+        #expect(notifications.hasError)
+        #expect(!notifications.isUpdating)
+        #expect(!notifications.isEnabled)
+    }
+
+    private func withDefaults(_ body: (UserDefaults) -> Void) {
+        let suite = "settings-test-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        body(defaults)
+    }
+
+    private func song(_ id: String, source: String? = "https://example.com/song.mp3") -> Song {
+        Song(id: id, title: id, duration: 60, absolutePath: source, cloudflareID: nil,
+             coverArt: nil, originalArtists: nil, coverArtists: nil, userUploaded: false)
+    }
+
+    private var manifest: ShimejiManifest {
+        ShimejiManifest(formatVersion: 1, packName: "Test", characters: ["a", "b"].map {
+            ShimejiCharacterDefinition(id: $0, displayName: $0, folder: $0, frameSize: 128,
+                                       anchor: ShimejiAnchor(x: 64, y: 128), actions: [:])
+        })
+    }
+}
+
+@MainActor
+private final class FakeNotificationCenter: DownloadNotificationCenter {
+    var status: UNAuthorizationStatus = .authorized
+    var allowed = true
+    var shouldThrow = false
+    var requests: [UNNotificationRequest] = []
+    var clearCount = 0
+    var onAdd: (() async -> Void)?
+
+    func authorizationStatus() async -> UNAuthorizationStatus { status }
+    func requestAuthorization() async throws -> Bool {
+        if shouldThrow { throw URLError(.unknown) }
+        return allowed
+    }
+    func add(_ request: UNNotificationRequest) async throws {
+        requests.append(request)
+        await onAdd?()
+    }
+    func clearCompletionNotifications() { clearCount += 1 }
+}

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -1035,6 +1035,65 @@ final class TwinskaraokeUITests: XCTestCase {
     }
   }
 
+  func testSettingsPersistAutoplayAndEnforceTransitionChoice() throws {
+    let app = launchApp()
+    openAccountToolbar(in: app)
+    openVisibleItem("Settings", in: app)
+    let autoplay = app.switches["Autoplay"].firstMatch
+    let autoMix = app.switches["Auto Mix"].firstMatch
+    let crossfade = app.switches["Crossfade"].firstMatch
+    XCTAssertTrue(autoplay.waitForExistence(timeout: 8))
+    let originalAutoplay = autoplay.value as? String
+    let originalAutoMix = autoMix.value as? String
+    let originalCrossfade = crossfade.value as? String
+    defer {
+      if autoplay.exists, autoplay.value as? String != originalAutoplay { autoplay.tap() }
+      if autoMix.exists, autoMix.value as? String != originalAutoMix { autoMix.tap() }
+      if crossfade.exists, crossfade.value as? String != originalCrossfade { crossfade.tap() }
+    }
+
+    if autoMix.value as? String != "1" {
+      autoMix.coordinate(withNormalizedOffset: CGVector(dx: 0.93, dy: 0.5)).tap()
+    }
+    XCTAssertEqual(crossfade.value as? String, "0")
+    crossfade.coordinate(withNormalizedOffset: CGVector(dx: 0.93, dy: 0.5)).tap()
+    XCTAssertEqual(crossfade.value as? String, "1")
+    XCTAssertEqual(autoMix.value as? String, "0")
+    XCTAssertTrue(app.sliders["Crossfade Duration"].waitForExistence(timeout: 3))
+
+    autoplay.coordinate(withNormalizedOffset: CGVector(dx: 0.93, dy: 0.5)).tap()
+    let selectedAutoplay = autoplay.value as? String
+    XCTAssertNotEqual(selectedAutoplay, originalAutoplay)
+    app.terminate()
+    app.launch()
+    openAccountToolbar(in: app)
+    openVisibleItem("Settings", in: app)
+    XCTAssertTrue(autoplay.waitForExistence(timeout: 8))
+    XCTAssertEqual(autoplay.value as? String, selectedAutoplay)
+  }
+
+  func testSettingsUseSelectedLanguageForThemeAndStrength() throws {
+    let app = XCUIApplication()
+    app.launchArguments = ["-UITestMode", "1", "-nk.language", "de", "-nk.appearance", "light",
+                           "-nk.hapticsEnabled", "YES", "-nk.hapticStrength", "medium"]
+    app.launch()
+    defer { app.terminate() }
+    openAccountToolbar(in: app)
+    openVisibleItem("Einstellungen", in: app)
+    XCTAssertTrue(app.switches["Automatische Wiedergabe"].waitForExistence(timeout: 8))
+    let theme = app.descendants(matching: .any).matching(identifier: "Settings.Theme").firstMatch
+    for _ in 0..<7 {
+      if theme.isHittable { break }
+      app.swipeUp()
+    }
+    XCTAssertTrue(theme.isHittable)
+    // The theme and strength labels come from runtime values rather than
+    // literal Text calls; verify they use the chosen locale too.
+    XCTAssertTrue(theme.label.contains("Hell"), theme.debugDescription)
+    let strength = app.descendants(matching: .any).matching(identifier: "Settings.HapticStrength").firstMatch
+    XCTAssertTrue(strength.label.contains("Mittel"), strength.debugDescription)
+  }
+
   func testAccountInformationDestinationsUseAdaptiveLayouts() throws {
     let app = launchApp()
     XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))


### PR DESCRIPTION
An audit of the Music settings page and its nested Shimeji, Developer and
Notifications pages found nine controls whose values persisted but that nothing
outside the view ever read, plus several that were wired yet behaved differently
from their label.

## Removed rather than faked

The three Library switches (add playlist songs, add favorite songs, sync
library), the Audio Quality picker, and the New Songs, Radio and Account
notification categories are gone.

Probing the public API turned up nothing to implement them against:

| Request | Result |
|---|---|
| `GET /api/user/library` | 404 — no separate song-library endpoint found |
| `GET /api/user/preferences` | 401 — exists, but does not establish a library-sync contract |
| `GET /api/songs/random` | 200 — MP3, Opus and HLS sources exist, but none is a selectable lossless tier compatible with the file-based EQ/AI playback path |
| `GET /api/notification` | 404 — no iOS push registration or category contract |
| `GET /swagger/v1/swagger.json` | empty — no usable OpenAPI contract at this location |

Probes were unauthenticated, read-only and bounded; no account mutations were
sent. These responses are evidence that no contract was found, not proof that
none could exist — if one of these features gets a real server contract later,
it needs its own implementation rather than a revived switch.

## Implemented

- **Auto-downloads** now permanently download on ordinary playback and crossfade
  handoffs, and switching the setting on also queues the current song. Radio is
  excluded, and the footer states that along with the cellular cost. The switch
  remains off by default.
- **Autoplay** persists across launches, asks for account recommendations when
  signed in and falls back to trending otherwise, drops the song that just ended
  along with duplicates and entries with no playable source, and cancels pending
  work when it is switched off, paused, or superseded by other playback.
- **Download-completion notifications**, opt-in and local, with authorization,
  denial and error handling, removal when switched off, and a link into system
  settings. The old default-on key is deliberately not reused, so an existing
  install is not silently opted in. These are local notifications for downloads
  finishing while the app is backgrounded — no push service, and no extension of
  background download execution.

## Fixed

- Auto Mix uses its own calculated duration instead of being capped by the
  Crossfade duration, which is hidden while Auto Mix is on.
- Re-enabling AI restarts auto-analysis for the current song; disabling it
  invalidates pending stem work and cancels analysis retries.
- The Shimeji character switches show the effective default rather than the
  empty stored set, so turning one character on no longer silently excludes
  every other one. Population counts are bounded consistently.
- Storage actions wait for deletion to finish before reporting success, and
  report failure. Music-cache deletion runs once, on the maintenance queue,
  instead of synchronously on the main actor and then again through
  `CacheManager`.
- The lyrics cache limit reads 64 MB, which is what `CacheManager` actually
  enforces — the page advertised 2 GB.
- Debug Logging honours its switch in Release as well as Debug, and turning
  Developer Mode off turns off debug logging and forced easter eggs with it.
- Settings labels, picker values, slider accessibility text and confirmations go
  through the string catalog, with translations added or corrected across all
  eight shipped languages. Previously these were passed to `Text` as runtime
  `String` values, which does not extract, so selecting another language left
  parts of the page in English.

## Verification

- 222 unit tests in 28 suites pass, including nine new settings regression tests
  covering autoplay persistence and filtering, notification opt-in, permission
  denial and error handling, and zero-work suppression.
- Four settings/account UI tests pass: settings navigation, adjacent account
  destinations, persisted Autoplay with mutually exclusive transitions, and
  German theme/strength rendering.
- Debug and Release builds succeed, warning-clean.
- The string catalog gained 71 keys and lost none; all eight languages are
  intact and translated units went from 3440 to 4288.

## Not covered by these tests

The notification tests use a simulated notification center, so live background
delivery on hardware is unproven. `GET /api/user/suggestions` returns 401
unauthenticated, so the signed-in recommendation path was never exercised — only
the trending fallback. Physical-device haptics and audible AI quality also need
device validation.

## Note for reviewers

`nk.downloadOnPlay` is reused rather than migrated to a new key. It defaults to
off, so a fresh install downloads nothing, but an existing install that switched
it on while it was inert will start permanently downloading played songs after
this lands. That was a deliberate call — the label always described this
behavior — but it is the one place where the "don't silently opt anyone in"
approach taken for notifications was not applied.

## Summary by Sourcery

Make settings controls reflect supported playback, download, notification, Shimeji, storage, developer, and localization behavior.

New Features:
- Add persistent autoplay with recommendation and trending fallbacks, candidate filtering, and cancellation of obsolete playback work.
- Add opt-in local notifications for completed background downloads with permission handling and system-settings guidance.

Bug Fixes:
- Make auto-downloads apply to played and crossfaded songs while excluding radio, and queue the current song when enabled.
- Correct Auto Mix duration handling, AI re-enablement and cancellation, Shimeji defaults and count bounds, storage deletion reporting, cache-size messaging, and developer logging behavior.
- Localize settings controls and dynamic labels across supported languages.

Enhancements:
- Remove unsupported library, audio-quality, and unused notification-category controls from the settings screens.
- Improve storage maintenance feedback and prevent duplicate or premature cache-clearing work.
- Simplify settings presentation while improving accessibility identifiers and localized accessibility values.

Tests:
- Add unit coverage for autoplay selection, Shimeji persistence, notification opt-in, denial, errors, delivery races, and suppression cases.
- Add UI coverage for persisted autoplay behavior, mutually exclusive playback settings, and localized settings labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Autoplay and automatic downloads when playback begins.
  * Added opt-in notifications when downloads finish, with permission and in-app controls.
  * Added improved cache-clearing progress and completion reporting.
  * Added localized Settings labels and accessibility text.
  * Improved Shimeji population limits and character selection controls.

* **Bug Fixes**
  * Disabling Developer Mode now also disables debug logging and easter egg triggers.
  * Improved autoplay recommendations, playback transitions, and cache reset behavior.
  * Download and notification settings now handle errors and disabled states more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->