### PR TITLE
Polish queue browsing and accessible editing

### DIFF
--- a/Twinskaraoke/Components/Player/EqualizerBars.swift
+++ b/Twinskaraoke/Components/Player/EqualizerBars.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct EqualizerBars: View {
     let isAnimating: Bool
+    var pausesWhileScrolling = true
     @Environment(\.appReduceEffects) private var reduceEffects
     @Environment(\.scenePhase) private var scenePhase
     private let scrollState = ScrollPerformanceState.shared
@@ -53,7 +54,8 @@ struct EqualizerBars: View {
     }
 
     private var shouldAnimateBars: Bool {
-        isAnimating && isVisible && !reduceEffects && scenePhase == .active && !scrollState.isScrolling
+        isAnimating && isVisible && !reduceEffects && scenePhase == .active
+            && (!pausesWhileScrolling || !scrollState.isScrolling)
     }
 }
 

--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -423,7 +423,7 @@ struct FullScreenPlayerView: View {
                         .environment(audioManager)
                 }
             }
-            .presentationDetents([.medium, .large])
+            .presentationDetents(dynamicTypeSize.isAccessibilitySize ? [.large] : [.medium, .large])
             .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showAddToPlaylist) {

--- a/Twinskaraoke/Features/Player/NowPlaying/MiniPlayerGesture.swift
+++ b/Twinskaraoke/Features/Player/NowPlaying/MiniPlayerGesture.swift
@@ -1,15 +1,6 @@
 import SwiftUI
 import UIKit
 
-/// Temporary device tracing in Debug and Release for the affected device build.
-/// No song, account, or other content is recorded.
-/// Keep a version stamp so a device report identifies the installed code path.
-enum PlayerGestureTrace {
-    static func record(_ message: @autoclosure () -> String) {
-        print("[PlayerGesture D2] \(message())")
-    }
-}
-
 /// A single recognizer owns the complete contact. A pan can never fall through
 /// to a second tap recognizer when the system accessory changes its layout.
 struct MiniPlayerGesture: UIViewRepresentable {
@@ -22,7 +13,6 @@ struct MiniPlayerGesture: UIViewRepresentable {
 
         override func didMoveToWindow() {
             super.didMoveToWindow()
-            PlayerGestureTrace.record("host=\(ObjectIdentifier(self)) window=\(String(describing: window.map(ObjectIdentifier.init))) OS=\(UIDevice.current.systemVersion)")
             recognizer.view?.removeGestureRecognizer(recognizer)
             guard let window else {
                 presentation.cancelDrag(from: .miniPlayer)
@@ -39,7 +29,6 @@ struct MiniPlayerGesture: UIViewRepresentable {
 
         func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
             guard let window else {
-                PlayerGestureTrace.record("host=\(ObjectIdentifier(self)) reject: no window")
                 return false
             }
             let point = touch.location(in: window)
@@ -51,8 +40,6 @@ struct MiniPlayerGesture: UIViewRepresentable {
             let eligible = recognizer.canBegin()
             if eligible && !modal { recognizer.acceptsTap = acceptsTap }
             let accepted = eligible && !modal && inBar
-            PlayerGestureTrace.record("host=\(ObjectIdentifier(self)) receive=\(accepted) point=\(point) eligible=\(eligible) modal=\(modal) inBar=\(inBar) control=\(!acceptsTap) expanded=\(presentation.isExpanded) owner=\(String(describing: presentation.dragSource)) animating=\(presentation.isAnimatingTransition) progress=\(presentation.progress)")
-            PlayerGestureTrace.record("regions=\(allRegions.map { "\($0.isTransport ? "controls" : "bar") visible=\($0.isVisible) frame=\($0.convert($0.bounds, to: window))" }.joined(separator: "; "))")
             return accepted
         }
 
@@ -69,21 +56,15 @@ struct MiniPlayerGesture: UIViewRepresentable {
                     presentation.drag(to: PlayerDismissMetrics.openingProgress(
                         translation: contact.translation, height: contact.height), from: .miniPlayer)
                 }
-                if recognizer.state == .began {
-                    PlayerGestureTrace.record("tracking began translation=\(contact.translation) progress=\(presentation.progress) owner=\(String(describing: presentation.dragSource))")
-                }
             case .ended:
                 if contact.isDragging {
                     let opens = PlayerDismissMetrics.shouldOpen(translation: contact.translation,
                         predictedTranslation: contact.projectedTranslation, height: contact.height)
                     presentation.endDrag(dismissing: !opens, from: .miniPlayer)
-                    PlayerGestureTrace.record("release open=\(opens) translation=\(contact.translation) projected=\(contact.projectedTranslation) expanded=\(presentation.isExpanded) animating=\(presentation.isAnimatingTransition) token=\(presentation.animationToken)")
                 } else {
-                    PlayerGestureTrace.record("tap expand")
                     presentation.expand()
                 }
             case .cancelled, .failed:
-                PlayerGestureTrace.record("action cancelled/failed state=\(recognizer.state.rawValue) translation=\(contact.translation)")
                 presentation.cancelDrag(from: .miniPlayer)
             default:
                 break
@@ -97,7 +78,6 @@ struct MiniPlayerGesture: UIViewRepresentable {
         private(set) var contact = MiniPlayerContact()
         private weak var contactWindow: UIWindow?
         private var trackedTouch: UITouch?
-        private var moveEvents = 0
 
         // The delegate admits only mini-player contacts, excluding modal
         // presentations. Native accessory gestures must not prevent
@@ -114,30 +94,23 @@ struct MiniPlayerGesture: UIViewRepresentable {
             super.touchesBegan(touches, with: event)
             guard canBegin(), trackedTouch == nil, touches.count == 1,
                   let touch = touches.first, let window = (view as? UIWindow) ?? view?.window else {
-                PlayerGestureTrace.record("raw begin rejected eligible=\(canBegin()) alreadyTracking=\(trackedTouch != nil) touchCount=\(touches.count)")
                 state = state == .possible ? .failed : .cancelled
                 return
             }
             trackedTouch = touch
             contactWindow = window
             contact.begin(at: touch.location(in: window), time: touch.timestamp, height: window.bounds.height)
-            PlayerGestureTrace.record("raw begin height=\(window.bounds.height) acceptsTap=\(acceptsTap)")
         }
 
         override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
             super.touchesMoved(touches, with: event)
             guard let touch = trackedTouch, touches.contains(touch), let window = contactWindow else { return }
             let wasDragging = contact.isDragging
-            moveEvents += 1
             switch contact.move(to: touch.location(in: window), time: touch.timestamp) {
             case .waiting: break
             case .dragging: state = wasDragging ? .changed : .began
             case .rejected:
-                PlayerGestureTrace.record("raw direction rejected translation=\(contact.translation) moves=\(moveEvents)")
                 state = .failed
-            }
-            if moveEvents == 1 || moveEvents.isMultiple(of: 10) {
-                PlayerGestureTrace.record("raw move count=\(moveEvents) state=\(state.rawValue) translation=\(contact.translation) modelProgress=\(NowPlayingPresentation.shared.progress)")
             }
         }
 
@@ -149,23 +122,19 @@ struct MiniPlayerGesture: UIViewRepresentable {
             }
             // A long stationary hold contributes zero release velocity.
             let recognized = contact.finish(at: touch.location(in: window), time: touch.timestamp)
-            PlayerGestureTrace.record("raw end recognized=\(recognized) drag=\(contact.isDragging) moves=\(moveEvents) translation=\(contact.translation) projected=\(contact.projectedTranslation)")
             state = recognized && (contact.isDragging || acceptsTap) ? .ended : .failed
         }
 
         override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
             super.touchesCancelled(touches, with: event)
-            PlayerGestureTrace.record("raw cancelled moves=\(moveEvents) translation=\(contact.translation)")
             state = .cancelled
         }
 
         override func reset() {
-            PlayerGestureTrace.record("reset state=\(state.rawValue) tracked=\(trackedTouch != nil) moves=\(moveEvents)")
             super.reset()
             trackedTouch = nil
             contactWindow = nil
             contact = MiniPlayerContact()
-            moveEvents = 0
         }
     }
 }

--- a/Twinskaraoke/Features/Player/NowPlaying/NowPlayingOverlay.swift
+++ b/Twinskaraoke/Features/Player/NowPlaying/NowPlayingOverlay.swift
@@ -139,12 +139,6 @@ struct NowPlayingOverlay: View {
             }
             guard presentation.isAnimatingTransition else { return }
             let token = presentation.animationToken
-            // Release diagnostics: gesture acceptance alone cannot establish
-            // whether the artwork settlement was selected. Record every gate
-            // once per close, without logging URLs or doing per-frame work.
-            if presentation.isClosingTransition {
-                PlayerGestureTrace.record("landing request token=\(token) reduceMotion=\(reduceMotion) image=\(snapshot.artwork != nil) canvas=\(canvasSize) pill=\(String(describing: presentation.barFrame)) thumbnail=\(String(describing: presentation.barArtworkFrame)) artwork=\(String(describing: presentation.playerArtworkFrame)) releaseProgress=\(presentation.progress)")
-            }
             if !reduceMotion, presentation.isClosingTransition,
                snapshot.artwork != nil, canvasSize.width > 0, canvasSize.height > 0,
                let pill = presentation.barFrame,
@@ -159,17 +153,6 @@ struct NowPlayingOverlay: View {
                 )
                 presentation.prepareClosingSettlement()
             }
-            if presentation.isClosingTransition {
-                let missing = [
-                    reduceMotion ? "reduceMotion" : nil,
-                    snapshot.artwork == nil ? "image" : nil,
-                    canvasSize.width <= 0 || canvasSize.height <= 0 ? "canvas" : nil,
-                    presentation.barFrame == nil ? "pill" : nil,
-                    presentation.barArtworkFrame == nil ? "thumbnail" : nil,
-                    presentation.playerArtworkFrame == nil ? "artworkFrame" : nil
-                ].compactMap { $0 }.joined(separator: ",")
-                PlayerGestureTrace.record("landing selected token=\(token) mode=\(closingTransition == nil ? "slide" : "cover-curve") settling=\(presentation.isSettlingArtwork) skipped=\(missing.isEmpty ? "none" : missing)")
-            }
             let animation: Animation? = reduceMotion ? nil : closingTransition != nil
                 ? .linear(duration: PlayerClosingGeometry.duration)
                 : .spring(response: 0.38, dampingFraction: 0.9)
@@ -178,9 +161,6 @@ struct NowPlayingOverlay: View {
                 closingPhase = 1
             } completion: {
                 guard token == presentation.animationToken else { return }
-                if closingTransition != nil {
-                    PlayerGestureTrace.record("landing complete token=\(token) phase=\(closingPhase) image=\(snapshot.artwork != nil) settling=\(presentation.isSettlingArtwork)")
-                }
                 withTransaction(Transaction(animation: nil)) {
                     closingTransition = nil
                     closingPhase = 0

--- a/Twinskaraoke/Features/Player/NowPlaying/NowPlayingPresentation.swift
+++ b/Twinskaraoke/Features/Player/NowPlaying/NowPlayingPresentation.swift
@@ -45,7 +45,6 @@ final class NowPlayingPresentation {
     }
 
     func animationDidComplete(token: Int) {
-        PlayerGestureTrace.record("animation completion token=\(token) current=\(animationToken) progress=\(progress)")
         guard token == animationToken else { return }
         isAnimatingTransition = false
         artworkTransitionSource = nil
@@ -235,7 +234,6 @@ final class NowPlayingPresentation {
 
     /// Applied by `NowPlayingOverlay` inside its own animation.
     func applyAnimationTarget() {
-        PlayerGestureTrace.record("animation apply token=\(animationToken) target=\(animationTarget)")
         progress = animationTarget
     }
 

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -6,6 +6,7 @@ struct QueueView: View {
     @Environment(\.appReduceMotion) private var reduceMotion
     @State private var showCurrentAddToPlaylist = false
     @State private var upNextEntries: [UpNextEntry] = []
+    @State private var isReordering = false
 
     private var queueToggleAnimation: Animation? {
         reduceMotion ? nil : AppMotion.quick
@@ -138,7 +139,9 @@ struct QueueView: View {
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
-                    .environment(\.editMode, .constant(.active))
+                    .smoothScrolling()
+                    .accessibilityIdentifier("Queue.List")
+                    .environment(\.editMode, .constant(isReordering ? .active : .inactive))
                 }
             }
         }
@@ -152,27 +155,73 @@ struct QueueView: View {
         .onAppear { refreshUpNextSongs() }
         .onChange(of: audioManager.queue) { _, _ in refreshUpNextSongs() }
         .onChange(of: audioManager.currentSong?.id) { _, _ in refreshUpNextSongs() }
+        .onChange(of: upNextEntries.isEmpty) { _, isEmpty in
+            if isEmpty { isReordering = false }
+        }
         .onDisappear {
             ArtworkPrefetcher.shared.cancel(reason: "queue up next")
         }
     }
 
     private func header(upNextCount: Int) -> some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
                 Text("Playing Next")
                     .font(AM.Font.groupHeader)
                     .foregroundStyle(.primary)
-                Text(upNextCount == 1 ? "1 song queued" : "\(upNextCount) songs queued")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-                    .contentTransition(.numericText())
+                    .accessibilityAddTraits(.isHeader)
+                Spacer(minLength: 8)
+                GlassXButton(action: {
+                    AppHaptic.dismiss.play()
+                    dismiss()
+                })
+                .accessibilityHint("Dismisses Playing Next.")
             }
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Playing Next")
-            .accessibilityValue(upNextCount == 1 ? "1 song queued" : "\(upNextCount) songs queued")
-            Spacer()
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    queueCount(upNextCount).fixedSize()
+                    Spacer(minLength: 8)
+                    queueActions(upNextCount).fixedSize()
+                }
+                VStack(alignment: .leading, spacing: 8) {
+                    queueCount(upNextCount)
+                    queueActions(upNextCount)
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 26)
+        .padding(.bottom, 14)
+        .animation(headerAnimation, value: upNextCount)
+    }
+
+    private func queueCount(_ count: Int) -> some View {
+        Text(count == 1 ? "1 song queued" : "\(count) songs queued")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+            .contentTransition(.numericText())
+    }
+
+    private func queueActions(_ upNextCount: Int) -> some View {
+        HStack(spacing: 8) {
+            if upNextCount > 1 || isReordering {
+                Button {
+                    AppHaptic.selection.play()
+                    withOptionalAnimation(queueMutationAnimation) {
+                        isReordering.toggle()
+                    }
+                } label: {
+                    Text(isReordering ? "Done" : "Reorder")
+                        .font(AM.Font.rowCompactTitle.weight(.semibold))
+                        .padding(.horizontal, 12)
+                        .frame(minHeight: 44)
+                        .background(Color.appControlInactiveFill, in: Capsule())
+                }
+                .buttonStyle(PressableButtonStyle())
+                .accessibilityIdentifier("Queue.Reorder")
+                .accessibilityHint(isReordering ? "Finishes rearranging the queue." : "Shows handles to rearrange upcoming songs.")
+            }
             if upNextCount > 0 {
                 Button(role: .destructive) {
                     AppHaptic.dismiss.play()
@@ -193,16 +242,7 @@ struct QueueView: View {
                 .accessibilityHint("Removes all songs from Playing Next.")
                 .transition(clearButtonTransition)
             }
-            GlassXButton(action: {
-                AppHaptic.dismiss.play()
-                dismiss()
-            })
-            .accessibilityHint("Dismisses Playing Next.")
         }
-        .padding(.horizontal, 20)
-        .padding(.top, 26)
-        .padding(.bottom, 14)
-        .animation(headerAnimation, value: upNextCount)
     }
 
     private func currentSongRow(_ current: Song) -> some View {

--- a/Twinskaraoke/Features/Player/QueueView.swift
+++ b/Twinskaraoke/Features/Player/QueueView.swift
@@ -274,7 +274,7 @@ struct QueueView: View {
                 }
                 Spacer()
 
-                EqualizerBars(isAnimating: audioManager.isPlaying)
+                EqualizerBars(isAnimating: audioManager.isPlaying, pausesWhileScrolling: false)
                     .frame(width: 16, height: 16)
                     .foregroundStyle(Color.appAccent)
             }

--- a/TwinskaraokeUITests/TwinskaraokeUITests.swift
+++ b/TwinskaraokeUITests/TwinskaraokeUITests.swift
@@ -895,6 +895,65 @@ final class TwinskaraokeUITests: XCTestCase {
     )
   }
 
+  func testQueueBrowsingAndReordering() throws {
+    try verifyQueueEditing()
+  }
+
+  func testQueueEditingWithAccessibilityText() throws {
+    try verifyQueueEditing(contentSizeCategory: "UICTContentSizeCategoryAccessibilityXL")
+  }
+
+  private func verifyQueueEditing(contentSizeCategory: String? = nil) throws {
+    let app = launchApp(initialSection: "home", preferredContentSizeCategory: contentSizeCategory)
+    openVisibleItem(
+      "Wake Me Up Before You Go-Go",
+      identifier: "HomeSongSection.Made for You.ui-home-song-1",
+      in: app
+    )
+    let mini = element(identifier: "MiniPlayerBar", in: app)
+    XCTAssertTrue(mini.waitForExistence(timeout: 8))
+    let start = mini.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.5))
+    let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.25))
+    start.press(forDuration: 0.05, thenDragTo: end, withVelocity: 400, thenHoldForDuration: 0.1)
+    let queueButton = app.buttons["PlayerToolbar.PlayingNext"].firstMatch
+    let queueButtonReady = waitUntil(timeout: 8) { queueButton.isHittable }
+    if !queueButtonReady {
+      let screenshot = XCTAttachment(screenshot: app.screenshot())
+      screenshot.name = "Queue opening failure"
+      screenshot.lifetime = .keepAlways
+      add(screenshot)
+      let hierarchy = XCTAttachment(string: app.debugDescription)
+      hierarchy.name = "Queue opening hierarchy"
+      hierarchy.lifetime = .keepAlways
+      add(hierarchy)
+    }
+    XCTAssertTrue(queueButtonReady, "The player queue button never became tappable")
+    queueButton.tap()
+
+    let reorder = app.buttons["Queue.Reorder"]
+    XCTAssertTrue(reorder.waitForExistence(timeout: 8))
+    XCTAssertEqual(reorder.label, "Reorder")
+    XCTAssertTrue(reorder.isHittable)
+    if contentSizeCategory != nil {
+      let list = element(identifier: "Queue.List", in: app)
+      XCTAssertTrue(waitUntil(timeout: 5) { list.frame.height > 160 })
+    }
+    let browseShot = XCTAttachment(screenshot: app.screenshot())
+    browseShot.name = contentSizeCategory == nil ? "Queue browsing" : "Queue accessibility text"
+    browseShot.lifetime = .keepAlways
+    add(browseShot)
+
+    reorder.tap()
+    XCTAssertTrue(waitUntil(timeout: 5) { reorder.label == "Done" })
+    reorder.tap()
+    XCTAssertTrue(waitUntil(timeout: 5) { reorder.label == "Reorder" })
+    reorder.tap()
+    app.buttons["Clear queue"].tap()
+    XCTAssertTrue(app.staticTexts["No songs queued"].waitForExistence(timeout: 5))
+    XCTAssertFalse(reorder.exists)
+    XCTAssertFalse(app.buttons["Clear queue"].exists)
+  }
+
   func testHomeSongOpensFullScreenPlayerControls() throws {
     let app = launchApp(initialSection: "home")
     XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15))


