### PR TITLE
Size the player against the height its content actually gets

### DIFF
--- a/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
+++ b/Twinskaraoke/Features/Player/FullScreenPlayerView.swift
@@ -10,8 +10,34 @@ private struct PlayerLayoutMetrics {
     let safeBottom: CGFloat
     let usesAccessibilityText: Bool
 
+    /// Room the dismiss handle occupies at the top of the player. The content
+    /// is padded past it, so it is not height the layout can spend.
+    static let dismissBarHeight: CGFloat = 44
+
+    /// Lifts the content clear of the home indicator without paying the whole
+    /// bottom inset, which reads as a gap under the toolbar.
+    private static let bottomInsetRelief: CGFloat = 8
+
+    var contentTopPadding: CGFloat {
+        safeTop + Self.dismissBarHeight
+    }
+
+    var contentBottomPadding: CGFloat {
+        max(0, safeBottom - Self.bottomInsetRelief)
+    }
+
+    /// The height the content actually gets, which is what every size below is
+    /// derived from.
+    ///
+    /// This used to be the full distance between the safe areas, ignoring the
+    /// padding the content is laid out with. On an iPhone 17 Pro that claimed
+    /// 778pt against the 742pt the content really has, which put `contentHeight`
+    /// 18pt above the `isCompactHeight` breakpoint: the layout sized itself for
+    /// the roomy variant, came out 57pt taller than the container, and the
+    /// `frame(height:)` below centred the overflow — floating the whole player
+    /// up by 28pt so the dismiss handle sat level with the status-bar clock.
     private var contentHeight: CGFloat {
-        max(1, containerSize.height - safeTop - safeBottom)
+        max(1, containerSize.height - contentTopPadding - contentBottomPadding)
     }
 
     private var isCompactHeight: Bool {
@@ -371,8 +397,8 @@ struct FullScreenPlayerView: View {
                                 musicLayout(song: song, metrics: metrics)
                             }
                         }
-                        .padding(.top, safeTop + 44)
-                        .padding(.bottom, max(0, safeBottom - 8))
+                        .padding(.top, metrics.contentTopPadding)
+                        .padding(.bottom, metrics.contentBottomPadding)
                         dismissBar
                             .padding(.top, safeTop)
                         SleepTimerStatus()
@@ -380,7 +406,11 @@ struct FullScreenPlayerView: View {
                             .padding(.trailing, 20)
                             .padding(.top, safeTop + 4)
                     }
-                    .frame(width: geo.size.width, height: geo.size.height)
+                    // Top-aligned, so content that still outgrows the canvas —
+                    // an accessibility text size, say — spills off the bottom
+                    // rather than being centred, which used to push the dismiss
+                    // handle up under the status bar where it is hard to hit.
+                    .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
                 }
                 .opacity(closingContentOpacity)
                 .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: closingContentOpacity)


### PR DESCRIPTION
`PlayerLayoutMetrics` derived every size from the full distance between the safe areas, while the content is laid out inside padding of `safeTop + 44` (the dismiss handle) and `safeBottom - 8`. On an iPhone 17 Pro that claimed 778pt against the 742pt the content really has.

The 36pt gap straddled the `isCompactHeight` breakpoint at 760, so the layout sized itself for the roomy variant on a canvas that could not hold it. Measured on iPhone 17 Pro / iOS 26.5:

| | before | after |
|---|---|---|
| content stack height | 930.7pt | 874.0pt |
| container height | 874.0pt | 874.0pt |
| stack origin y | -28.3 | 0.0 |
| dismiss handle y | 33.7 | 62.0 |
| status bar | 0-54 | 0-54 |

`frame(height:)` centred the 56.7pt of overflow, so everything floated up by 28.3pt: the dismiss handle sat level with the status-bar clock with its tap target buried under the bar, and the bottom toolbar was pushed onto the home indicator.

## Changes

- `contentHeight` subtracts the padding the content is actually laid out with, which on that device selects the compact metrics and brings the layout to exactly the container height.
- The two paddings move onto `PlayerLayoutMetrics` (`contentTopPadding` / `contentBottomPadding`) so the sizing and the layout cannot drift apart again.
- The container frame is top-aligned, so content that still outgrows the canvas — an accessibility text size, say — spills off the bottom rather than being centred back up under the status bar.

## Validation

- `testPlayerSwipeUpAndSleepTimer` already covered this and was **failing on `main`**: `XCTAssertGreaterThan failed: ("55.66666666666666") is not greater than ("60.0")`. It passes with this change, and reverting the change on this branch reproduces the failure.
- iOS unit suite: 234 tests passed, 0 failures.
- iOS Release build and static analysis: clean, no diagnostics.
- Verified by instrumenting the live view hierarchy on iPhone 17 Pro / iOS 26.5 and by screenshot comparison.

Only measured on iPhone 17 Pro / iOS 26.5. Devices whose content height falls on the other side of the 760pt breakpoint are unaffected by the breakpoint change but still get the corrected padding, and iPad layouts are worth a look on device.

## Note for #131

That PR relaxes this assertion to `handle.frame.midY > statusBar.frame.maxY` (54pt), which makes it pass without the layout being fixed. With this change in, the assertion can be tightened to `handle.frame.minY >= statusBar.frame.maxY`.

## Summary by Sourcery

Align the full-screen player with its actual content area to keep controls accessible and prevent vertical overflow from being centered under system UI.

Bug Fixes:
- Fix full-screen player sizing so its layout is based on the height available to the content, preventing compact-height misclassification and vertical overflow into system areas.
- Keep oversized player content top-aligned so accessibility-sized layouts do not move the dismiss handle beneath the status bar.

Enhancements:
- Centralize player content padding in the layout metrics used for both sizing and rendering, preventing the two calculations from diverging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-screen player layout calculations to better account for top and bottom safe-area spacing.
  * Kept the dismiss control positioned correctly when player content exceeds the available screen height.
  * Updated content alignment and padding for more consistent full-screen playback layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->