### PR TITLE
Polish browsing shelves and loading placeholders

### DIFF
--- a/Twinskaraoke/Components/Home/HomeSections.swift
+++ b/Twinskaraoke/Components/Home/HomeSections.swift
@@ -51,8 +51,9 @@ struct PlaylistCarousel: View {
                                 .frame(width: 60, height: tileWidth)
                         }
                     }
-                    .padding(.horizontal, horizontalPadding)
+                    .scrollTargetLayout()
                 }
+                .musicShelfScrolling(horizontalMargin: horizontalPadding)
             }
         }
         .trackingWidth(into: $availableWidth)
@@ -103,8 +104,9 @@ struct HomeSongSection: View {
                             )
                         }
                     }
-                    .padding(.horizontal, horizontalPadding)
+                    .scrollTargetLayout()
                 }
+                .musicShelfScrolling(horizontalMargin: horizontalPadding)
             }
         }
         .trackingWidth(into: $availableWidth)

--- a/Twinskaraoke/Components/Home/HomeSkeletonViews.swift
+++ b/Twinskaraoke/Components/Home/HomeSkeletonViews.swift
@@ -1,13 +1,79 @@
 import SwiftUI
 
 struct HomeSkeletonView: View {
+    var availableWidth: CGFloat = 390
+
     var body: some View {
-        CenteredLoadingView(label: "Loading Home")
+        BrowseLoadingPlaceholder(availableWidth: availableWidth, label: "Loading Home")
     }
 }
 
 struct NewSkeletonView: View {
+    var availableWidth: CGFloat = 390
+
     var body: some View {
-        CenteredLoadingView(label: "Loading New")
+        BrowseLoadingPlaceholder(availableWidth: availableWidth, label: "Loading New", featured: true)
+    }
+}
+
+/// Static placeholders establish the browsing layout without running decorative animations.
+private struct BrowseLoadingPlaceholder: View {
+    let availableWidth: CGFloat
+    let label: String
+    var featured = false
+    @ScaledMetric(relativeTo: .subheadline) private var labelAllowance: CGFloat = AM.Layout.shelfLabelAllowance
+
+    private var tileWidth: CGFloat {
+        AM.Layout.shelfTileWidth(for: min(availableWidth, AM.Layout.wideContentMaxWidth))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AM.Spacing.xxl) {
+            if featured {
+                VStack(alignment: .leading, spacing: AM.Spacing.s) {
+                    MusicSkeletonLine(width: 110, height: 10)
+                    MusicSkeletonLine(width: 180, height: 20)
+                    MusicSkeletonBlock(cornerRadius: AM.Radius.card)
+                        .frame(height: min(max(availableWidth - AM.Spacing.screenMargin * 2, 300), 420) * 0.56)
+                }
+                .frame(width: min(max(availableWidth - AM.Spacing.screenMargin * 2, 300), 420))
+                .padding(.horizontal, AM.Spacing.screenMargin)
+                .accessibilityHidden(true)
+            }
+
+            ForEach(0..<2) { index in
+                VStack(alignment: .leading, spacing: AM.Spacing.sectionHeaderGap) {
+                    HStack {
+                        MusicSkeletonLine(width: index == 0 ? 140 : 180, height: 22)
+                            .accessibilityHidden(true)
+                        Spacer()
+                        if index == 0 {
+                            ProgressView().accessibilityLabel(label)
+                        }
+                    }
+                    .padding(.horizontal, AM.Spacing.screenMargin)
+
+                    HStack(alignment: .top, spacing: AM.Spacing.l) {
+                        ForEach(0..<6) { _ in
+                            VStack(alignment: .leading, spacing: AM.Spacing.s) {
+                                MusicSkeletonBlock(cornerRadius: AM.Radius.card)
+                                    .frame(width: tileWidth, height: tileWidth)
+                                MusicSkeletonLine(width: tileWidth * 0.82)
+                                MusicSkeletonLine(width: tileWidth * 0.56, height: 11, tone: .tertiary)
+                            }
+                            .frame(width: tileWidth, height: tileWidth + labelAllowance, alignment: .topLeading)
+                        }
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                    .padding(.horizontal, AM.Spacing.screenMargin)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .clipped()
+                    .accessibilityHidden(true)
+                }
+            }
+        }
+        .frame(maxWidth: AM.Layout.wideContentMaxWidth)
+        .frame(maxWidth: .infinity)
+        .allowsHitTesting(false)
     }
 }