### PR DESCRIPTION
The Playing Next queue previously stayed in edit mode, exposing delete and drag controls during ordinary browsing. Open it in browsing mode and provide Reorder/Done controls. The header stacks its count and actions when horizontal space is limited, and clearing the queue exits edit mode.

Open song and radio queues at full height for accessibility text sizes so the enlarged header leaves usable space for upcoming items. Connect queue scrolling to the existing scroll tracker while keeping the pinned Now Playing bars animated. Remove the leftover PlayerGesture tracing and its diagnostic counters without changing gesture handling.

Validation:
- Queue browsing, Reorder/Done, and clearing while editing passed on iPhone 17 Pro Max and iPad Pro 13-inch at normal and accessibility text sizes (iOS 26.5).
- The existing player-opening/sleep-timer UI test passed; normal and large-text queue screenshots were inspected.
- The final scrolling-animation adjustment and logging cleanup passed a Debug simulator build and git diff --check.

Earlier phone test attempts failed while opening the player, before reaching the queue. A later comparison run passed both the existing player-opening test and the normal-size queue test; the cause of those earlier opening failures remains unconfirmed.

## Summary by Sourcery

Improve Playing Next browsing and accessibility while preserving player gestures and scrolling animations.

New Features:
- Add accessible queue browsing with explicit Reorder and Done controls and responsive queue header actions.
- Open the full-screen player at a large detent for accessibility text sizes.

Bug Fixes:
- Ensure clearing the Playing Next queue exits reorder mode.
- Keep Now Playing animation active while the queue is scrolling.

Enhancements:
- Connect queue scrolling to smooth scrolling behavior and expose stable accessibility identifiers.
- Remove temporary player gesture tracing and diagnostic counters without altering gesture behavior.

Tests:
- Add UI coverage for queue browsing, reordering, clearing, and accessibility text layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added queue reordering controls with clear “Reorder” and “Done” actions.
  - Improved queue layout, scrolling, accessibility support, and empty-queue behavior.
  - Preserved equalizer animation while scrolling in the queue.
  - Adjusted queue presentation for larger accessibility text sizes.

- **Bug Fixes**
  - Improved queue interaction and editing behavior across standard and accessibility text sizes.

- **Tests**
  - Added UI coverage for browsing, reordering, clearing, and accessibility-focused queue workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->