--- a/Twinskaraoke/Components/Shared/ScrollOptimization.swift
+++ b/Twinskaraoke/Components/Shared/ScrollOptimization.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 
 extension View {
+    /// Aligns a horizontal shelf to its cards while retaining an inset at both ends.
+    /// The shelf's stack must declare `scrollTargetLayout()`.
+    func musicShelfScrolling(horizontalMargin: CGFloat = AM.Spacing.screenMargin) -> some View {
+        contentMargins(.horizontal, horizontalMargin, for: .scrollContent)
+            .scrollTargetBehavior(.viewAligned)
+            .smoothScrolling()
+    }
+
     func smoothScrolling(bounceBehavior: ScrollBounceBehavior = .basedOnSize) -> some View {
         modifier(SmoothScrollingModifier(bounceBehavior: bounceBehavior))
     }

--- a/Twinskaraoke/Features/Home/HomeView.swift
+++ b/Twinskaraoke/Features/Home/HomeView.swift
@@ -18,7 +18,7 @@ struct HomeView: View {
                 ScrollView {
                     Group {
                         if viewModel.isLoading {
-                            HomeSkeletonView()
+                            HomeSkeletonView(availableWidth: proxy.size.width)
                                 .transition(.opacity)
                         } else {
                             homeOverview(availableWidth: proxy.size.width)

--- a/Twinskaraoke/Features/Home/NewSections.swift
+++ b/Twinskaraoke/Features/Home/NewSections.swift
@@ -46,8 +46,9 @@ struct NewFeaturedRail: View {
                         )
                     }
                 }
-                .padding(.horizontal, AM.Spacing.screenMargin)
+                .scrollTargetLayout()
             }
+            .musicShelfScrolling()
         }
         .trackingWidth(into: $availableWidth)
         .frame(height: cardArtworkHeight + AM.Spacing.s + cardTextAllowance)
@@ -149,8 +150,9 @@ struct NewSongRail: View {
                             )
                         }
                     }
-                    .padding(.horizontal, AM.Spacing.screenMargin)
+                    .scrollTargetLayout()
                 }
+                .musicShelfScrolling()
             }
         }
         .trackingWidth(into: $availableWidth)
@@ -224,8 +226,9 @@ struct NewPlaylistRail: View {
                             }
                         }
                     }
-                    .padding(.horizontal, AM.Spacing.screenMargin)
+                    .scrollTargetLayout()
                 }
+                .musicShelfScrolling()
             }
         }
         .trackingWidth(into: $availableWidth)

--- a/Twinskaraoke/Features/Home/NewView.swift
+++ b/Twinskaraoke/Features/Home/NewView.swift
@@ -17,7 +17,7 @@ struct NewView: View {
                 ScrollView {
                     Group {
                         if viewModel.isLoading {
-                            NewSkeletonView()
+                            NewSkeletonView(availableWidth: proxy.size.width)
                                 .transition(.opacity)
                         } else {
                             newOverview(availableWidth: proxy.size.width)


### PR DESCRIPTION
Home and New shelves now settle with cards aligned to the content margin after horizontal scrolling. Their scroll activity also pauses decorative effects through the existing scroll tracker. Content margins preserve the inset at both ends of each shelf.

Replace the Home and New loading spinners with static artwork and text placeholders plus one progress indicator. Placeholder dimensions follow the available width and text size, and decorative blocks are hidden from accessibility.

Validation: six UI tests passed on iOS 26.5—four on iPhone 17 Pro Max covering Home, New, large text, and player opening/sleep timer behavior; two on iPad Pro 13-inch covering the wide Home and New layouts. Inspected the phone Home screenshot and passed git diff --check. Frame-rate improvement has not been measured.

## Summary by Sourcery

Polish Home and New browsing shelves and loading states for more consistent alignment, responsive layouts, and quieter loading feedback.

New Features:
- Replace Home and New loading spinners with responsive static browsing placeholders and a single accessible progress indicator.

Bug Fixes:
- Align Home and New shelf cards after horizontal scrolling while preserving content insets at both ends.

Enhancements:
- Pause or optimize decorative scrolling effects through the shared shelf scrolling behavior.